### PR TITLE
immutable student demographics

### DIFF
--- a/models/build/edfi_3/students/bld_ef3__immutable_stu_demos.sql
+++ b/models/build/edfi_3/students/bld_ef3__immutable_stu_demos.sql
@@ -22,7 +22,7 @@ joined as (
         stg_student.last_name,
         concat(stg_student.last_name, ', ', stg_student.first_name,
             coalesce(' ' || left(stg_student.middle_name, 1), '')) as display_name,
-        concat(display_name, ' (', stg_student.student_unique_id, ')') as safe_display_name
+        concat(display_name, ' (', stg_student.student_unique_id, ')') as safe_display_name,
         stg_student.birth_date,
         stu_demos.gender,
         stu_races.race_ethnicity,

--- a/models/build/edfi_3/students/bld_ef3__immutable_stu_demos.sql
+++ b/models/build/edfi_3/students/bld_ef3__immutable_stu_demos.sql
@@ -39,7 +39,7 @@ deduped as (
         dbt_utils.deduplicate(
             relation='joined',
             partition_by='k_student_xyear',
-            order_by='api_year desc'
+            order_by='school_year desc'
         )
     }}
 )

--- a/models/build/edfi_3/students/bld_ef3__immutable_stu_demos.sql
+++ b/models/build/edfi_3/students/bld_ef3__immutable_stu_demos.sql
@@ -1,0 +1,46 @@
+-- extract the most recent version of immutable student demographics
+-- so that our most current understanding of these values can be applied
+-- accross all historic years
+with stg_student as (
+    select * from {{ ref('stg_ef3__students') }}
+),
+stu_demos as (
+    select * from {{ ref('bld_ef3__choose_stu_demos') }}
+),
+stu_races as (
+    select * from {{ ref('bld_ef3__stu_race_ethnicity') }}
+),
+joined as (
+    select
+        stg_student.k_student,
+        stg_student.k_student_xyear,
+        stg_student.tenant_code,
+        stg_student.api_year as school_year,
+        stu_demos.ed_org_id,
+        stg_student.first_name,
+        stg_student.middle_name,
+        stg_student.last_name,
+        concat(stg_student.last_name, ', ', stg_student.first_name,
+            coalesce(' ' || left(stg_student.middle_name, 1), '')) as display_name,
+        concat(display_name, ' (', stg_student.student_unique_id, ')') as safe_display_name
+        stg_student.birth_date,
+        stu_demos.gender,
+        stu_races.race_ethnicity,
+        stu_races.race_array
+    from stg_student
+    join stu_demos
+        on stg_student.k_student = stu_demos.k_student
+    left join stu_races
+        on stu_demos.k_student = stu_races.k_student
+        and stu_demos.ed_org_id = stu_races.ed_org_id
+),
+deduped as (
+        {{
+        dbt_utils.deduplicate(
+            relation='joined',
+            partition_by='k_student_xyear',
+            order_by='api_year desc'
+        )
+    }}
+)
+select * from deduped

--- a/models/build/edfi_3/students/bld_ef3__immutable_stu_demos.sql
+++ b/models/build/edfi_3/students/bld_ef3__immutable_stu_demos.sql
@@ -1,3 +1,11 @@
+{# If edu var has been configured to make demos immutable, set partition var to `k_student_xyear` so demos are unique by xyear #}
+{# otherwise, use k_student so demos are unique by student+year #}
+{%- if var('edu:stu_demos:make_demos_immutable', False) -%}
+    {%- set stu_partition_var = 'k_student_xyear' -%}
+{%- else -%}
+    {%- set stu_partition_var = 'k_student' -%}
+{%- endif -%}
+
 -- extract the most recent version of immutable student demographics
 -- so that our most current understanding of these values can be applied
 -- accross all historic years
@@ -38,7 +46,7 @@ deduped as (
         {{
         dbt_utils.deduplicate(
             relation='joined',
-            partition_by='k_student_xyear',
+                partition_by=stu_partition_var,
             order_by='school_year desc'
         )
     }}

--- a/models/core_warehouse/dim_student.sql
+++ b/models/core_warehouse/dim_student.sql
@@ -6,7 +6,16 @@
   )
 }}
 
+{# Load custom data sources from var #}
 {% set custom_data_sources = var("edu:stu_demos:custom_data_sources") %}
+
+{# If edu var has been configured to make demos immutable, set join var to `k_student_xyear` bc demos are unique by xyear #}
+{# otherwise, use k_student bc demos are unique by student+year #}
+{%- if var('edu:stu_demos:make_demos_immutable', False) -%}
+    {%- set demos_join_var = 'k_student_xyear' -%}
+{%- else -%}
+    {%- set demos_join_var = 'k_student' -%}
+{%- endif -%}
 
 with stg_student as (
     select * from {{ ref('stg_ef3__students') }}
@@ -156,7 +165,7 @@ formatted as (
     join stu_demos
         on stg_student.k_student = stu_demos.k_student
     join stu_immutable_demos
-        on stu_demos.k_student_xyear = stu_immutable_demos.k_student_xyear
+        on stu_demos.{{demos_join_var}} = stu_immutable_demos.{{demos_join_var}}
         and stu_demos.ed_org_id = stu_immutable_demos.ed_org_id
     left join stu_ids
         on stu_demos.k_student = stu_ids.k_student

--- a/models/core_warehouse/dim_student.sql
+++ b/models/core_warehouse/dim_student.sql
@@ -156,7 +156,7 @@ formatted as (
     join stu_demos
         on stg_student.k_student = stu_demos.k_student
     join stu_immutable_demos
-        on stu_demos.k_student = stu_immutable_demos.k_student
+        on stu_demos.k_student_xyear = stu_immutable_demos.k_student_xyear
         and stu_demos.ed_org_id = stu_immutable_demos.ed_org_id
     left join stu_ids
         on stu_demos.k_student = stu_ids.k_student


### PR DESCRIPTION
This PR creates a category of demographic variables that the warehouse will consider 'immutable', in the sense that new data is treated as corrections to the record rather than incremental updates.

Since the student dimension is annualized, we keep a record of what a student's demographics were as of each school year. However this can have negative consequences in some cases: if a student's name changes across years we may want to avoid having their prior name appear in reporting.

This branch designates a subset of student demographics as immutable, collects the most recently observed version of these records, and applies them across all history.

An alternative approach would be to make this set of immutable characteristics user-configurable, or otherwise present current and historic versions of records in a more nuanced way.