### PR TITLE
Feature/assessment normalizations

### DIFF
--- a/models/build/edfi_3/assessments/bld_ef3__student_assessments_long_results.sql
+++ b/models/build/edfi_3/assessments/bld_ef3__student_assessments_long_results.sql
@@ -4,6 +4,12 @@ with score_results as (
 xwalk_scores as (
     select * from {{ ref('xwalk_assessment_scores') }}
 ),
+xwalk_score_values as (
+    select * from {{ ref('xwalk_assessment_score_values') }}
+),
+xwalk_score_value_thresholds as (
+    select * from {{ ref('xwalk_assessment_score_value_thresholds') }}
+),
 performance_levels as (
     select
         tenant_code,
@@ -34,16 +40,35 @@ dedupe_results as (
 ),
 merged_xwalk as (
     select
-        tenant_code,
-        api_year,
-        k_student_assessment,
-        score_name as original_score_name,
-        coalesce(normalized_score_name, 'other') as normalized_score_name,
-        score_result
+        dedupe_results.tenant_code,
+        dedupe_results.api_year,
+        dedupe_results.k_student_assessment,
+        dedupe_results.score_name as original_score_name,
+        coalesce(xwalk_scores.normalized_score_name, 'other') as normalized_score_name,
+        -- todo should we rename this to original_?
+        dedupe_results.score_result,
+        coalesce(xwalk_score_value_thresholds.normalized_score_result::varchar,
+                 xwalk_score_values.normalized_score_result::varchar,
+                 score_result::varchar
+                ) as normalized_score_result
     from dedupe_results
     left join xwalk_scores
         on dedupe_results.assessment_identifier = xwalk_scores.assessment_identifier
         and dedupe_results.namespace = xwalk_scores.namespace
         and dedupe_results.score_name = xwalk_scores.original_score_name
+    left join xwalk_score_values
+        on dedupe_results.assessment_identifier = xwalk_score_values.assessment_identifier
+        and dedupe_results.namespace = xwalk_score_values.namespace
+        and xwalk_scores.normalized_score_name = xwalk_score_values.normalized_score_name
+        and dedupe_results.score_result = xwalk_score_values.original_score_result
+    left join xwalk_score_value_thresholds
+        on dedupe_results.assessment_identifier = xwalk_score_value_thresholds.assessment_identifier
+        and dedupe_results.namespace = xwalk_score_value_thresholds.namespace
+        and xwalk_scores.normalized_score_name = xwalk_score_value_thresholds.normalized_score_name
+        -- todo check these comparators -- what if there's a value between the upper and next lower? eg value is 20.4 and the cutoffs are 20 and 21
+        -- todo review my use of try_to_numeric here -- the idea is to allow numeric values to merge, otherwise don't merge without error
+        and try_to_numeric(dedupe_results.score_result) >= xwalk_score_value_thresholds.lower_bound
+        and try_to_numeric(dedupe_results.score_result) <= xwalk_score_value_thresholds.upper_bound
+
 )
 select * from merged_xwalk

--- a/models/build/edfi_3/assessments/bld_ef3__student_assessments_long_results.sql
+++ b/models/build/edfi_3/assessments/bld_ef3__student_assessments_long_results.sql
@@ -45,7 +45,6 @@ merged_xwalk as (
         dedupe_results.k_student_assessment,
         dedupe_results.score_name as original_score_name,
         coalesce(xwalk_scores.normalized_score_name, 'other') as normalized_score_name,
-        -- todo should we rename this to original_?
         dedupe_results.score_result,
         coalesce(xwalk_score_value_thresholds.normalized_score_result::varchar,
                  xwalk_score_values.normalized_score_result::varchar,

--- a/models/build/edfi_3/assessments/bld_ef3__student_assessments_long_results.sql
+++ b/models/build/edfi_3/assessments/bld_ef3__student_assessments_long_results.sql
@@ -69,6 +69,7 @@ merged_xwalk as (
         -- todo review my use of try_to_numeric here -- the idea is to allow numeric values to merge, otherwise don't merge without error
         and try_to_numeric(dedupe_results.score_result) >= xwalk_score_value_thresholds.lower_bound
         and try_to_numeric(dedupe_results.score_result) <= xwalk_score_value_thresholds.upper_bound
+        -- todo in future, may need to include subject & grade level in this join (with options to join across subjects)
 
 )
 select * from merged_xwalk

--- a/models/build/edfi_3/assessments/bld_ef3__student_objective_assessments_long_results.sql
+++ b/models/build/edfi_3/assessments/bld_ef3__student_objective_assessments_long_results.sql
@@ -4,6 +4,12 @@ with score_results as (
 xwalk_scores as (
     select * from {{ ref('xwalk_objective_assessment_scores') }}
 ),
+xwalk_score_values as (
+    select * from {{ ref('xwalk_assessment_score_values') }}
+),
+xwalk_score_value_thresholds as (
+    select * from {{ ref('xwalk_assessment_score_value_thresholds') }}
+),
 performance_levels as (
     select
         tenant_code,
@@ -39,13 +45,31 @@ merged_xwalk as (
         api_year,
         k_student_objective_assessment,
         score_name as original_score_name,
-        coalesce(normalized_score_name, 'other') as normalized_score_name,
-        score_result
+        coalesce(xwalk_scores.normalized_score_name, 'other') as normalized_score_name,
+        score_result,
+        coalesce(xwalk_score_value_thresholds.normalized_score_result::varchar,
+                 xwalk_score_values.normalized_score_result::varchar,
+                 score_result::varchar
+                ) as normalized_score_result
     from dedupe_results
     left join xwalk_scores
         on dedupe_results.assessment_identifier = xwalk_scores.assessment_identifier
         and dedupe_results.namespace = xwalk_scores.namespace
         and dedupe_results.objective_assessment_identification_code = xwalk_scores.objective_assessment_identification_code
         and dedupe_results.score_name = xwalk_scores.original_score_name
+    left join xwalk_score_values
+        on dedupe_results.assessment_identifier = xwalk_score_values.assessment_identifier
+        and dedupe_results.namespace = xwalk_score_values.namespace
+        and xwalk_scores.normalized_score_name = xwalk_score_values.normalized_score_name
+        and dedupe_results.score_result = xwalk_score_values.original_score_result
+    left join xwalk_score_value_thresholds
+        on dedupe_results.assessment_identifier = xwalk_score_value_thresholds.assessment_identifier
+        and dedupe_results.namespace = xwalk_score_value_thresholds.namespace
+        and xwalk_scores.normalized_score_name = xwalk_score_value_thresholds.normalized_score_name
+        -- todo check these comparators -- what if there's a value between the upper and next lower? eg value is 20.4 and the cutoffs are 20 and 21
+        -- todo review my use of try_to_numeric here -- the idea is to allow numeric values to merge, otherwise don't merge without error
+        and try_to_numeric(dedupe_results.score_result) >= xwalk_score_value_thresholds.lower_bound
+        and try_to_numeric(dedupe_results.score_result) <= xwalk_score_value_thresholds.upper_bound
+        -- todo in future, may need to include subject & grade level in this join (with options to join across subjects)
 )
 select * from merged_xwalk

--- a/models/core_warehouse/fct_student_assessment.sql
+++ b/models/core_warehouse/fct_student_assessment.sql
@@ -46,7 +46,7 @@ student_assessments_wide as (
         {{ dbt_utils.pivot(
             'normalized_score_name',
             dbt_utils.get_column_values(ref('xwalk_assessment_scores'), 'normalized_score_name'),
-            then_value='score_result',
+            then_value='normalized_score_result',
             else_value='NULL',
             agg='max',
             quote_identifiers=False

--- a/models/core_warehouse/fct_student_assessment.sql
+++ b/models/core_warehouse/fct_student_assessment.sql
@@ -54,7 +54,7 @@ student_assessments_wide as (
             quote_identifiers=False
         ) }},
         {#- find distinct score names that are in one of the normalize_result xwalks (distinct scores to add normalized_ column for) -#}
-        {% set normalized_names_values = dbt_utils.get_column_values(ref('xwalk_assessment_score_values'), 'normalized_score_name') %}
+        {% set normalized_names_values = dbt_utils.get_column_values(ref('xwalk_assessment_score_values'), 'normalized_score_name') or [] %}
         {% set normalized_names_thresholds = dbt_utils.get_column_values(ref('xwalk_assessment_score_value_thresholds'), 'normalized_score_name') or [] %}
         {{ dbt_utils.pivot(
             'normalized_score_name',

--- a/models/core_warehouse/fct_student_assessment.sql
+++ b/models/core_warehouse/fct_student_assessment.sql
@@ -14,6 +14,9 @@ with student_assessments_long_results as (
 student_assessments as (
     select * from {{ ref('stg_ef3__student_assessments') }}
 ),
+xwalk_assessment_seasons as (
+    select * from {{ ref('xwalk_assessment_seasons') }}
+),
 object_agg_other_results as (
     select
         k_student_assessment,
@@ -30,9 +33,11 @@ student_assessments_wide as (
         student_assessments.tenant_code,
         student_assessments.student_assessment_identifier,
         student_assessments.serial_number,
-        school_year,
-        administration_date,
-        administration_end_date,
+        student_assessments.school_year,
+        student_assessments.administration_date,
+        student_assessments.administration_end_date,
+        xwalk_assessment_seasons.season_name as administration_season,
+        xwalk_assessment_seasons.season_num as administration_season_num,
         event_description,
         administration_environment,
         administration_language,
@@ -46,8 +51,17 @@ student_assessments_wide as (
         {{ dbt_utils.pivot(
             'normalized_score_name',
             dbt_utils.get_column_values(ref('xwalk_assessment_scores'), 'normalized_score_name'),
+            then_value='score_result',
+            else_value='NULL',
+            agg='max',
+            quote_identifiers=False
+        ) }},
+        {{ dbt_utils.pivot(
+            'normalized_score_name',
+            dbt_utils.get_column_values(ref('xwalk_assessment_scores'), 'normalized_score_name'),
             then_value='normalized_score_result',
             else_value='NULL',
+            prefix='normalized_',
             agg='max',
             quote_identifiers=False
         ) }}
@@ -58,7 +72,11 @@ student_assessments_wide as (
         and student_assessments_long_results.normalized_score_name != 'other'
     left join object_agg_other_results
         on student_assessments.k_student_assessment = object_agg_other_results.k_student_assessment
-    {{ dbt_utils.group_by(n=18) }}
+    left join xwalk_assessment_seasons
+        on student_assessments.school_year = xwalk_assessment_seasons.school_year
+        and student_assessments.administration_date >= xwalk_assessment_seasons.start_date
+        and student_assessments.administration_date <= xwalk_assessment_seasons.end_date
+    {{ dbt_utils.group_by(n=20) }}
 )
 select *
 from student_assessments_wide

--- a/models/core_warehouse/fct_student_assessment.sql
+++ b/models/core_warehouse/fct_student_assessment.sql
@@ -1,3 +1,5 @@
+-- depends_on: {{ ref('xwalk_assessment_score_values') }}
+-- depends_on: {{ ref('xwalk_assessment_score_value_thresholds') }}
 {{
   config(
     post_hook=[
@@ -56,9 +58,12 @@ student_assessments_wide as (
             agg='max',
             quote_identifiers=False
         ) }},
+        {#- find distinct score names that are in one of the normalize_result xwalks (distinct scores to add normalized_ column for) -#}
+        {% set normalized_names_values = dbt_utils.get_column_values(ref('xwalk_assessment_score_values'), 'normalized_score_name') %}
+        {% set normalized_names_thresholds = dbt_utils.get_column_values(ref('xwalk_assessment_score_value_thresholds'), 'normalized_score_name') or [] %}
         {{ dbt_utils.pivot(
             'normalized_score_name',
-            dbt_utils.get_column_values(ref('xwalk_assessment_scores'), 'normalized_score_name'),
+            (score_values_names + score_value_threshold_names) | unique,
             then_value='normalized_score_result',
             else_value='NULL',
             prefix='normalized_',

--- a/models/core_warehouse/fct_student_objective_assessment.sql
+++ b/models/core_warehouse/fct_student_objective_assessment.sql
@@ -1,3 +1,5 @@
+-- depends_on: {{ ref('xwalk_objective_assessment_score_values') }}
+-- depends_on: {{ ref('xwalk_objective_assessment_score_value_thresholds') }}
 {{
   config(
     post_hook=[
@@ -49,6 +51,18 @@ student_obj_assessments_wide as (
             dbt_utils.get_column_values(ref('xwalk_objective_assessment_scores'), 'normalized_score_name'),
             then_value='score_result',
             else_value='NULL',
+            agg='max',
+            quote_identifiers=False
+        ) }},
+        {#- find distinct score names that are in one of the normalize_result xwalks (distinct scores to add normalized_ column for) -#}
+        {% set normalized_names_values = dbt_utils.get_column_values(ref('xwalk_objective_assessment_score_values'), 'normalized_score_name') or [] %}
+        {% set normalized_names_thresholds = dbt_utils.get_column_values(ref('xwalk_objective_assessment_score_value_thresholds'), 'normalized_score_name') or [] %}
+        {{ dbt_utils.pivot(
+            'normalized_score_name',
+            (normalized_names_values + normalized_names_thresholds) | unique,
+            then_value='normalized_score_result',
+            else_value='NULL',
+            prefix='normalized_',
             agg='max',
             quote_identifiers=False
         ) }}


### PR DESCRIPTION
### Overview
Assessment score results in the ODS are often not in the format needed to present in downstream dashboards, or in analytical queries. This branch adds the ability to create "normalized" columns in `fct_student_assessment`, `fct_student_objective_assessment`, where each implementation can customize how they map these values. For example, you may want to map a "Percentile" result on a 1-100 scale to be a "performance_level" on a 1-5 scale. Or, you may want to add ordered integer values e.g. "Low -> 1; Medium -> 2; High -> 3".

### Description of Changes
- In `bld_ef3__student_assessment_long_results` and `bld_ef3__student_objective assessment_long_results`, add `normalized_score_result` to model, to allow for normalization of results
- In `fct_student_assessment` and `fct_student_objective_assessment`, create new columns `normalize_{score_name}` wherever they have been configured. e.g. if you add rows to `xwalk_assessment_score_values.csv` for `performance_level`, a new column `normalized_performance_level` will be created with normalized score results

### Dependent on:
These xwalks added to implementation repo:
- `xwallk_assessment_score_values`
- `xwalk_assessment_score_value_thresholds`
- `xwalk_objective_assessment_score_values`
- `xwalk_objective_assessment_score_value_thresholds`

Example PR: https://github.com/edanalytics/stadium_txdemo/pull/9

### Questions:
- Is "normalized" the right wording for these kind of customizations? I don't want to confuse "display values" with "re-scaled values", but there is overlap there
- Is it right to overload a general "normalized_" column with various use cases, when some may need to be integers vs. characters, etc.?
- Generally, are `edu_wh` models the correct place for this kind of normalization?
- When should re-mapping of values live in student warehouse tables, vs. in dimensions or xwalks?

### TODOs:
- Work on a larger "assessments engine" feature that separates normalized info from assessment-specific info & efficiently serves those data to downstream purposes
- In the future, we may need to allow these xwalks to join separately on subject, grade level, etc.
