### PR TITLE
Add 'bypass_rls' tag to dim_subgroup in dbt_project.yml. This feature…

### DIFF
--- a/dbt_project.yml
+++ b/dbt_project.yml
@@ -28,6 +28,8 @@ models:
       +schema: rls
     core_warehouse:
       +schema: wh
+      dim_subgroup:
+        +tags: [ 'bypass_rls' ]
     qc:
       +schema: qc
 


### PR DESCRIPTION
… allows RLS to automatically bypass this model if the package is used.