### PR TITLE
make trailing comma conditional before calls to alias_pivot

### DIFF
--- a/macros/get_single_value.sql
+++ b/macros/get_single_value.sql
@@ -1,0 +1,30 @@
+{# This macro will be available in v1.0 of dbt utils. Copied to here for now. #}
+{% macro get_single_value(query, default) %}
+
+{# This macro returns the (0, 0) record in a query, i.e. the first row of the first column #}
+
+    {%- call statement('get_query_result', fetch_result=True, auto_begin=false) -%}
+
+        {{ query }}
+
+    {%- endcall -%}
+
+    {%- if execute -%}
+
+        {% set r = load_result('get_query_result').table.columns[0].values() %}
+        {% if r | length == 0 %}
+            {% do print('Query `' ~ query ~ '` returned no rows. Using the default value: ' ~ default) %}
+            {% set sql_result = default %}
+        {% else %}
+            {% set sql_result = r[0] %}
+        {% endif %}
+
+    {%- else -%}
+
+        {% set sql_result = default %}
+
+    {%- endif -%}
+
+    {% do return(sql_result) %}
+
+{% endmacro %}

--- a/macros/is_empty_model.sql
+++ b/macros/is_empty_model.sql
@@ -1,0 +1,12 @@
+{# Check if a model is empty (has zero rows). Return boolean #}
+{% macro is_empty_model(model_name) %}
+
+  {%- set sql_statement  -%}
+    select count(*) from {{ ref(model_name) }}
+  {%- endset -%}
+
+  {%- set nrow = get_single_value(sql_statement) -%}
+
+  {{ return(nrow == 0) }}
+
+{% endmacro %}

--- a/models/build/edfi_3/courses/bld_ef3__course_char__combined_wide.sql
+++ b/models/build/edfi_3/courses/bld_ef3__course_char__combined_wide.sql
@@ -13,19 +13,21 @@ pivoted as (
         api_year,
         k_course,
         k_course_offering,
-        k_course_section,
-        {{ alias_pivot(
-            column='indicator_name',
-            cmp_col_name='characteristic_descriptor',
-            alias_col_name='indicator_name',
-            xwalk_ref='xwalk_course_level_characteristics',
-            agg='sum',
-            null_false=True,
-            cast='boolean',
-            then_value=1,
-            else_value=0,
-            quote_identifiers=False
-        ) }}
+        k_course_section
+        {%- if not is_empty_model('xwalk_course_level_characteristics') -%},
+          {{ alias_pivot(
+              column='indicator_name',
+              cmp_col_name='characteristic_descriptor',
+              alias_col_name='indicator_name',
+              xwalk_ref='xwalk_course_level_characteristics',
+              agg='sum',
+              null_false=True,
+              cast='boolean',
+              then_value=1,
+              else_value=0,
+              quote_identifiers=False
+          ) }}
+        {%- endif -%}
     from char_long
     group by 1,2,3,4,5
 )

--- a/models/build/edfi_3/students/bld_ef3__student_characteristics.sql
+++ b/models/build/edfi_3/students/bld_ef3__student_characteristics.sql
@@ -9,17 +9,19 @@ select
     api_year,
     k_student,
     k_student_xyear,
-    ed_org_id,
-    {{ alias_pivot(column='student_characteristic',
-                 cmp_col_name='characteristic_descriptor',
-                 alias_col_name='indicator_name',
-                 xwalk_ref='xwalk_student_characteristics',
-                 agg='sum',
-                 null_false=True,
-                 cast='boolean',
-                 then_value=1,
-                 else_value=0,
-                 quote_identifiers=False) }}
+    ed_org_id
+    {%- if not is_empty_model('xwalk_student_characteristics') -%},
+      {{ alias_pivot(column='student_characteristic',
+                   cmp_col_name='characteristic_descriptor',
+                   alias_col_name='indicator_name',
+                   xwalk_ref='xwalk_student_characteristics',
+                   agg='sum',
+                   null_false=True,
+                   cast='boolean',
+                   then_value=1,
+                   else_value=0,
+                   quote_identifiers=False) }}
+    {%- endif -%}
 from stu_char
 left join xwalk_stu_char 
     on stu_char.student_characteristic = xwalk_stu_char.characteristic_descriptor

--- a/models/build/edfi_3/students/bld_ef3__student_indicators.sql
+++ b/models/build/edfi_3/students/bld_ef3__student_indicators.sql
@@ -18,17 +18,19 @@ pivoted as (
         api_year,
         k_student,
         k_student_xyear,
-        ed_org_id,
-        {{ alias_pivot(column='indicator_name',
-                    cmp_col_name='original_indicator_name',
-                    alias_col_name='dim_stu_name',
-                    xwalk_ref='xwalk_student_indicators',
-                    agg='min',
-                    null_false=False,
-                    cast=null,
-                    then_value='indicator_value',
-                    else_value='null',
-                    quote_identifiers=False) }}
+        ed_org_id
+        {%- if not is_empty_model('xwalk_student_indicators') -%},
+          {{ alias_pivot(column='indicator_name',
+                      cmp_col_name='original_indicator_name',
+                      alias_col_name='dim_stu_name',
+                      xwalk_ref='xwalk_student_indicators',
+                      agg='min',
+                      null_false=False,
+                      cast=null,
+                      then_value='indicator_value',
+                      else_value='null',
+                      quote_identifiers=False) }}
+        {% endif %}
     from stu_ind
     left join xwalk_stu_ind 
         on stu_ind.indicator_name = xwalk_stu_ind.original_indicator_name


### PR DESCRIPTION
- add macro is_model_empty (returns true if zero rows, useful for checking if seed has records)
- add macro get_single_value from dbt utils release candidate, will be available in v1.0. used in is_model_empty
- for build models that have alias_pivot, don't return a trailing comma or call the pivot if the seed table is empty