### PR TITLE
Add depends-on hint and newline to bld_ef3__course_char__combined_wid…

### DIFF
--- a/macros/is_empty_model.sql
+++ b/macros/is_empty_model.sql
@@ -5,7 +5,7 @@
     select count(*) from {{ ref(model_name) }}
   {%- endset -%}
 
-  {%- set nrow = get_single_value(sql_statement) -%}
+  {%- set nrow = edu_wh.get_single_value(sql_statement) -%}
 
   {{ return(nrow == 0) }}
 

--- a/macros/is_empty_model.sql
+++ b/macros/is_empty_model.sql
@@ -1,12 +1,13 @@
 {# Check if a model is empty (has zero rows). Return boolean #}
 {% macro is_empty_model(model_name) %}
+  {% if execute %}
+      {%- set sql_statement  -%}
+        select count(*) from {{ ref(model_name) }}
+      {%- endset -%}
 
-  {%- set sql_statement  -%}
-    select count(*) from {{ ref(model_name) }}
-  {%- endset -%}
+      {%- set nrow = edu_wh.get_single_value(sql_statement) -%}
 
-  {%- set nrow = get_single_value(sql_statement) -%}
-
-  {{ return(nrow == 0) }}
+      {{ return(nrow == 0) }}
+  {% endif %}
 
 {% endmacro %}

--- a/macros/is_empty_model.sql
+++ b/macros/is_empty_model.sql
@@ -1,13 +1,12 @@
 {# Check if a model is empty (has zero rows). Return boolean #}
 {% macro is_empty_model(model_name) %}
-  {% if execute %}
-      {%- set sql_statement  -%}
-        select count(*) from {{ ref(model_name) }}
-      {%- endset -%}
 
-      {%- set nrow = edu_wh.get_single_value(sql_statement) -%}
+  {%- set sql_statement  -%}
+    select count(*) from {{ ref(model_name) }}
+  {%- endset -%}
 
-      {{ return(nrow == 0) }}
-  {% endif %}
+  {%- set nrow = get_single_value(sql_statement) -%}
+
+  {{ return(nrow == 0) }}
 
 {% endmacro %}

--- a/models/build/edfi_3/courses/bld_ef3__course_char__combined_wide.sql
+++ b/models/build/edfi_3/courses/bld_ef3__course_char__combined_wide.sql
@@ -1,5 +1,3 @@
--- depends_on: {{ ref('xwalk_course_level_characteristics') }}
-
 -- todo: need some test cases of this
 -- todo: preferable to cast this to boolean after agg, but need to modify macro
 -- todo: need a filtered get_column_values to avoid NULL becoming a column?

--- a/models/build/edfi_3/courses/bld_ef3__course_char__combined_wide.sql
+++ b/models/build/edfi_3/courses/bld_ef3__course_char__combined_wide.sql
@@ -1,3 +1,5 @@
+-- depends_on: {{ ref('xwalk_course_level_characteristics') }}
+
 -- todo: need some test cases of this
 -- todo: preferable to cast this to boolean after agg, but need to modify macro
 -- todo: need a filtered get_column_values to avoid NULL becoming a column?
@@ -27,7 +29,7 @@ pivoted as (
               else_value=0,
               quote_identifiers=False
           ) }}
-        {%- endif -%}
+        {%- endif %}
     from char_long
     group by 1,2,3,4,5
 )


### PR DESCRIPTION
…e.sql; fix is_empty_model() macro to run on execute and reference get_single_value() macro within its namespace.

This PR fixes four issues with the current implementation of 'bld_ef3__course_char__combined_wide':
1. The macro is_model_empty() always returns False during compile, so an if-execute conditional is required.
2. The macro is_model_empty() raises an error that its helper macro get_single_value() is missing, unless its package namespace is referenced.
3. The ref to 'xwalk_course_level_characteristics' is within a jinja-conditional, so a depends_on SQL hint is required during compile.
4. If 'xwalk_course_level_characteristics' is empty, the compiled SQL combines the last column with the 'FROM' of the select, so the jinja end-if needs its terminal whitespace.