### PR TITLE
add custom indicators (optional list of cols) to dim school

### DIFF
--- a/dbt_project.yml
+++ b/dbt_project.yml
@@ -74,3 +74,4 @@ vars:
   # withdraw codes that should exclude students from enrollment altogether
   'edu:enroll:exclude_withdraw_codes': ['No show', 'Invalid enrollment']
 
+  'edu:schools:custom_indicators': Null

--- a/models/core_warehouse/dim_school.sql
+++ b/models/core_warehouse/dim_school.sql
@@ -59,6 +59,15 @@ formatted as (
         stg_school.charter_status,
         stg_school.charter_approval_agency,
         stg_school.magnet_type,
+
+        -- custom indicators
+        {% set custom_indicators = var('edu:schools:custom_indicators') %}
+        {%- if custom_indicators is not none and custom_indicators | length -%}
+          {%- for indicator in custom_indicators -%}
+              {{ custom_indicators[indicator]['where'] }} as {{ indicator }},
+          {%- endfor -%}
+        {%- endif %}
+
         stg_school.website,
         choose_address.address_type,
         choose_address.street_address,


### PR DESCRIPTION
For Boston, they want a simple indicator for "in district schools", see configured here: https://github.com/edanalytics/stadium_boston/commit/45de9674b7507a2025006bbd00797b2b61039cfd

@ejoranlienea Any flags from you on adding this functionality? Obviously we'd prefer these types of indicators to be configured in the ODS, but this is a pretty lightweight way to save a lot of repetitive string matching by Boston's analysts