### PR TITLE
add post hook to create k_network foreign keys using xwalk

### DIFF
--- a/models/core_warehouse/dim_school.sql
+++ b/models/core_warehouse/dim_school.sql
@@ -1,7 +1,18 @@
+-- depends_on: {{ ref('dim_network') }}
 {{
   config(
     post_hook=[
         "alter table {{ this }} add primary key (k_school)",
+
+        "{% set network_types = dbt_utils.get_column_values(
+                           table=ref('xwalk_network_association_types'),
+                           column='network_type',
+                           where=\"association_type = 'school'\",
+                           order_by='network_type')
+        %}
+        {% for network_type in network_types %} 
+            alter table {{ this }} add constraint fk_{{this.name}}_{{network_type}}_network foreign key (k_network__{{network_type}}) references {{ ref('dim_network') }} (k_network)
+         {% endfor %}"
     ]
   )
 }}
@@ -38,7 +49,7 @@ formatted as (
         %}
         {%- if network_types is not none and network_types | length -%}
           {%- for network_type in network_types -%}
-            bld_network_associations.k_network__{{network_type}},
+            bld_network_associations.k_network__{{network_type}}::varchar(32) as k_network__{{network_type}},
           {%- endfor -%}
         {%- endif %}
         stg_school.tenant_code,
@@ -67,7 +78,6 @@ formatted as (
               {{ custom_indicators[indicator]['where'] }} as {{ indicator }},
           {%- endfor -%}
         {%- endif %}
-
         stg_school.website,
         choose_address.address_type,
         choose_address.street_address,

--- a/models/core_warehouse/dim_school.sql
+++ b/models/core_warehouse/dim_school.sql
@@ -12,6 +12,7 @@
         %}
         {% for network_type in network_types %} 
             alter table {{ this }} add constraint fk_{{this.name}}_{{network_type}}_network foreign key (k_network__{{network_type}}) references {{ ref('dim_network') }} (k_network)
+            {%if not loop.last%};{%endif%}
          {% endfor %}"
     ]
   )


### PR DESCRIPTION
Implementations may have arbitrarily many types of networks. these are configured in `xwalk_network_association_types`, and come through dim_school as `k_network__{{region_type}}`. This branch adds a post hook that loops over those network types and creates a foreign key to `dim_network`.

tests:
- boston with current set up (1 network type in xwalk, 1 in data)
- boston with imaginary set up (2 network types in xwalk, 1 in data) -- this is why I needed to add a `;` in between looped statements. **is that dangerous?**
- tested with the `set network_types` to top of script to avoid duplicating code, but this doesn't work. I believe post hooks are compiled separately, so it needs to be defined in both places