### PR TITLE
added dim_education_service_center

### DIFF
--- a/models/core_warehouse/dim_education_service_center.sql
+++ b/models/core_warehouse/dim_education_service_center.sql
@@ -1,0 +1,45 @@
+{{
+  config(
+    post_hook=[
+        "alter table {{ this }} add primary key (k_service_center)",
+    ]
+  )
+}}
+
+with stg_esc as (
+    select * from {{ ref('stg_ef3__education_service_centers') }}
+),
+
+choose_address as (
+    {{ row_pluck(ref('stg_ef3__education_service_centers__addresses'),
+                key='k_service_center',
+                column='address_type',
+                preferred='Physical',
+                where='address_end_date is null') }}
+),
+formatted as (
+    select 
+        stg_esc.k_service_center,
+        stg_esc.tenant_code,
+        stg_esc.service_center_id,
+        stg_esc.service_center_name,
+        stg_esc.service_center_short_name,
+        stg_esc.operational_status,
+        choose_address.address_type,
+        choose_address.street_address,
+        choose_address.city,
+        choose_address.name_of_county,
+        choose_address.state_code,
+        choose_address.postal_code,
+        choose_address.building_site_number,
+        choose_address.locale,
+        choose_address.congressional_district,
+        choose_address.county_fips_code,
+        choose_address.latitude,
+        choose_address.longitude
+    from stg_esc
+    left join choose_address 
+        on stg_esc.k_service_center = choose_address.k_service_center
+)
+select * from formatted
+order by tenant_code, k_service_center

--- a/models/core_warehouse/dim_education_service_center.sql
+++ b/models/core_warehouse/dim_education_service_center.sql
@@ -1,7 +1,7 @@
 {{
   config(
     post_hook=[
-        "alter table {{ this }} add primary key (k_service_center)",
+        "alter table {{ this }} add primary key (k_education_service_center)",
     ]
   )
 }}
@@ -12,18 +12,20 @@ with stg_esc as (
 
 choose_address as (
     {{ row_pluck(ref('stg_ef3__education_service_centers__addresses'),
-                key='k_service_center',
+                key='k_education_service_center',
                 column='address_type',
                 preferred='Physical',
                 where='address_end_date is null') }}
 ),
 formatted as (
     select 
-        stg_esc.k_service_center,
+        stg_esc.k_education_service_center,
         stg_esc.tenant_code,
         stg_esc.service_center_id,
         stg_esc.service_center_name,
         stg_esc.service_center_short_name,
+        stg_esc.state_education_agency_id,
+        stg_esc.website,
         stg_esc.operational_status,
         choose_address.address_type,
         choose_address.street_address,
@@ -39,7 +41,7 @@ formatted as (
         choose_address.longitude
     from stg_esc
     left join choose_address 
-        on stg_esc.k_service_center = choose_address.k_service_center
+        on stg_esc.k_education_service_center = choose_address.k_education_service_center
 )
 select * from formatted
-order by tenant_code, k_service_center
+order by tenant_code, k_education_service_center

--- a/models/core_warehouse/dim_education_service_center.yml
+++ b/models/core_warehouse/dim_education_service_center.yml
@@ -1,0 +1,6 @@
+version: 2
+
+models:
+  - name: dim_education_service_center
+    config:
+      tags: ['esc']


### PR DESCRIPTION
Added dim model and yml file for education service centers, modeled off `dim_lea`. Tested and working in Boston.

One small concern - I called the key `k_service_center` in the staging model, but that doesn't totally follow the convention of matching the dim model name. We could go with `dim_service_center`, `k_education_service_center`, or convert to using `dim_esc` and `k_esc` if we want better consistency.