### PR TITLE
Feature/accordian columns coalesce

### DIFF
--- a/macros/accordion_columns.sql
+++ b/macros/accordion_columns.sql
@@ -6,8 +6,11 @@ be included in a table.
     in the table
   - source_alias: the alias of the table within the sql expression. If none (default)
     it will reuse the source_table name.
+  - coalesce_value: if this value is specified, a coalesce function will be added with
+    this value as the second parameter (to be returned if the value in the column is null).
+    If none (default), the coalesce function will not be added.
 -#}
-{% macro accordion_columns(source_table, exclude_columns, source_alias=none) %}
+{% macro accordion_columns(source_table, exclude_columns, source_alias=none, coalesce_value=none) %}
   {%- if source_alias is none -%}
    {%- set source_alias = source_table -%} 
   {%- endif -%}
@@ -15,7 +18,13 @@ be included in a table.
     ref(source_table),
       except=exclude_columns
     ) %}
-  {%- for col in keep_cols %}
-    {{ source_alias }}.{{ col }},
-  {%- endfor %}
+  {%- if coalesce_value is none %}
+    {%- for col in keep_cols %}
+      {{ source_alias }}.{{ col }},
+    {%- endfor %}
+  {%- else -%}
+    {%- for col in keep_cols %}
+      coalesce({{ source_alias }}.{{ col }}, {{ coalesce_value }}) as {{ col }},
+    {%- endfor %}  
+  {%- endif -%}
 {% endmacro %}

--- a/models/core_warehouse/dim_student.sql
+++ b/models/core_warehouse/dim_student.sql
@@ -111,7 +111,8 @@ formatted as (
         {{ accordion_columns(
             source_table='bld_ef3__student_characteristics',
             exclude_columns=['tenant_code', 'api_year', 'k_student', 'k_student_xyear', 'ed_org_id'],
-            source_alias='stu_chars'
+            source_alias='stu_chars',
+            coalesce_value = 'FALSE'
         ) }}
 
         -- student indicators
@@ -125,7 +126,8 @@ formatted as (
         {{ accordion_columns(
             source_table='bld_ef3__student_programs',
             exclude_columns=['tenant_code', 'api_year', 'k_student', 'k_student_xyear', 'ed_org_id'],
-            source_alias='stu_programs'
+            source_alias='stu_programs',
+            coalesce_value = 'FALSE'
         ) }}
 
         -- intersection groups


### PR DESCRIPTION
This feature came from looking at the Jeffco student programs indicators in `dim_student`, which are sparsely populated with true/false for students involved in at least one program but are null for most students. We would prefer to have those null values shown as false, to avoid confusion with what null vs. false means. These columns are added to `dim_student` using the `accordion_columns` macro.

I added an optional parameter called `coalesce_value` to the `accordion_columns` macro. When this value is provided, a coalesce function is added with the returned column as the first parameter and the `coalesce_value` as the second.

I added a `coalesce_value` to the student programs and student characteristics columns, since both only contain boolean columns. Student indicators are not necessarily all booleans, so I left that one unchanged. I tested this in Jeffco and it is working as intended.