### PR TITLE
restrict district, school ownership by tenant

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Allow assessment results to come through even if they don't match a xwalk entry
 - Add `k_school` to more models
 - Add configuration to customize the preferred email address for staff
+- Restrict the relationships between tenant and LEAs/schools
 ## Fixes 
 
 

--- a/models/build/edfi_3/bld_ef3__tenant_lea_ownership.sql
+++ b/models/build/edfi_3/bld_ef3__tenant_lea_ownership.sql
@@ -1,0 +1,10 @@
+-- in multi-tenant systems, it is possible for each tenant to individually 
+-- define all the districts/schools in a state. We want to avoid having 
+-- each tenant individually define each district and school, and only
+-- keep the definition from the tenant that actually has ownership
+-- since the relationship between tenant and district is not codified anywhere,
+-- we observe it from student enrollments.
+select distinct ssa.tenant_code, lea_id
+from {{ ref('stg_ef3__student_school_associations') }} ssa 
+join {{ ref('stg_ef3__schools') }} sch 
+    on ssa.k_school = sch.k_school

--- a/models/core_warehouse/dim_lea.sql
+++ b/models/core_warehouse/dim_lea.sql
@@ -9,7 +9,9 @@
 with stg_lea as (
     select * from {{ ref('stg_ef3__local_education_agencies') }}
 ),
-
+tenant_lea_ownership as (
+    select * from {{ ref('bld_ef3__tenant_lea_ownership') }}
+),
 choose_address as (
     {{ row_pluck(ref('stg_ef3__local_education_agencies__addresses'),
                 key='k_lea',
@@ -46,6 +48,9 @@ formatted as (
     from stg_lea
     left join choose_address 
         on stg_lea.k_lea = choose_address.k_lea
+    join tenant_lea_ownership
+        on stg_lea.tenant_code = tenant_lea_ownership.tenant_code
+        and stg_lea.lea_id = tenant_lea_ownership.lea_id
 )
 select * from formatted
 order by tenant_code, k_lea


### PR DESCRIPTION
In Texas, each district-level ODS individually defines _all_ LEAs and Schools in the entire state. This leads to an undesired outcome, where all districts and schools have a separate row in `dim_lea` and `dim_school` for every tenant in the warehouse, and neither table is unique by `lea_id` or `school_id` alone.

This new build model and join in `dim_lea` uses `studentSchoolAssociation` to determine which tenants _actually_ contain which districts, and filtering out the rest. Since `dim_school` depends on a join to `dim_lea`, this restriction also cascades there.

A weakness here is that if district A ever pushed an enrollment of a student at district B, this build model would then contain two LEAs for that tenant, leading to duplication again. This seems unlikely, but may be possible.