### PR TITLE
add assessment wh models

### DIFF
--- a/models/build/edfi_3/assessments/bld_ef3__assessment_grade_levels.sql
+++ b/models/build/edfi_3/assessments/bld_ef3__assessment_grade_levels.sql
@@ -1,0 +1,11 @@
+with stg_assessment_grades as (
+    select * from {{ ref('stg_ef3__assessments__grade_levels') }}
+),
+build_object as (
+    select 
+        k_assessment,
+        array_agg(grade_level) as grades_array
+    from stg_assessment_grades
+    group by 1
+)
+select * from build_object

--- a/models/build/edfi_3/assessments/bld_ef3__assessment_performance_levels.sql
+++ b/models/build/edfi_3/assessments/bld_ef3__assessment_performance_levels.sql
@@ -1,0 +1,12 @@
+with stg_assessment_perf_levels as (
+    select * from {{ ref('stg_ef3__assessments__performance_levels') }}
+),
+build_object as (
+    select 
+        k_assessment,
+        array_agg(object_construct('performance_level_name', performance_level_name,
+                                   'performance_level_value', performance_level_value)) as performance_levels_array
+    from stg_assessment_perf_levels
+    group by 1
+)
+select * from build_object

--- a/models/build/edfi_3/assessments/bld_ef3__assessment_scores.sql
+++ b/models/build/edfi_3/assessments/bld_ef3__assessment_scores.sql
@@ -1,0 +1,11 @@
+with stg_assessment_scores as (
+    select * from {{ ref('stg_ef3__assessments__scores') }}
+),
+build_object as (
+    select 
+        k_assessment,
+        array_agg(score_name) as scores_array
+    from stg_assessment_scores
+    group by 1
+)
+select * from build_object

--- a/models/build/edfi_3/assessments/bld_ef3__objective_assessment_performance_levels.sql
+++ b/models/build/edfi_3/assessments/bld_ef3__objective_assessment_performance_levels.sql
@@ -1,0 +1,12 @@
+with stg_obj_assessment_perf_levels as (
+    select * from {{ ref('stg_ef3__objective_assessments__performance_levels') }}
+),
+build_object as (
+    select 
+        k_objective_assessment,
+        array_agg(object_construct('performance_level_name', performance_level_name,
+                                   'performance_level_value', performance_level_value)) as performance_levels_array
+    from stg_obj_assessment_perf_levels
+    group by 1
+)
+select * from build_object

--- a/models/build/edfi_3/assessments/bld_ef3__objective_assessment_scores.sql
+++ b/models/build/edfi_3/assessments/bld_ef3__objective_assessment_scores.sql
@@ -1,0 +1,11 @@
+with stg_obj_assessment_scores as (
+    select * from {{ ref('stg_ef3__objective_assessments__scores') }}
+),
+build_object as (
+    select 
+        k_objective_assessment,
+        array_agg(score_name) as scores_array
+    from stg_obj_assessment_scores
+    group by 1
+)
+select * from build_object

--- a/models/build/edfi_3/assessments/bld_ef3__student_assessments_long_results.sql
+++ b/models/build/edfi_3/assessments/bld_ef3__student_assessments_long_results.sql
@@ -1,0 +1,47 @@
+with score_results as (
+    select * from {{ ref('stg_ef3__student_assessments__score_results') }}
+),
+xwalk_scores as (
+    select * from {{ ref('xwalk_assessment_scores') }}
+),
+performance_levels as (
+    select
+        tenant_code,
+        api_year,
+        k_student_assessment,
+        assessment_identifier,
+        namespace,
+        -- normalize column names to stack with scores
+        performance_level_name as score_name,
+        performance_level_result as score_result
+    from {{ ref('stg_ef3__student_assessments__performance_levels') }}
+),
+stack_results as (
+    select * from score_results
+    union all 
+    select * from performance_levels
+),
+-- todo: we have seen examples of the say key existing in both score results and PLs
+-- this will choose the highest score result
+dedupe_results as (
+    {{
+        dbt_utils.deduplicate(
+            relation='stack_results',
+            partition_by='k_student_assessment, score_name',
+            order_by='score_result desc'
+        )
+    }}
+),
+merged_xwalk as (
+    select
+        k_student_assessment,
+        score_name as original_score_name,
+        coalesce(normalized_score_name, 'other') as normalized_score_name,
+        score_result
+    from dedupe_results
+    left join xwalk_scores
+        on dedupe_results.assessment_identifier = xwalk_scores.assessment_identifier
+        and dedupe_results.namespace = xwalk_scores.namespace
+        and dedupe_results.score_name = xwalk_scores.original_score_name
+)
+select * from merged_xwalk

