### PR TITLE
change chronic absence threshold to be inclusive

### DIFF
--- a/macros/msr_chronic_absentee.sql
+++ b/macros/msr_chronic_absentee.sql
@@ -1,4 +1,4 @@
 {% macro msr_chronic_absentee(attendance_rate, days_enrolled) %}
-  {{ attendance_rate }} < {{ var('edu:attendance:chronic_absence_threshold') }}
+  {{ attendance_rate }} <= {{ var('edu:attendance:chronic_absence_threshold') }}
     and {{ days_enrolled }} >= {{ var('edu:attendance:chronic_absence_min_days') }}
 {% endmacro %}


### PR DESCRIPTION
Include students with an attendance rate that exactly equals the threshold (the configured default is 90%) as chronically absent. This is in line with Boston's definition, and several other states I have researched. If you need to exclude exactly 90%, you can set the threshold in the config to be 89.99.