### PR TITLE
fix recent bug from "first school day" - include single calendar schools in the join

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 ## New features
 ## Under the hood
 ## Fixes 
+ - Implement "first day school" rule for single-caldendar schools in fct_student_school_association
 
 # edu_wh v0.2.1
 ## New features

--- a/models/core_warehouse/fct_student_school_association.sql
+++ b/models/core_warehouse/fct_student_school_association.sql
@@ -89,8 +89,11 @@ formatted as (
     left join single_calendar_schools
         on stg_stu_school.k_school = single_calendar_schools.k_school
         and stg_stu_school.school_year = single_calendar_schools.school_year
-    left join first_school_day
-        on stg_stu_school.k_school_calendar = first_school_day.k_school_calendar
+    left join 
+        on coalesce(
+            dim_school_calendar.k_school_calendar,
+            single_calendar_schools.k_school_calendar
+        ) = first_school_day.k_school_calendar
     where true
     -- exclude students who exited before the first school day
     and (exit_withdraw_date >= first_school_day.calendar_date

--- a/models/core_warehouse/fct_student_school_association.sql
+++ b/models/core_warehouse/fct_student_school_association.sql
@@ -89,7 +89,7 @@ formatted as (
     left join single_calendar_schools
         on stg_stu_school.k_school = single_calendar_schools.k_school
         and stg_stu_school.school_year = single_calendar_schools.school_year
-    left join 
+    left join first_school_day
         on coalesce(
             dim_school_calendar.k_school_calendar,
             single_calendar_schools.k_school_calendar


### PR DESCRIPTION
This fixes a bug from the chronic absence branch. It was exposed on Boston dev (prod is a bit behind, doesn't have the chronic absence update yet). Rows  are mistakenly dropped from  `fct_student_school_association`, if they are not associated with a calendar. This is common in single calendar schools, see previous fix here:
https://github.com/edanalytics/edu_wh/blob/830c24fc2654bf5aaf3748645ef42bad9c015e85/models/core_warehouse/fct_student_school_association.sql#L31-L38

This branch changes the join to `first_school_day` so that single calendar schools are not dropped from the filter `and (exit_withdraw_date >= first_school_day.calendar_date
        or exit_withdraw_date is null)`