--- a/models/build/edfi_3/assessments/bld_ef3__student_assessments_long_results.sql
+++ b/models/build/edfi_3/assessments/bld_ef3__student_assessments_long_results.sql
@@ -21,7 +21,7 @@ stack_results as (
     union all 
     select * from performance_levels
 ),
--- todo: we have seen examples of the say key existing in both score results and PLs
+-- we have seen examples of the say key existing in both score results and PLs
 -- this will choose the highest score result
 dedupe_results as (
     {{

--- a/models/build/edfi_3/assessments/bld_ef3__student_objective_assessments_long_results.sql
+++ b/models/build/edfi_3/assessments/bld_ef3__student_objective_assessments_long_results.sql
@@ -1,0 +1,49 @@
+with score_results as (
+    select * from {{ ref('stg_ef3__student_objective_assessments__score_results') }}
+),
+xwalk_scores as (
+    select * from {{ ref('xwalk_objective_assessment_scores') }}
+),
+performance_levels as (
+    select
+        tenant_code,
+        api_year,
+        k_student_objective_assessment,
+        assessment_identifier,
+        namespace,
+        objective_assessment_identification_code,
+        -- normalize column names to stack with scores
+        performance_level_name as score_name,
+        performance_level_result as score_result
+    from {{ ref('stg_ef3__student_objective_assessments__performance_levels') }}
+),
+stack_results as (
+    select * from score_results
+    union all 
+    select * from performance_levels
+),
+-- todo: we have seen examples of the say key existing in both score results and PLs
+-- this will choose the highest score result
+dedupe_results as (
+    {{
+        dbt_utils.deduplicate(
+            relation='stack_results',
+            partition_by='k_student_objective_assessment, score_name',
+            order_by='score_result desc'
+        )
+    }}
+),
+merged_xwalk as (
+    select
+        k_student_objective_assessment,
+        score_name as original_score_name,
+        coalesce(normalized_score_name, 'other') as normalized_score_name,
+        score_result
+    from dedupe_results
+    left join xwalk_scores
+        on dedupe_results.assessment_identifier = xwalk_scores.assessment_identifier
+        and dedupe_results.namespace = xwalk_scores.namespace
+        and dedupe_results.objective_assessment_identification_code = xwalk_scores.objective_assessment_identification_code
+        and dedupe_results.score_name = xwalk_scores.original_score_name
+)
+select * from merged_xwalk

--- a/models/build/edfi_3/assessments/bld_ef3__student_objective_assessments_long_results.sql
+++ b/models/build/edfi_3/assessments/bld_ef3__student_objective_assessments_long_results.sql
@@ -22,7 +22,7 @@ stack_results as (
     union all 
     select * from performance_levels
 ),
--- todo: we have seen examples of the say key existing in both score results and PLs
+-- we have seen examples of the say key existing in both score results and PLs
 -- this will choose the highest score result
 dedupe_results as (
     {{

--- a/models/core_warehouse/dim_assessment.sql
+++ b/models/core_warehouse/dim_assessment.sql
@@ -1,0 +1,54 @@
+{{
+  config(
+    post_hook=[
+        "alter table {{ this }} add primary key (k_assessment)"
+    ]
+  )
+}}
+
+with stg_assessments as (
+    select * from {{ ref('stg_ef3__assessments') }}
+),
+assessment_scores as (
+    select * from {{ ref('bld_ef3__assessment_scores') }}
+),
+assessment_pls as (
+    select * from {{ ref('bld_ef3__assessment_performance_levels') }}
+),
+assessment_grades as (
+    select * from {{ ref('bld_ef3__assessment_grade_levels') }}
+),
+formatted as (
+    select
+        stg_assessments.k_assessment,
+        stg_assessments.tenant_code,
+        stg_assessments.api_year as school_year,
+        stg_assessments.assessment_identifier,
+        stg_assessments.namespace,
+        stg_assessments.assessment_title,
+        stg_assessments.academic_subject,
+        stg_assessments.is_adaptive_assessment,
+        stg_assessments.assessment_family,
+        stg_assessments.assessment_form,
+        stg_assessments.assessment_version,
+        stg_assessments.max_raw_score,
+        stg_assessments.nomenclature,
+        stg_assessments.revision_date,
+        stg_assessments.assessment_category,
+        stg_assessments.assessment_period_begin_date,
+        stg_assessments.assessment_period_end_date,
+        stg_assessments.content_standard,
+        assessment_scores.scores_array,
+        assessment_pls.performance_levels_array,
+        assessment_grades.grades_array
+    from stg_assessments
+    -- making all of these left joins because none of these are actually required
+    left join assessment_scores 
+        on stg_assessments.k_assessment = assessment_scores.k_assessment
+    left join assessment_pls
+        on stg_assessments.k_assessment = assessment_pls.k_assessment
+    left join assessment_grades
+        on stg_assessments.k_assessment = assessment_grades.k_assessment
+)
+select * from formatted
+order by tenant_code, k_assessment

--- a/models/core_warehouse/dim_assessment.yml
+++ b/models/core_warehouse/dim_assessment.yml
@@ -1,0 +1,31 @@
+version: 2
+
+models:
+  - name: dim_assessment
+    description: >
+      Defines an assessment and all known characteristics.
+    columns:
+      - name: k_assessment
+        description: Generated primary key composed of `tenant_code`, `api_year`, `academicSubjectDescriptor`, `assessmentIdentifier`, and `namespace`.
+        tests: 
+          - unique
+      - name: tenant_code
+      - name: school_year
+      - name: assessment_identifier
+      - name: namespace
+      - name: assessment_title
+      - name: academic_subject
+      - name: is_adaptive_assessment
+      - name: assessment_family
+      - name: assessment_form
+      - name: assessment_version
+      - name: max_raw_score
+      - name: nomenclature
+      - name: revision_date
+      - name: assessment_category
+      - name: assessment_period_begin_date
+      - name: assessment_period_end_date
+      - name: content_standard
+      - name: scores_array
+      - name: performance_levels_array
+      - name: grades_array

--- a/models/core_warehouse/dim_objective_assessment.sql
+++ b/models/core_warehouse/dim_objective_assessment.sql
@@ -1,0 +1,43 @@
+{{
+  config(
+    post_hook=[
+        "alter table {{ this }} add primary key (k_objective_assessment)",
+        "alter table {{ this }} add constraint fk_{{ this.name }}_assessment foreign key (k_assessment) references {{ ref('dim_assessment') }}"
+    ]
+  )
+}}
+
+with stg_obj_assessments as (
+    select * from {{ ref('stg_ef3__objective_assessments') }}
+),
+obj_assessment_scores as (
+    select * from {{ ref('bld_ef3__objective_assessment_scores') }}
+),
+obj_assessment_pls as (
+    select * from {{ ref('bld_ef3__objective_assessment_performance_levels') }}
+),
+formatted as (
+    select
+        stg_obj_assessments.k_objective_assessment,
+        stg_obj_assessments.k_assessment,
+        stg_obj_assessments.tenant_code,
+        stg_obj_assessments.api_year as school_year,
+        stg_obj_assessments.assessment_identifier,
+        stg_obj_assessments.namespace,
+        stg_obj_assessments.objective_assessment_description,
+        stg_obj_assessments.objective_assessment_identification_code,
+        stg_obj_assessments.max_raw_score,
+        stg_obj_assessments.nomenclature,
+        stg_obj_assessments.percent_of_assessment,
+        stg_obj_assessments.academic_subject,
+        obj_assessment_scores.scores_array,
+        obj_assessment_pls.performance_levels_array
+    from stg_obj_assessments
+    -- making all of these left joins because none of these are actually required
+    left join obj_assessment_scores 
+        on stg_obj_assessments.k_objective_assessment = obj_assessment_scores.k_objective_assessment
+    left join obj_assessment_pls
+        on stg_obj_assessments.k_objective_assessment = obj_assessment_pls.k_objective_assessment
+)
+select * from formatted
+order by tenant_code, k_objective_assessment

--- a/models/core_warehouse/dim_objective_assessment.yml
+++ b/models/core_warehouse/dim_objective_assessment.yml
@@ -1,0 +1,26 @@
+version: 2
+
+models:
+  - name: dim_objective_assessment
+    description: >
+      Defines an objective assessment and all known characteristics.
+    columns:
+      - name: k_objective_assessment
+        description: >
+            Generated primary key composed of `tenant_code`, `api_year`, `academicSubjectDescriptor`,
+            `assessmentIdentifier`, `namespace`, and `objectiveAssessmentIdentificationCode`.
+        tests: 
+          - unique
+      - name: k_assessment
+      - name: tenant_code
+      - name: school_year
+      - name: assessment_identifier
+      - name: namespace
+      - name: objective_assessment_description
+      - name: objective_assessment_identification_code
+      - name: max_raw_score
+      - name: nomenclature
+      - name: percent_of_assessment
+      - name: academic_subject
+      - name: scores_array
+      - name: performance_levels_array

--- a/models/core_warehouse/fct_student_assessment.sql
+++ b/models/core_warehouse/fct_student_assessment.sql
@@ -53,7 +53,7 @@ student_assessments_wide as (
         and student_assessments_long_results.normalized_score_name != 'other'
     left join object_agg_other_results
         on student_assessments.k_student_assessment = object_agg_other_results.k_student_assessment
-    group by 1,2,3,4,5,6,7,8,9,10,11,12,13,14,15
+    {{ dbt_utils.group_by(n=15) }}
 )
 select *
 from student_assessments_wide

--- a/models/core_warehouse/fct_student_assessment.sql
+++ b/models/core_warehouse/fct_student_assessment.sql
@@ -1,0 +1,59 @@
+{{
+  config(
+    post_hook=[
+        "alter table {{ this }} add primary key (k_student_assessment)",
+        "alter table {{ this }} add constraint fk_{{ this.name }}_assessment foreign key (k_assessment) references {{ ref('dim_assessment') }}",
+        "alter table {{ this }} add constraint fk_{{ this.name }}_student foreign key (k_student) references {{ ref('dim_student') }}"
+    ]
+  )
+}}
+
+with student_assessments_long_results as (
+    select * from {{ ref('bld_ef3__student_assessments_long_results') }}
+),
+student_assessments as (
+    select * from {{ ref('stg_ef3__student_assessments') }}
+),
+object_agg_other_results as (
+    select
+        k_student_assessment,
+        object_agg(original_score_name, score_result::variant) as v_other_results
+    from student_assessments_long_results
+    where normalized_score_name = 'other'
+    group by 1
+),
+student_assessments_wide as (
+    select
+        student_assessments.k_student_assessment,
+        student_assessments.k_assessment,
+        student_assessments.k_student,
+        school_year,
+        administration_date,
+        administration_end_date,
+        event_description,
+        administration_environment,
+        administration_language,
+        event_circumstance,
+        platform_type,
+        reason_not_tested,
+        retest_indicator,
+        when_assessed_grade_level,
+        v_other_results,
+        {{ dbt_utils.pivot(
+            'normalized_score_name',
+            dbt_utils.get_column_values(ref('xwalk_assessment_scores'), 'normalized_score_name'),
+            then_value='score_result',
+            else_value='NULL',
+            agg='max',
+            quote_identifiers=False
+        ) }}
+    from student_assessments
+    join student_assessments_long_results
+        on student_assessments.k_student_assessment = student_assessments_long_results.k_student_assessment
+        and student_assessments_long_results.normalized_score_name != 'other'
+    left join object_agg_other_results
+        on student_assessments.k_student_assessment = object_agg_other_results.k_student_assessment
+    group by 1,2,3,4,5,6,7,8,9,10,11,12,13,14,15
+)
+select *
+from student_assessments_wide

--- a/models/core_warehouse/fct_student_assessment.yml
+++ b/models/core_warehouse/fct_student_assessment.yml
@@ -1,0 +1,37 @@
+version: 2
+
+models: 
+  - name: fct_student_assessment
+    description: >
+      Student assessment records. The wide results columns are
+      determined based on the `normalized_score_name` column
+      from the seed table `xwalk_assessment_scores`.
+    columns:
+      - name: k_student_assessment
+        description: >
+          Generated primary key composed of `tenant_code`, `api_year`, and `studentAssessmentIdentifier`.
+        tests: 
+          - unique
+      - name: k_assessment
+      - name: k_student
+      - name: school_year
+      - name: administration_date
+      - name: administration_end_date
+      - name: event_description
+      - name: administration_environment
+      - name: administration_language
+      - name: event_circumstance
+      - name: platform_type
+      - name: reason_not_tested
+      - name: retest_indicator
+      - name: when_assessed_grade_level
+      - name: v_other_results
+        description: >
+          This is an array of all additional score results that were not
+          mapped in the seed table `xwalk_assessment_scores`.
+      - name: scale_score
+        description: >
+          One of the results columns that could exist if mapped in the seed table `xwalk_assessment_scores`.
+      - name: sem
+        description: >
+          One of the results columns that could exist if mapped in the seed table `xwalk_assessment_scores`.

--- a/models/core_warehouse/fct_student_objective_assessment.sql
+++ b/models/core_warehouse/fct_student_objective_assessment.sql
@@ -56,7 +56,7 @@ student_obj_assessments_wide as (
         and student_obj_assessments_long_results.normalized_score_name != 'other'
     left join object_agg_other_results
         on student_obj_assessments.k_student_objective_assessment = object_agg_other_results.k_student_objective_assessment
-    group by 1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17
+    {{ dbt_utils.group_by(n=17) }}
 )
 select *
 from student_obj_assessments_wide

--- a/models/core_warehouse/fct_student_objective_assessment.sql
+++ b/models/core_warehouse/fct_student_objective_assessment.sql
@@ -1,0 +1,62 @@
+{{
+  config(
+    post_hook=[
+        "alter table {{ this }} add primary key (k_student_objective_assessment)",
+        "alter table {{ this }} add constraint fk_{{ this.name }}_objective_assessment foreign key (k_objective_assessment) references {{ ref('dim_objective_assessment') }}",
+        "alter table {{ this }} add constraint fk_{{ this.name }}_assessment foreign key (k_assessment) references {{ ref('dim_assessment') }}",
+        "alter table {{ this }} add constraint fk_{{ this.name }}_student foreign key (k_student) references {{ ref('dim_student') }}"
+    ]
+  )
+}}
+
+with student_obj_assessments_long_results as (
+    select * from {{ ref('bld_ef3__student_objective_assessments_long_results') }}
+),
+student_obj_assessments as (
+    select * from {{ ref('stg_ef3__student_objective_assessments') }}
+),
+object_agg_other_results as (
+    select
+        k_student_objective_assessment,
+        object_agg(original_score_name, score_result::variant) as v_other_results
+    from student_obj_assessments_long_results
+    where normalized_score_name = 'other'
+    group by 1
+),
+student_obj_assessments_wide as (
+    select
+        student_obj_assessments.k_student_objective_assessment,
+        student_obj_assessments.k_objective_assessment,
+        student_obj_assessments.k_student_assessment,
+        student_obj_assessments.k_assessment,
+        student_obj_assessments.k_student,
+        school_year,
+        administration_date,
+        administration_end_date,
+        event_description,
+        administration_environment,
+        administration_language,
+        event_circumstance,
+        platform_type,
+        reason_not_tested,
+        retest_indicator,
+        when_assessed_grade_level,
+        v_other_results,
+        {{ dbt_utils.pivot(
+            'normalized_score_name',
+            dbt_utils.get_column_values(ref('xwalk_objective_assessment_scores'), 'normalized_score_name'),
+            then_value='score_result',
+            else_value='NULL',
+            agg='max',
+            quote_identifiers=False
+        ) }}
+    from student_obj_assessments
+    join student_obj_assessments_long_results
+        on student_obj_assessments.k_student_objective_assessment = student_obj_assessments_long_results.k_student_objective_assessment
+        and student_obj_assessments_long_results.normalized_score_name != 'other'
+    left join object_agg_other_results
+        on student_obj_assessments.k_student_objective_assessment = object_agg_other_results.k_student_objective_assessment
+    group by 1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17
+)
+select *
+from student_obj_assessments_wide

--- a/models/core_warehouse/fct_student_objective_assessment.yml
+++ b/models/core_warehouse/fct_student_objective_assessment.yml
@@ -1,0 +1,39 @@
+version: 2
+
+models: 
+  - name: fct_student_objective_assessment
+    description: >
+      Student objective assessment records. The wide results columns are
+      determined based on the `normalized_score_name` column
+      from the seed table `xwalk_objective_assessment_scores`.
+    columns:
+      - name: k_student_objective_assessment
+        description: >
+          Generated primary key composed of `tenant_code`, `api_year`, `studentAssessmentIdentifier`, and `objectiveAssessmentIdentificationCode`.
+        tests: 
+          - unique
+      - name: k_objective_assessment
+      - name: k_student_assessment
+      - name: k_assessment
+      - name: k_student
+      - name: school_year
+      - name: administration_date
+      - name: administration_end_date
+      - name: event_description
+      - name: administration_environment
+      - name: administration_language
+      - name: event_circumstance
+      - name: platform_type
+      - name: reason_not_tested
+      - name: retest_indicator
+      - name: when_assessed_grade_level
+      - name: v_other_results
+        description: >
+          This is an array of all additional score results that were not
+          mapped in the seed table `xwalk_objective_assessment_scores`.
+      - name: scale_score
+        description: >
+          One of the results columns that could exist if mapped in the seed table `xwalk_objective_assessment_scores`.
+      - name: sem
+        description: >
+          One of the results columns that could exist if mapped in the seed table `xwalk_objective_assessment_scores`.


### PR DESCRIPTION
Included in this feature:
- Dimension tables for assessments and objective assessments
- Fact tables for student assessments and student objective assessments
- Multiple build tables

A few additional notes:
- The build tables relating to assessments and objective assessments exist to present additional information within the dimensional models in a cleaned-up, readable way.
- The build tables relating to student assessments and student objective assessments stack performance levels and score results in order to unpivot downstream across all results. Additionally, we have seen examples of the same key existing in both the score results and performance levels with different values, which required the extra dedupe within these build models (side note: there are tests for this in the source repo).
- The results that will be cast wide in the fact models are customizable and are defined in additional seeds. Results that are not included in this seed are added to an 'other' column so that they are still available to query directly from the fact models.