### PR TITLE
Bugfix/staff assoc join by year

### DIFF
--- a/models/core_warehouse/fct_staff_school_association.sql
+++ b/models/core_warehouse/fct_staff_school_association.sql
@@ -1,7 +1,7 @@
 {{
   config(
     post_hook=[
-        "alter table {{ this }} add primary key (k_staff, k_lea, k_school, program_assignment, school_year, begin_date)",
+        "alter table {{ this }} add primary key (k_staff, k_lea, k_school, program_assignment, school_year)",
         "alter table {{ this }} add constraint fk_{{ this.name }}_school foreign key (k_school) references {{ ref('dim_school') }}",
     ]
   )

--- a/models/core_warehouse/fct_staff_school_association.sql
+++ b/models/core_warehouse/fct_staff_school_association.sql
@@ -1,7 +1,7 @@
 {{
   config(
     post_hook=[
-        "alter table {{ this }} add primary key (k_staff, k_school, program_assignment, school_year)",
+        "alter table {{ this }} add primary key (k_staff, k_lea, k_school, program_assignment, school_year, begin_date)",
         "alter table {{ this }} add constraint fk_{{ this.name }}_school foreign key (k_school) references {{ ref('dim_school') }}",
     ]
   )
@@ -59,10 +59,12 @@ formatted as (
         on stg_staff_school.k_staff = dim_staff.k_staff
     left join stg_staff_ed_org_assign as lea_assign
         on stg_staff_school.k_staff = lea_assign.k_staff
+        and stg_staff_school.school_year = lea_assign.school_year
         and dim_school.k_lea = lea_assign.k_lea
         and lea_assign.ed_org_type = 'LocalEducationAgency'
     left join stg_staff_ed_org_assign as school_assign
         on stg_staff_school.k_staff = school_assign.k_staff
+        and stg_staff_school.school_year = school_assign.school_year
         and dim_school.k_school = school_assign.k_school
         and school_assign.ed_org_type = 'School'
     -- staff-calendar association is optional


### PR DESCRIPTION
School year is needed in the join to avoid many-to-many joins (bc k_staff is not annualized)

Tested on Boston, duplicates correctly removed.

Future development needed:
- fix the unique key of this model. Edfi allows for duplicates per staff/ed_org/assignment, if begin_date differs. This could realistically occur if a teacher went on leave then returned to school later in the year. But in practice I have seen these duplicates from poor data quality -- Boston has multiyear ODS so all historic staff assignments are assigned to each year; SCDE has next year assignments linked to each year. To fix the unique key, we could first dedupe staff_edorg_assign_assoc to take the latest begin_date, to ensure a 1:1 join
- Handle poor data quality by filtering to staff begin/end dates fit within the window of the school year?
- (maybe in Boston repo only) Handle staff assignments at EducationServiceCenters