### PR TITLE
Feature/chronic absenteeism update

### DIFF
--- a/models/core_warehouse/fct_student_daily_attendance.sql
+++ b/models/core_warehouse/fct_student_daily_attendance.sql
@@ -132,7 +132,7 @@ positive_attendance_deduped as (
         dbt_utils.deduplicate(
             relation='fill_positive_attendance',
             partition_by='k_student, k_school, calendar_date',
-            order_by='total_instructional_days'
+            order_by='is_enrolled desc, total_instructional_days'
         )
     }}
 ),

--- a/models/core_warehouse/fct_student_daily_attendance.sql
+++ b/models/core_warehouse/fct_student_daily_attendance.sql
@@ -81,10 +81,6 @@ fill_positive_attendance as (
         bld_attendance_sessions.total_instructional_days,
         stu_enr_att_cal.tenant_code,
         stu_enr_att_cal.calendar_date,
-        coalesce(
-            fct_student_school_att.attendance_event_category,
-            '{{ var("edu:attendance:in_attendance_code") }}' 
-        ) as attendance_event_category,
         fct_student_school_att.attendance_event_reason,
         -- set enrollment flag: 1 during enrollment, 0 after, no row prior
         case 
@@ -93,6 +89,12 @@ fill_positive_attendance as (
             then 1.0
             else 0.0
         end is_enrolled,
+        case 
+            when is_enrolled = 0 then 'Not Enrolled'
+            else coalesce(
+                    fct_student_school_att.attendance_event_category,
+                    '{{ var("edu:attendance:in_attendance_code") }}') 
+        end as attendance_event_category,
         coalesce(
             case 
                 when is_enrolled = 1 then fct_student_school_att.is_absent

--- a/models/core_warehouse/fct_student_daily_attendance.yml
+++ b/models/core_warehouse/fct_student_daily_attendance.yml
@@ -26,7 +26,7 @@ models:
       - name: is_absent
         description: Indicator for absence. Defined via descriptor mapping in `xwalk_attendance_events`
       - name: is_present
-        description: Inverse of `is_absent`, for use in calculations.
+        description: Inverse of `is_absent`, for use in calculations. Can be fractional.
       - name: is_enrolled
       - name: total_days_enrolled
       - name: cumulative_days_absent

--- a/models/core_warehouse/msr_student_cumulative_attendance.sql
+++ b/models/core_warehouse/msr_student_cumulative_attendance.sql
@@ -26,10 +26,7 @@ aggregated as (
         sum(is_absent) as days_absent,
         sum(is_present) as days_attended,
         sum(is_enrolled) as days_enrolled,
-        case 
-          when days_enrolled = 0 then null
-          else round(100 * days_attended / days_enrolled, 2)
-        end as  attendance_rate,
+        round(100 * days_attended / nullif(days_enrolled, 0), 2) as attendance_rate,
         days_enrolled >= {{ var('edu:attendance:chronic_absence_min_days') }} as meets_enrollment_threshold,
         {{ msr_chronic_absentee('attendance_rate', 'days_enrolled') }} as is_chronic_absentee
     from stu_daily_attendance

--- a/models/core_warehouse/msr_student_cumulative_attendance.sql
+++ b/models/core_warehouse/msr_student_cumulative_attendance.sql
@@ -26,7 +26,10 @@ aggregated as (
         sum(is_absent) as days_absent,
         sum(is_present) as days_attended,
         sum(is_enrolled) as days_enrolled,
-        round(100 * days_attended / days_enrolled, 2) as attendance_rate,
+        case 
+          when days_enrolled = 0 then null
+          else round(100 * days_attended / days_enrolled, 2)
+        end as  attendance_rate,
         days_enrolled >= {{ var('edu:attendance:chronic_absence_min_days') }} as meets_enrollment_threshold,
         {{ msr_chronic_absentee('attendance_rate', 'days_enrolled') }} as is_chronic_absentee
     from stu_daily_attendance

--- a/models/core_warehouse/msr_student_cumulative_attendance.sql
+++ b/models/core_warehouse/msr_student_cumulative_attendance.sql
@@ -23,9 +23,9 @@ aggregated as (
         stu_daily_attendance.k_school,
         dim_calendar_date.school_year,
         any_value(stu_daily_attendance.tenant_code) as tenant_code,
-        sum(is_absent::int) as days_absent,
-        sum(is_present::int) as days_attended,
-        sum(is_enrolled::int) as days_enrolled,
+        sum(is_absent) as days_absent,
+        sum(is_present) as days_attended,
+        sum(is_enrolled) as days_enrolled,
         round(100 * days_attended / days_enrolled, 2) as attendance_rate,
         days_enrolled >= {{ var('edu:attendance:chronic_absence_min_days') }} as meets_enrollment_threshold,
         {{ msr_chronic_absentee('attendance_rate', 'days_enrolled') }} as is_chronic_absentee

--- a/tests/config_tests/cfg_attendance_codes_valid_range.sql
+++ b/tests/config_tests/cfg_attendance_codes_valid_range.sql
@@ -1,7 +1,7 @@
 {{
   config(
       store_failures = true,
-      severity       = 'warn'
+      severity       = 'error'
     )
 }}
 select distinct is_absent

--- a/tests/config_tests/cfg_attendance_codes_valid_range.sql
+++ b/tests/config_tests/cfg_attendance_codes_valid_range.sql
@@ -1,0 +1,9 @@
+{{
+  config(
+      store_failures = true,
+      severity       = 'warn'
+    )
+}}
+select distinct is_absent
+from {{ ref('xwalk_attendance_events') }}
+where is_absent not between 0 and 1

--- a/tests/value_tests/invalid_enrollments.sql
+++ b/tests/value_tests/invalid_enrollments.sql
@@ -1,0 +1,35 @@
+{{
+  config(
+      store_failures = true,
+      severity       = 'warn'
+    )
+}}
+with stg_stu_school as (
+    select * from {{ ref('stg_ef3__student_school_associations') }}
+),
+first_school_day as (
+    select k_school_calendar, min(calendar_date) as calendar_date
+    from {{ ref('dim_calendar_date') }}
+    group by 1
+)
+select 
+    exit_withdraw_date < first_school_day.calendar_date as exit_before_first_day,
+    exit_withdraw_date < entry_date as exit_before_entry,
+    {% set excl_withdraw_codes =  var('edu:enroll:exclude_withdraw_codes')  %}
+    {% if excl_withdraw_codes | length -%}
+      {% if excl_withdraw_codes is string -%}
+        {% set excl_withdraw_codes = [excl_withdraw_codes] %}
+      {%- endif -%}
+      stg_stu_school.exit_withdraw_type in (
+      '{{ excl_withdraw_codes | join("', '") }}'
+      ) as excluded_withdraw_code,
+    {% else %}
+        null as excluded_withdraw_code,
+    {% endif %}
+    stg_stu_school.*
+from stg_stu_school
+left join first_school_day 
+    on stg_stu_school.k_school_calendar = first_school_day.k_school_calendar
+where exit_before_first_day
+or exit_before_entry
+or excluded_withdraw_code


### PR DESCRIPTION
This branch introduces two features and two potentially breaking changes to `fct_student_daily_attendance`:

1. **Make all indicators like `is_absent` floats instead of booleans**
  - This allows for fractional attendance codes (like half days), and makes it easier to sum indicators (without coercing them first)
  - Also makes it easier to introduce fully proportional daily attendance (computed from section attendance) without changing the table signature
  - **Migration:** `xwalk_attendance_events` must switch from `True/False` values in `is_absent` to numbers between 0 and 1. Existing T/F values can be swapped for `1.0` / `0.0`
  - **Migration:** Metrics should not coerce these indicators to integer to allow for fractional attendance

2. **Include daily attendance values for students after their enrollment ends.**
  - All indicators (absent, present, enrolled) are set to 0 after or between enrollments, so sums on these values still work as expected
  - This allows daily or over-time calculations of Chronic Absenteeism metrics, since these include students who were but are no longer enrolled. On days after or between enrollments, a student's absence rate, cumulative counts, and metric values stay as they were on their last enrolled day. If a student re-enrolls at the same school, counts continue accumulating after that day.
  - **Migration:** Average Daily Attendance style metrics should either filter out rows where `is_enrolled = 0` to avoid counting students not actually eligible, or make sure they are doing `sum(is_enrolled)` rather than `count(*)` to avoid inflating denominators.

Also introduces a configuration test to ensure all attendance codes are specified between 0 and 1, as setting a value like `50` instead of `0.5` would break the logic.