### PR TITLE
Feature/parents

### DIFF
--- a/models/build/edfi_3/parents/bld_ef3__parent_wide_emails.sql
+++ b/models/build/edfi_3/parents/bld_ef3__parent_wide_emails.sql
@@ -7,8 +7,8 @@ parent_email_types as (
 emails_wide as (
   select 
     k_parent,
-    -- todo: do I need api year in here?
-    -- or do I dedupe to keep latest?
+    tenant_code,
+    -- note: this is already deduped to be the most recent record for a parent
     {{ dbt_utils.pivot(
       'normalized_email_type',
       dbt_utils.get_column_values(ref('xwalk_parent_email_types'), 'normalized_email_type'),

--- a/models/build/edfi_3/parents/bld_ef3__parent_wide_emails.sql
+++ b/models/build/edfi_3/parents/bld_ef3__parent_wide_emails.sql
@@ -1,4 +1,4 @@
-stg_parent_emails as (
+with stg_parent_emails as (
     select * from {{ ref('stg_ef3__parents__emails') }}
 ),
 parent_email_types as (

--- a/models/build/edfi_3/parents/bld_ef3__parent_wide_emails.sql
+++ b/models/build/edfi_3/parents/bld_ef3__parent_wide_emails.sql
@@ -8,6 +8,7 @@ emails_wide as (
   select 
     k_parent,
     -- todo: do I need api year in here?
+    -- or do I dedupe to keep latest?
     {{ dbt_utils.pivot(
       'normalized_email_type',
       dbt_utils.get_column_values(ref('xwalk_parent_email_types'), 'normalized_email_type'),

--- a/models/build/edfi_3/parents/bld_ef3__parent_wide_emails.sql
+++ b/models/build/edfi_3/parents/bld_ef3__parent_wide_emails.sql
@@ -16,7 +16,8 @@ emails_wide as (
       agg='max',
       then_value='email_address',
       else_value='null',
-      suffix='_email_address'
+      suffix='_email_address',
+      quote_identifiers = False
     ) }}
     {%- endif %}
   from stg_parent_emails

--- a/models/build/edfi_3/parents/bld_ef3__parent_wide_emails.sql
+++ b/models/build/edfi_3/parents/bld_ef3__parent_wide_emails.sql
@@ -8,8 +8,8 @@ emails_wide as (
   select 
     k_parent,
     tenant_code
-    -- note: this is already deduped to be the most recent record for a parent
     {%- if not is_empty_model('xwalk_parent_email_types') -%},
+    -- note: this is already deduped to be the most recent record for a parent
     {{ dbt_utils.pivot(
       'normalized_email_type',
       dbt_utils.get_column_values(ref('xwalk_parent_email_types'), 'normalized_email_type'),

--- a/models/build/edfi_3/parents/bld_ef3__parent_wide_emails.sql
+++ b/models/build/edfi_3/parents/bld_ef3__parent_wide_emails.sql
@@ -1,0 +1,22 @@
+stg_parent_emails as (
+    select * from {{ ref('stg_ef3__parents__emails') }}
+),
+parent_email_types as (
+    select * from {{ ref('xwalk_parent_email_types') }}
+),
+emails_wide as (
+  select 
+    k_parent,
+    {{ dbt_utils.pivot(
+      'normalized_email_type',
+      dbt_utils.get_column_values(ref('xwalk_parent_email_types'), 'normalized_email_type'),
+      agg='max',
+      then_value='email_address',
+      suffix='_email_address'
+    ) }}
+  from stg_parent_emails
+  join parent_email_types 
+    on stg_parent_emails.email_type = parent_email_types.original_email_type
+  group by k_parent
+)
+select * from emails_wide

--- a/models/build/edfi_3/parents/bld_ef3__parent_wide_emails.sql
+++ b/models/build/edfi_3/parents/bld_ef3__parent_wide_emails.sql
@@ -11,8 +11,9 @@ emails_wide as (
     {{ dbt_utils.pivot(
       'normalized_email_type',
       dbt_utils.get_column_values(ref('xwalk_parent_email_types'), 'normalized_email_type'),
-      agg='listagg',
+      agg='max',
       then_value='email_address',
+      else_value='null',
       suffix='_email_address'
     ) }}
   from stg_parent_emails

--- a/models/build/edfi_3/parents/bld_ef3__parent_wide_emails.sql
+++ b/models/build/edfi_3/parents/bld_ef3__parent_wide_emails.sql
@@ -20,6 +20,6 @@ emails_wide as (
   from stg_parent_emails
   join parent_email_types 
     on stg_parent_emails.email_type = parent_email_types.original_email_type
-  group by k_parent
+  group by k_parent, tenant_code
 )
 select * from emails_wide

--- a/models/build/edfi_3/parents/bld_ef3__parent_wide_emails.sql
+++ b/models/build/edfi_3/parents/bld_ef3__parent_wide_emails.sql
@@ -7,10 +7,11 @@ parent_email_types as (
 emails_wide as (
   select 
     k_parent,
+    -- todo: do I need api year in here?
     {{ dbt_utils.pivot(
       'normalized_email_type',
       dbt_utils.get_column_values(ref('xwalk_parent_email_types'), 'normalized_email_type'),
-      agg='max',
+      agg='listagg',
       then_value='email_address',
       suffix='_email_address'
     ) }}

--- a/models/build/edfi_3/parents/bld_ef3__parent_wide_emails.sql
+++ b/models/build/edfi_3/parents/bld_ef3__parent_wide_emails.sql
@@ -7,8 +7,9 @@ parent_email_types as (
 emails_wide as (
   select 
     k_parent,
-    tenant_code,
+    tenant_code
     -- note: this is already deduped to be the most recent record for a parent
+    {%- if not is_empty_model('xwalk_parent_email_types') -%},
     {{ dbt_utils.pivot(
       'normalized_email_type',
       dbt_utils.get_column_values(ref('xwalk_parent_email_types'), 'normalized_email_type'),
@@ -17,6 +18,7 @@ emails_wide as (
       else_value='null',
       suffix='_email_address'
     ) }}
+    {%- endif %}
   from stg_parent_emails
   join parent_email_types 
     on stg_parent_emails.email_type = parent_email_types.original_email_type

--- a/models/build/edfi_3/parents/bld_ef3__parent_wide_phone_numbers.sql
+++ b/models/build/edfi_3/parents/bld_ef3__parent_wide_phone_numbers.sql
@@ -7,8 +7,8 @@ parent_phone_number_types as (
 phones_wide as (
   select 
     k_parent,
-    -- todo: do I need api year in here?
-    -- or do I dedupe to keep latest?
+    tenant_code,
+    -- note: this is already deduped to be the most recent record for a parent
     {{ dbt_utils.pivot(
       'normalized_phone_number_type',
       dbt_utils.get_column_values(ref('xwalk_parent_phone_number_types'), 'normalized_phone_number_type'),

--- a/models/build/edfi_3/parents/bld_ef3__parent_wide_phone_numbers.sql
+++ b/models/build/edfi_3/parents/bld_ef3__parent_wide_phone_numbers.sql
@@ -1,0 +1,22 @@
+stg_parent_phones as (
+    select * from {{ ref('stg_ef3__parents__telephones') }}
+),
+parent_phone_number_types as (
+    select * from {{ ref('xwalk_parent_phone_number_types') }}
+),
+phones_wide as (
+  select 
+    k_parent,
+    {{ dbt_utils.pivot(
+      'normalized_phone_number_type',
+      dbt_utils.get_column_values(ref('xwalk_parent_phone_number_types'), 'normalized_phone_number_type'),
+      agg='max',
+      then_value='phone_number',
+      suffix='_phone_number'
+    ) }}
+  from stg_parent_phones
+  join parent_phone_number_types
+    on stg_parent_phones.phone_number_type = parent_phone_number_types.original_phone_number_type
+  group by k_parent
+)
+select * from phones_wide

--- a/models/build/edfi_3/parents/bld_ef3__parent_wide_phone_numbers.sql
+++ b/models/build/edfi_3/parents/bld_ef3__parent_wide_phone_numbers.sql
@@ -11,8 +11,9 @@ phones_wide as (
     {{ dbt_utils.pivot(
       'normalized_phone_number_type',
       dbt_utils.get_column_values(ref('xwalk_parent_phone_number_types'), 'normalized_phone_number_type'),
-      agg='listagg',
+      agg='max',
       then_value='phone_number',
+      else_value='null',
       suffix='_phone_number'
     ) }}
   from stg_parent_phones

--- a/models/build/edfi_3/parents/bld_ef3__parent_wide_phone_numbers.sql
+++ b/models/build/edfi_3/parents/bld_ef3__parent_wide_phone_numbers.sql
@@ -9,6 +9,7 @@ phones_wide as (
     k_parent,
     tenant_code,
     -- note: this is already deduped to be the most recent record for a parent
+    {%- if not is_empty_model('xwalk_parent_phone_number_types') -%},
     {{ dbt_utils.pivot(
       'normalized_phone_number_type',
       dbt_utils.get_column_values(ref('xwalk_parent_phone_number_types'), 'normalized_phone_number_type'),
@@ -17,6 +18,7 @@ phones_wide as (
       else_value='null',
       suffix='_phone_number'
     ) }}
+    {%- endif %}
   from stg_parent_phones
   join parent_phone_number_types
     on stg_parent_phones.phone_number_type = parent_phone_number_types.original_phone_number_type

--- a/models/build/edfi_3/parents/bld_ef3__parent_wide_phone_numbers.sql
+++ b/models/build/edfi_3/parents/bld_ef3__parent_wide_phone_numbers.sql
@@ -20,6 +20,6 @@ phones_wide as (
   from stg_parent_phones
   join parent_phone_number_types
     on stg_parent_phones.phone_number_type = parent_phone_number_types.original_phone_number_type
-  group by k_parent
+  group by k_parent, tenant_code
 )
 select * from phones_wide

--- a/models/build/edfi_3/parents/bld_ef3__parent_wide_phone_numbers.sql
+++ b/models/build/edfi_3/parents/bld_ef3__parent_wide_phone_numbers.sql
@@ -16,7 +16,8 @@ phones_wide as (
       agg='max',
       then_value='phone_number',
       else_value='null',
-      suffix='_phone_number'
+      suffix='_phone_number',
+      quote_identifiers = False
     ) }}
     {%- endif %}
   from stg_parent_phones

--- a/models/build/edfi_3/parents/bld_ef3__parent_wide_phone_numbers.sql
+++ b/models/build/edfi_3/parents/bld_ef3__parent_wide_phone_numbers.sql
@@ -1,4 +1,4 @@
-stg_parent_phones as (
+with stg_parent_phones as (
     select * from {{ ref('stg_ef3__parents__telephones') }}
 ),
 parent_phone_number_types as (

--- a/models/build/edfi_3/parents/bld_ef3__parent_wide_phone_numbers.sql
+++ b/models/build/edfi_3/parents/bld_ef3__parent_wide_phone_numbers.sql
@@ -7,9 +7,9 @@ parent_phone_number_types as (
 phones_wide as (
   select 
     k_parent,
-    tenant_code,
-    -- note: this is already deduped to be the most recent record for a parent
+    tenant_code
     {%- if not is_empty_model('xwalk_parent_phone_number_types') -%},
+    -- note: this is already deduped to be the most recent record for a parent
     {{ dbt_utils.pivot(
       'normalized_phone_number_type',
       dbt_utils.get_column_values(ref('xwalk_parent_phone_number_types'), 'normalized_phone_number_type'),

--- a/models/build/edfi_3/parents/bld_ef3__parent_wide_phone_numbers.sql
+++ b/models/build/edfi_3/parents/bld_ef3__parent_wide_phone_numbers.sql
@@ -7,10 +7,11 @@ parent_phone_number_types as (
 phones_wide as (
   select 
     k_parent,
+    -- todo: do I need api year in here?
     {{ dbt_utils.pivot(
       'normalized_phone_number_type',
       dbt_utils.get_column_values(ref('xwalk_parent_phone_number_types'), 'normalized_phone_number_type'),
-      agg='max',
+      agg='listagg',
       then_value='phone_number',
       suffix='_phone_number'
     ) }}

--- a/models/build/edfi_3/parents/bld_ef3__parent_wide_phone_numbers.sql
+++ b/models/build/edfi_3/parents/bld_ef3__parent_wide_phone_numbers.sql
@@ -8,6 +8,7 @@ phones_wide as (
   select 
     k_parent,
     -- todo: do I need api year in here?
+    -- or do I dedupe to keep latest?
     {{ dbt_utils.pivot(
       'normalized_phone_number_type',
       dbt_utils.get_column_values(ref('xwalk_parent_phone_number_types'), 'normalized_phone_number_type'),

--- a/models/core_warehouse/dim_parent.sql
+++ b/models/core_warehouse/dim_parent.sql
@@ -1,0 +1,34 @@
+{{
+  config(
+    post_hook=[
+        "alter table {{ this }} add primary key (k_parent)",
+    ]
+  )
+}}
+
+with stg_parent as (
+    select * from {{ ref('stg_ef3__parents') }}
+),
+formatted as (
+    select 
+        stg_parent.k_parent,
+        stg_parent.tenant_code,
+        stg_parent.parent_unique_id,
+        stg_parent.person_id,
+        stg_parent.login_id,
+        stg_parent.person_source_system,
+        stg_parent.last_name || ', ' || stg_parent.first_name as display_name,
+        stg_parent.first_name,
+        stg_parent.last_name,
+        stg_parent.middle_name,
+        stg_parent.maiden_name,
+        stg_parent.personal_title_prefix,
+        stg_parent.generation_code_suffix,
+        stg_parent.sex,
+        stg_parent.highest_completed_level_of_education
+        -- leaving out contact info/addresses entirely given the difference in grain
+        -- todo: need to determine what to do here
+    from stg_parent
+)
+select * from formatted
+order by tenant_code, k_parent

--- a/models/core_warehouse/dim_parent.sql
+++ b/models/core_warehouse/dim_parent.sql
@@ -9,6 +9,19 @@
 with stg_parent as (
     select * from {{ ref('stg_ef3__parents') }}
 ),
+parent_phones_wide as (
+    select * from {{ ref('bld_ef3__parent_wide_phone_numbers') }}
+),
+parent_emails_wide as (
+    select * from {{ ref('bld_ef3__parent_wide_emails') }}
+),
+choose_address as (
+    {{ row_pluck(ref('stg_ef3__parents__addresses'),
+                key='k_parent',
+                column='address_type',
+                preferred='Home',
+                where='(do_not_publish is null or not do_not_publish)') }}
+),
 formatted as (
     select 
         stg_parent.k_parent,
@@ -25,10 +38,19 @@ formatted as (
         stg_parent.personal_title_prefix,
         stg_parent.generation_code_suffix,
         stg_parent.sex,
-        stg_parent.highest_completed_level_of_education
+        stg_parent.highest_completed_level_of_education,
+        {{ dbt_utils.star(from=ref('bld_ef3__parent_wide_phone_numbers'), except=["k_parent"]) }},
+        {{ dbt_utils.star(from=ref('bld_ef3__parent_wide_emails'), except=["k_parent"]) }},
+        choose_address.full_address
         -- leaving out contact info/addresses entirely given the difference in grain
         -- todo: need to determine what to do here
     from stg_parent
+    left join parent_phones_wide
+      on stg_parent.k_parent = parent_phones_wide.k_parent
+    left join parent_emails_wide
+      on stg_parent.k_parent = parent_emails_wide.k_parent
+    left join choose_address
+        on stg_parent.k_parent = choose_address.k_parent
 )
 select * from formatted
 order by tenant_code, k_parent

--- a/models/core_warehouse/dim_parent.sql
+++ b/models/core_warehouse/dim_parent.sql
@@ -26,7 +26,6 @@ formatted as (
     select 
         stg_parent.k_parent,
         stg_parent.tenant_code,
-        -- todo: add this? technically could be different for different parents so could be helpful to know when this information is from
         stg_parent.api_year as school_year,
         stg_parent.parent_unique_id,
         stg_parent.person_id,
@@ -41,11 +40,17 @@ formatted as (
         stg_parent.generation_code_suffix,
         stg_parent.sex,
         stg_parent.highest_completed_level_of_education,
-        {{ dbt_utils.star(from=ref('bld_ef3__parent_wide_phone_numbers'), except=["k_parent", "tenant_code"]) }},
-        {{ dbt_utils.star(from=ref('bld_ef3__parent_wide_emails'), except=["k_parent", "tenant_code"]) }},
+        {{ accordion_columns(
+            source_table='bld_ef3__parent_wide_phone_numbers',
+            exclude_columns=["k_parent", "tenant_code"],
+            source_alias='parent_phones_wide'
+        ) }}
+        {{ accordion_columns(
+            source_table='bld_ef3__parent_wide_emails',
+            exclude_columns=["k_parent", "tenant_code"],
+            source_alias='parent_emails_wide'
+        ) }}
         choose_address.full_address
-        -- leaving out contact info/addresses entirely given the difference in grain
-        -- todo: need to determine what to do here
     from stg_parent
     left join parent_phones_wide
       on stg_parent.k_parent = parent_phones_wide.k_parent

--- a/models/core_warehouse/dim_parent.sql
+++ b/models/core_warehouse/dim_parent.sql
@@ -41,8 +41,8 @@ formatted as (
         stg_parent.generation_code_suffix,
         stg_parent.sex,
         stg_parent.highest_completed_level_of_education,
-        {{ dbt_utils.star(from=ref('bld_ef3__parent_wide_phone_numbers'), except=["k_parent"]) }},
-        {{ dbt_utils.star(from=ref('bld_ef3__parent_wide_emails'), except=["k_parent"]) }},
+        {{ dbt_utils.star(from=ref('bld_ef3__parent_wide_phone_numbers'), except=["k_parent", "tenant_code"]) }},
+        {{ dbt_utils.star(from=ref('bld_ef3__parent_wide_emails'), except=["k_parent", "tenant_code"]) }},
         choose_address.full_address
         -- leaving out contact info/addresses entirely given the difference in grain
         -- todo: need to determine what to do here

--- a/models/core_warehouse/dim_parent.sql
+++ b/models/core_warehouse/dim_parent.sql
@@ -26,6 +26,8 @@ formatted as (
     select 
         stg_parent.k_parent,
         stg_parent.tenant_code,
+        -- todo: add this? technically could be different for different parents so could be helpful to know when this information is from
+        stg_parent.api_year as school_year,
         stg_parent.parent_unique_id,
         stg_parent.person_id,
         stg_parent.login_id,

--- a/models/core_warehouse/dim_parent.yml
+++ b/models/core_warehouse/dim_parent.yml
@@ -1,0 +1,34 @@
+version: 2
+
+models:
+  - name: dim_parent
+    description: >
+      Defines parents, some of their key characteristics, and their contact information.
+    columns:
+      - name: k_parent
+        description: Defining key for the parent, which is consistent across years.
+        tests: 
+          - unique
+          - not_null
+      - name: tenant_code
+      - name: parent_unique_id
+        description: The parent's unique id number in the education organization.
+      - name: person_id
+      - name: login_id
+      - name: person_source_system
+      - name: display_name
+        description: The parent's last name, first name, and middle initial.
+      - name: first_name
+        description: The parent's first name, or given name.
+      - name: last_name
+        description: The parent's last name, family name, or surname.
+      - name: middle_name
+        description: The parent's middle name.
+      - name: maiden_name
+        description: The parent's maiden name
+      - name: personal_title_prefix
+      - name: generation_code_suffix
+      - name: sex
+      - name: highest_completed_level_of_education
+      - name: full_address
+        description: The parent's full mailing address

--- a/models/core_warehouse/dim_parent.yml
+++ b/models/core_warehouse/dim_parent.yml
@@ -11,6 +11,7 @@ models:
           - unique
           - not_null
       - name: tenant_code
+      - name: school_year
       - name: parent_unique_id
         description: The parent's unique id number in the education organization.
       - name: person_id

--- a/models/core_warehouse/fct_student_parent_association.sql
+++ b/models/core_warehouse/fct_student_parent_association.sql
@@ -1,7 +1,7 @@
 {{
   config(
     post_hook=[
-        "alter table {{ this }} add primary key (k_student, k_parent, school_year)",
+        "alter table {{ this }} add primary key (k_student, k_parent)",
         "alter table {{ this }} add constraint fk_{{ this.name }}_student foreign key (k_student) references {{ ref('dim_student') }}",
         "alter table {{ this }} add constraint fk_{{ this.name }}_parent foreign key (k_parent) references {{ ref('dim_parent') }}",
     ]

--- a/models/core_warehouse/fct_student_parent_association.sql
+++ b/models/core_warehouse/fct_student_parent_association.sql
@@ -41,9 +41,9 @@ formatted as (
     -- subset to only the stu/parent records associated with the most recent student records
     join most_recent_k_student
         on stg_stu_parent.k_student = most_recent_k_student.k_student
-    -- this will associate the above stu/parent records to all student records (all k_student for a k_student_xyear)
+    -- this will associate the above stu/parent records to all student records (aka. all k_student for a k_student_xyear)
     join dim_student 
-        on most_recent_k_student.k_student_xyear = dim_student.k_student_xyear
+        on stg_stu_parent.k_student_xyear = dim_student.k_student_xyear
     join dim_parent
         on stg_stu_parent.k_parent = dim_parent.k_parent
 )

--- a/models/core_warehouse/fct_student_parent_association.sql
+++ b/models/core_warehouse/fct_student_parent_association.sql
@@ -1,7 +1,7 @@
 {{
   config(
     post_hook=[
-        "alter table {{ this }} add primary key (k_student, k_parent)",
+        "alter table {{ this }} add primary key (k_student, k_parent, school_year)",
         "alter table {{ this }} add constraint fk_{{ this.name }}_student foreign key (k_student) references {{ ref('dim_student') }}",
         "alter table {{ this }} add constraint fk_{{ this.name }}_parent foreign key (k_parent) references {{ ref('dim_parent') }}",
     ]

--- a/models/core_warehouse/fct_student_parent_association.sql
+++ b/models/core_warehouse/fct_student_parent_association.sql
@@ -33,7 +33,7 @@ formatted as (
         stg_stu_parent.is_legal_guardian
     from stg_stu_parent
     join dim_student 
-        on stg_stu_section.k_student = dim_student.k_student
+        on stg_stu_parent.k_student = dim_student.k_student
     join dim_parent
         on stg_stu_parent.k_parent = dim_parent.k_parent
 )

--- a/models/core_warehouse/fct_student_parent_association.sql
+++ b/models/core_warehouse/fct_student_parent_association.sql
@@ -21,7 +21,7 @@ dim_parent as (
 most_recent_k_student as (
     select k_student
     from dim_student
-    having school_year = max(school_year) over (partition by k_student_xyear) 
+    qualify school_year = max(school_year) over (partition by k_student_xyear) 
 ),
 formatted as (
     select 

--- a/models/core_warehouse/fct_student_parent_association.sql
+++ b/models/core_warehouse/fct_student_parent_association.sql
@@ -1,0 +1,39 @@
+{{
+  config(
+    post_hook=[
+        "alter table {{ this }} add primary key (k_student, k_parent)",
+        "alter table {{ this }} add constraint fk_{{ this.name }}_student foreign key (k_student) references {{ ref('dim_student') }}",
+        "alter table {{ this }} add constraint fk_{{ this.name }}_parent foreign key (k_parent) references {{ ref('dim_parent') }}",
+    ]
+  )
+}}
+
+with stg_stu_parent as (
+    select * from {{ ref('stg_ef3__student_parent_associations') }}
+),
+dim_student as (
+    select * from {{ ref('dim_student') }}
+),
+dim_parent as (
+    select * from {{ ref('dim_parent') }}
+),
+formatted as (
+    select 
+        dim_student.k_student,
+        dim_student.k_student_xyear,
+        dim_parent.k_parent,
+        stg_stu_parent.school_year,
+        stg_stu_parent.contact_priority,
+        stg_stu_parent.contact_restrictions,
+        stg_stu_parent.relation_type,
+        stg_stu_parent.is_emergency_contact,
+        stg_stu_parent.is_living_with,
+        stg_stu_parent.is_primary_contact,
+        stg_stu_parent.is_legal_guardian
+    from stg_stu_parent
+    join dim_student 
+        on stg_stu_section.k_student = dim_student.k_student
+    join dim_parent
+        on stg_stu_parent.k_parent = dim_parent.k_parent
+)
+select * from formatted

--- a/models/core_warehouse/fct_student_parent_association.sql
+++ b/models/core_warehouse/fct_student_parent_association.sql
@@ -22,6 +22,7 @@ formatted as (
         dim_student.k_student,
         dim_student.k_student_xyear,
         dim_parent.k_parent,
+        stg_stu_parent.tenant_code,
         stg_stu_parent.school_year,
         stg_stu_parent.contact_priority,
         stg_stu_parent.contact_restrictions,

--- a/models/core_warehouse/fct_student_parent_association.yml
+++ b/models/core_warehouse/fct_student_parent_association.yml
@@ -2,13 +2,19 @@ version: 2
 
 models: 
   - name: fct_student_parent_association
-    description: Associations between students and parents. 
+    description: >
+      Associations between students and parents. 
+      
+      Note: We chose to only keep current associations by determining the most recent
+      student record, subsetting to parent associations from that year, then applying the
+      information to all other years (for cross-year analytical/reporting purposes).
+
+      *Primary Key:* `k_student, k_parent`
     tests:
       - dbt_utils.unique_combination_of_columns:
           combination_of_columns:
             - k_student
             - k_parent
-            - school_year
     columns:
       - name: k_student
       - name: k_student_xyear

--- a/models/core_warehouse/fct_student_parent_association.yml
+++ b/models/core_warehouse/fct_student_parent_association.yml
@@ -1,0 +1,25 @@
+version: 2
+
+models: 
+  - name: fct_student_parent_association
+    description: Associations between students and parents. 
+    tests:
+      - dbt_utils.unique_combination_of_columns:
+          combination_of_columns:
+            - k_student
+            - k_parent
+            - school_year
+    columns:
+      - name: k_student
+      - name: k_student_xyear
+      - name: k_parent
+      - name: tenant_code
+      - name: school_year
+      - name: contact_priority
+      - name: contact_restrictions
+      - name: relation_type
+        description: The type of relationship the parent has with the student (e.g. Mother, Father, Aunt, etc.) 
+      - name: is_emergency_contact
+      - name: is_living_with
+      - name: is_primary_contact
+      - name: is_legal_guardian

--- a/packages.yml
+++ b/packages.yml
@@ -1,3 +1,3 @@
 packages:
   - git: "https://github.com/edanalytics/edu_edfi_source.git"
-    revision: feature/parents
+    revision: feature/full_address

--- a/packages.yml
+++ b/packages.yml
@@ -1,3 +1,3 @@
 packages:
   - git: "https://github.com/edanalytics/edu_edfi_source.git"
-    revision: 0.1.0
+    revision: feature/full_address

--- a/packages.yml
+++ b/packages.yml
@@ -1,3 +1,3 @@
 packages:
   - git: "https://github.com/edanalytics/edu_edfi_source.git"
-    revision: 0.1.0
+    revision: feature/parents

--- a/packages.yml
+++ b/packages.yml
@@ -1,3 +1,3 @@
 packages:
   - git: "https://github.com/edanalytics/edu_edfi_source.git"
-    revision: feature/full_address
+    revision: 0.1.0

--- a/packages.yml
+++ b/packages.yml
@@ -1,3 +1,4 @@
 packages:
-  - git: "https://github.com/edanalytics/edu_edfi_source.git"
-    revision: 0.1.2
+  - local: ~/code/edu_edfi_source
+  #- git: "https://github.com/edanalytics/edu_edfi_source.git"
+   # revision: 0.1.2

--- a/packages.yml
+++ b/packages.yml
@@ -1,4 +1,3 @@
 packages:
-  - local: ~/code/edu_edfi_source
-  #- git: "https://github.com/edanalytics/edu_edfi_source.git"
-   # revision: 0.1.2
+  - git: "https://github.com/edanalytics/edu_edfi_source.git"
+    revision: 0.1.2

--- a/tests/integrity_tests/all_students_have_one_primary_contact.sql
+++ b/tests/integrity_tests/all_students_have_one_primary_contact.sql
@@ -9,9 +9,9 @@ Find students who have multiple primary contacts in the student parent associati
 }}
 -- find students with multiple primary contacts
 with stu_with_multiple_primary_contacts as (
-  select tenant_code, api_year, k_student, sum(is_primary_contact::int) as n_primary_contacts
+  select tenant_code, school_year, k_student, sum(is_primary_contact::int) as n_primary_contacts
   from {{ ref('fct_student_parent_association') }}
-  group by tenant_code, api_year, k_student
+  group by tenant_code, school_year, k_student
   having n_primary_contacts > 1
 )
 select * from stu_with_multiple_primary_contacts

--- a/tests/integrity_tests/all_students_have_one_primary_contact.sql
+++ b/tests/integrity_tests/all_students_have_one_primary_contact.sql
@@ -1,0 +1,17 @@
+/*
+Find students who have multiple primary contacts in the student parent associations.
+*/
+{{
+  config(
+      store_failures = true,
+      severity       = 'warn'
+    )
+}}
+-- find students with multiple primary contacts
+with stu_with_multiple_primary_contacts as (
+  select tenant_code, api_year, k_student, sum(is_primary_contact::int) as n_primary_contacts
+  from {{ ref('fct_student_parent_association') }}
+  group by tenant_code, api_year, k_student
+  having n_primary_contacts > 1
+)
+select * from stu_with_multiple_primary_contacts

--- a/tests/integrity_tests/one_school_year_per_student_parent_association.sql
+++ b/tests/integrity_tests/one_school_year_per_student_parent_association.sql
@@ -4,7 +4,7 @@ Find students parent associations with multiple school years.
 {{
   config(
       store_failures = true,
-      severity       = 'fail'
+      severity       = 'error'
     )
 }}
 -- find students with multiple primary contacts

--- a/tests/integrity_tests/one_school_year_per_student_parent_association.sql
+++ b/tests/integrity_tests/one_school_year_per_student_parent_association.sql
@@ -7,7 +7,7 @@ Find students parent associations with multiple school years.
       severity       = 'error'
     )
 }}
--- find students with multiple primary contacts
+-- Find students parent associations with multiple school years.
 with stu_parent_associations_with_multiple_school_years as (
   select tenant_code, k_student_xyear, k_parent, count(distinct school_year) as n_school_years
   from {{ ref('fct_student_parent_association') }}

--- a/tests/integrity_tests/one_school_year_per_student_parent_association.sql
+++ b/tests/integrity_tests/one_school_year_per_student_parent_association.sql
@@ -1,0 +1,17 @@
+/*
+Find students parent associations with multiple school years.
+*/
+{{
+  config(
+      store_failures = true,
+      severity       = 'fail'
+    )
+}}
+-- find students with multiple primary contacts
+with stu_parent_associations_with_multiple_school_years as (
+  select tenant_code, k_student_xyear, k_parent, count(distinct school_year) as n_school_years
+  from {{ ref('fct_student_parent_association') }}
+  group by tenant_code, k_student_xyear, k_parent
+  having n_school_years > 1
+)
+select * from stu_parent_associations_with_multiple_school_years


### PR DESCRIPTION
Included in this feature:
- build models to cast parent emails and phones wide, with the resulting column names being determined by xwalks (Note: the need for xwalks results from special characters in the original names - It would be easy to switch all special characters to an empty string but that would be an issue for `/` or anything analogous, which we've seen already)
- parent dimension that merges on the above build tables as well as a full mailing address ('home' option chosen when available)
- fact table with student parent associations (Note the logic used to determine 'current' associations)
- two custom tests:
    1. one that checks that a student only has a single primary contact (severity: warn)
    2. one that checks whether a given student_xyr/parent association is linked only in a single `school_year` (severity: error) - this may seem weird because we link the most recent student/parent association to all `k_student`s for a `k_student_xyear` but the `school_year` will remain the same, which is why there should still only be a single `school_year` for a `k_student_xyear`/`k_parent`

This feature requires that `feature/full_address` in the source package is also merged.