### PR TITLE
Create cfg_student_programs_consistent_agg_types.sql

### DIFF
--- a/tests/config_tests/cfg_student_programs_consistent_agg_types.sql
+++ b/tests/config_tests/cfg_student_programs_consistent_agg_types.sql
@@ -1,0 +1,38 @@
+/*
+Find records where the is_active, is_annual, and is_ever values are 
+not consistent across each indicator_name. This can occur when there 
+are many program_name values mapped to a single indicator_name.
+*/
+{{
+  config(
+      store_failures = true,
+      severity       = 'warn'
+    )
+}}
+with xwalk_student_programs as (
+    select * from {{ ref('xwalk_student_programs') }}
+),
+grouped as (
+    select 
+        indicator_name,
+        is_active,
+        is_annual,
+        is_ever
+    from xwalk_student_programs
+    group by indicator_name, is_active, is_annual, is_ever
+),
+counts as (
+    select 
+        indicator_name, 
+        count(*) as count_unique_configs
+    from grouped
+    group by indicator_name
+),
+joined as (
+    select xwalk_student_programs.*
+    from xwalk_student_programs
+    join counts
+        on xwalk_student_programs.indicator_name = counts.indicator_name
+    where count_unique_configs > 1
+)
+select * from joined


### PR DESCRIPTION
Added a test that warns of invalid indicator column values in `xwalk_student_programs`. This would occur if there are many `program_name` values mapped to a single `indicator_name` and the indicator columns (`is_active`, `is_annual`, `is_ever`) are not consistent. Tested & working. 

Test xwalk:
![test_xwalk](https://user-images.githubusercontent.com/56237580/228934030-530553b0-dcb4-4365-a3d9-9dba964b4ba7.PNG)

Test results:
![Test_results](https://user-images.githubusercontent.com/56237580/228934039-589f6bb6-6800-41b4-aa23-b4ca76ab9447.PNG)