### PR TITLE
add configurable stu-program-agg columns

### DIFF
--- a/models/build/edfi_3/students/bld_ef3__student_program__homeless.sql
+++ b/models/build/edfi_3/students/bld_ef3__student_program__homeless.sql
@@ -33,7 +33,7 @@ maxed as (
         ) as is_homeless_annual, -- the student had a homeless program enrollment any time during the year
 
         -- custom homeless program agg indicators
-        {% if custom_program_agg_indicators is not none and custom_program_agg_indicators | length -%}
+        {% if custom_program_agg_indicators -%}
           {%- for indicator in custom_program_agg_indicators -%}
             {{ custom_program_agg_indicators[indicator]['agg_sql'] }} as {{ indicator }},
           {%- endfor -%}

--- a/models/build/edfi_3/students/bld_ef3__student_program__homeless.sql
+++ b/models/build/edfi_3/students/bld_ef3__student_program__homeless.sql
@@ -7,6 +7,8 @@
 {# customizable: the column that defines the end date for the homeless program #}
 {% set exit_date_column = var('edu:homeless:exit_date_column') %}
 
+{# customizable: extra indicators to create in the aggregate query #}
+{% set custom_program_agg_indicators = var('edu:homeless:custom_program_agg_indicators', None) %}
 
 with stage as (
     select * from {{ ref('stg_ef3__student_homeless_program_associations') }}
@@ -29,6 +31,13 @@ maxed as (
         max(
           {{ value_not_in_list(field='program_name', excluded_items=exclude_programs) }}
         ) as is_homeless_annual, -- the student had a homeless program enrollment any time during the year
+
+        -- custom homeless program agg indicators
+        {% if custom_program_agg_indicators is not none and custom_program_agg_indicators | length -%}
+          {%- for indicator in custom_program_agg_indicators -%}
+            {{ custom_program_agg_indicators[indicator]['agg_sql'] }} as {{ indicator }},
+          {%- endfor -%}
+        {%- endif %}
 
         max(is_awaiting_foster_care) as is_awaiting_foster_care,
         max(is_homeless_unaccompanied_youth) as is_homeless_unaccompanied_youth,

--- a/models/build/edfi_3/students/bld_ef3__student_program__language_instruction.sql
+++ b/models/build/edfi_3/students/bld_ef3__student_program__language_instruction.sql
@@ -33,7 +33,7 @@ maxed as (
         ) as is_english_language_learner_annual, -- the student had a language instruction program enrollment any time during the year
 
         -- custom language instruction program agg indicators
-        {% if custom_program_agg_indicators is not none and custom_program_agg_indicators | length -%}
+        {% if custom_program_agg_indicators -%}
           {%- for indicator in custom_program_agg_indicators -%}
             {{ custom_program_agg_indicators[indicator]['agg_sql'] }} as {{ indicator }},
           {%- endfor -%}

--- a/models/build/edfi_3/students/bld_ef3__student_program__language_instruction.sql
+++ b/models/build/edfi_3/students/bld_ef3__student_program__language_instruction.sql
@@ -7,6 +7,8 @@
 {# customizable: the column that defines the end date for the language instruction program #}
 {% set exit_date_column = var('edu:language_instruction:exit_date_column') %}
 
+{# customizable: extra indicators to create in the aggregate query #}
+{% set custom_program_agg_indicators = var('edu:language_instruction:custom_program_agg_indicators', None) %}
 
 with stage as (
     select * from {{ ref('stg_ef3__student_language_instruction_program_associations') }}
@@ -29,6 +31,13 @@ maxed as (
         max(
           {{ value_not_in_list(field='program_name', excluded_items=exclude_programs) }}
         ) as is_english_language_learner_annual, -- the student had a language instruction program enrollment any time during the year
+
+        -- custom language instruction program agg indicators
+        {% if custom_program_agg_indicators is not none and custom_program_agg_indicators | length -%}
+          {%- for indicator in custom_program_agg_indicators -%}
+            {{ custom_program_agg_indicators[indicator]['agg_sql'] }} as {{ indicator }},
+          {%- endfor -%}
+        {%- endif %}
 
         max(has_english_learner_participation) as has_english_learner_participation
 

--- a/models/build/edfi_3/students/bld_ef3__student_program__special_education.sql
+++ b/models/build/edfi_3/students/bld_ef3__student_program__special_education.sql
@@ -34,7 +34,7 @@ maxed as (
         ) as is_special_education_annual, -- the student had a special education program enrollment any time during the year
 
         -- custom special ed program agg indicators
-        {% if custom_program_agg_indicators is not none and custom_program_agg_indicators | length -%}
+        {% if custom_program_agg_indicators -%}
           {%- for indicator in custom_program_agg_indicators -%}
             {{ custom_program_agg_indicators[indicator]['agg_sql'] }} as {{ indicator }},
           {%- endfor -%}

--- a/models/build/edfi_3/students/bld_ef3__student_program__special_education.sql
+++ b/models/build/edfi_3/students/bld_ef3__student_program__special_education.sql
@@ -7,6 +7,9 @@
 {# customizable: the column that defines the end date for the language instruction program #}
 {% set exit_date_column = var('edu:special_ed:exit_date_column') %}
 
+{# customizable: extra indicators to create in the aggregate query #}
+{% set custom_program_agg_indicators = var('edu:special_ed:custom_program_agg_indicators', None) %}
+
 
 with stage as (
     select * from {{ ref('stg_ef3__student_special_education_program_associations') }}
@@ -29,6 +32,13 @@ maxed as (
         max(
           {{ value_not_in_list(field='program_name', excluded_items=exclude_programs) }}
         ) as is_special_education_annual, -- the student had a special education program enrollment any time during the year
+
+        -- custom special ed program agg indicators
+        {% if custom_program_agg_indicators is not none and custom_program_agg_indicators | length -%}
+          {%- for indicator in custom_program_agg_indicators -%}
+            {{ custom_program_agg_indicators[indicator]['agg_sql'] }} as {{ indicator }},
+          {%- endfor -%}
+        {%- endif %}
 
         max(is_idea_eligible) as is_idea_eligible,
         max(is_multiply_disabled) as is_multiply_disabled

--- a/models/build/edfi_3/students/bld_ef3__student_program__title_i_part_a.sql
+++ b/models/build/edfi_3/students/bld_ef3__student_program__title_i_part_a.sql
@@ -33,7 +33,7 @@ maxed as (
         ) as is_title_i_annual, -- the student had a title_i program enrollment any time during the year
 
         -- custom title i program agg indicators
-        {% if custom_program_agg_indicators is not none and custom_program_agg_indicators | length -%}
+        {% if custom_program_agg_indicators -%}
           {%- for indicator in custom_program_agg_indicators -%}
             {{ custom_program_agg_indicators[indicator]['agg_sql'] }} as {{ indicator }},
           {%- endfor -%}

--- a/models/build/edfi_3/students/bld_ef3__student_program__title_i_part_a.sql
+++ b/models/build/edfi_3/students/bld_ef3__student_program__title_i_part_a.sql
@@ -7,6 +7,8 @@
 {# customizable: the column that defines the end date for the title_i program #}
 {% set exit_date_column = var('edu:title_i:exit_date_column') %}
 
+{# customizable: extra indicators to create in the aggregate query #}
+{% set custom_program_agg_indicators = var('edu:title_i:custom_program_agg_indicators', None) %}
 
 with stage as (
     select * from {{ ref('stg_ef3__student_title_i_part_a_program_associations') }}
@@ -29,6 +31,13 @@ maxed as (
         max(
           {{ value_not_in_list(field='program_name', excluded_items=exclude_programs) }}
         ) as is_title_i_annual, -- the student had a title_i program enrollment any time during the year
+
+        -- custom title i program agg indicators
+        {% if custom_program_agg_indicators is not none and custom_program_agg_indicators | length -%}
+          {%- for indicator in custom_program_agg_indicators -%}
+            {{ custom_program_agg_indicators[indicator]['agg_sql'] }} as {{ indicator }},
+          {%- endfor -%}
+        {%- endif %}
 
         max(title_i_part_a_participant_status) as title_i_part_a_participant_status
 

--- a/models/core_warehouse/dim_student.sql
+++ b/models/core_warehouse/dim_student.sql
@@ -93,7 +93,7 @@ formatted as (
             {% for agg_type in var('edu:special_ed:agg_types') %}
                 coalesce(stu_special_ed.is_special_education_{{agg_type}}, false) as is_special_education_{{agg_type}},
             {% endfor %}
-            {% if custom_special_ed_program_agg_indicators is not none and custom_special_ed_program_agg_indicators | length -%}
+            {% if custom_special_ed_program_agg_indicators -%}
                 {% for custom_indicator in custom_special_ed_program_agg_indicators %}
                 coalesce(stu_special_ed.{{custom_indicator}}, false) as {{custom_indicator}},
                 {% endfor %}
@@ -104,7 +104,7 @@ formatted as (
             {% for agg_type in var('edu:language_instruction:agg_types') %}
                 coalesce(stu_language_instruction.is_english_language_learner_{{agg_type}}, false) as is_english_language_learner_{{agg_type}},
             {% endfor %}
-            {% if custom_language_instruction_program_agg_indicators is not none and custom_language_instruction_program_agg_indicators | length -%}
+            {% if custom_language_instruction_program_agg_indicators -%}
                 {% for custom_indicator in custom_language_instruction_program_agg_indicators %}
                 coalesce(stu_language_instruction.{{custom_indicator}}, false) as {{custom_indicator}},
                 {% endfor %}
@@ -115,7 +115,7 @@ formatted as (
             {% for agg_type in var('edu:homeless:agg_types') %}
                 coalesce(stu_homeless.is_homeless_{{agg_type}}, false) as is_homeless_{{agg_type}},
             {% endfor %}
-            {% if custom_homeless_program_agg_indicators is not none and custom_homeless_program_agg_indicators | length -%}
+            {% if custom_homeless_program_agg_indicators -%}
                 {% for custom_indicator in custom_homeless_program_agg_indicators %}
                 coalesce(stu_homeless.{{custom_indicator}}, false) as {{custom_indicator}},
                 {% endfor %}
@@ -126,7 +126,7 @@ formatted as (
             {% for agg_type in var('edu:title_i:agg_types') %}
                 coalesce(stu_title_i_part_a.is_title_i_{{agg_type}}, false) as is_title_i_{{agg_type}},
             {% endfor %}
-            {% if custom_title_i_program_agg_indicators is not none and custom_stitle_i_program_agg_indicators | length -%}
+            {% if custom_title_i_program_agg_indicators -%}
                 {% for custom_indicator in custom_title_i_program_agg_indicators %}
                 coalesce(stu_title_i_part_a.{{custom_indicator}}, false) as {{custom_indicator}},
                 {% endfor %}

--- a/models/core_warehouse/dim_student.sql
+++ b/models/core_warehouse/dim_student.sql
@@ -87,6 +87,9 @@ formatted as (
             {% for agg_type in var('edu:special_ed:agg_types') %}
                 coalesce(stu_special_ed.is_special_education_{{agg_type}}, false) as is_special_education_{{agg_type}},
             {% endfor %}
+            {% for custom_indicator in var('edu:special_ed:custom_program_agg_indicators') %}
+               coalesce(stu_special_ed.{{custom_indicator}}, false) as {{custom_indicator}},
+            {% endfor %}
         {% endif %}
 
         {% if var('src:program:language_instruction:enabled', True) %}

--- a/models/core_warehouse/dim_student.sql
+++ b/models/core_warehouse/dim_student.sql
@@ -8,6 +8,9 @@
 
 {% set custom_data_sources = var("edu:stu_demos:custom_data_sources") %}
 
+{# customizable: extra indicators to create in the aggregate query #}
+{% set custom_program_agg_indicators = var('edu:special_ed:custom_program_agg_indicators', None) %}
+
 with stg_student as (
     select * from {{ ref('stg_ef3__students') }}
 ),
@@ -87,9 +90,11 @@ formatted as (
             {% for agg_type in var('edu:special_ed:agg_types') %}
                 coalesce(stu_special_ed.is_special_education_{{agg_type}}, false) as is_special_education_{{agg_type}},
             {% endfor %}
-            {% for custom_indicator in var('edu:special_ed:custom_program_agg_indicators') %}
-               coalesce(stu_special_ed.{{custom_indicator}}, false) as {{custom_indicator}},
-            {% endfor %}
+            {% if custom_program_agg_indicators is not none and custom_program_agg_indicators | length -%}
+                {% for custom_indicator in custom_program_agg_indicators %}
+                coalesce(stu_special_ed.{{custom_indicator}}, false) as {{custom_indicator}},
+                {% endfor %}
+            {% endif %}
         {% endif %}
 
         {% if var('src:program:language_instruction:enabled', True) %}

--- a/models/core_warehouse/dim_student.sql
+++ b/models/core_warehouse/dim_student.sql
@@ -9,7 +9,10 @@
 {% set custom_data_sources = var("edu:stu_demos:custom_data_sources") %}
 
 {# customizable: extra indicators to create in the aggregate query #}
-{% set custom_program_agg_indicators = var('edu:special_ed:custom_program_agg_indicators', None) %}
+{% set custom_special_ed_program_agg_indicators = var('edu:special_ed:custom_program_agg_indicators', None) %}
+{% set custom_homeless_program_agg_indicators = var('edu:homeless:custom_program_agg_indicators', None) %}
+{% set custom_language_instruction_program_agg_indicators = var('edu:language_instruction:custom_program_agg_indicators', None) %}
+{% set custom_title_i_program_agg_indicators = var('edu:title_i:custom_program_agg_indicators', None) %}
 
 with stg_student as (
     select * from {{ ref('stg_ef3__students') }}
@@ -90,8 +93,8 @@ formatted as (
             {% for agg_type in var('edu:special_ed:agg_types') %}
                 coalesce(stu_special_ed.is_special_education_{{agg_type}}, false) as is_special_education_{{agg_type}},
             {% endfor %}
-            {% if custom_program_agg_indicators is not none and custom_program_agg_indicators | length -%}
-                {% for custom_indicator in custom_program_agg_indicators %}
+            {% if custom_special_ed_program_agg_indicators is not none and custom_special_ed_program_agg_indicators | length -%}
+                {% for custom_indicator in custom_special_ed_program_agg_indicators %}
                 coalesce(stu_special_ed.{{custom_indicator}}, false) as {{custom_indicator}},
                 {% endfor %}
             {% endif %}
@@ -101,18 +104,33 @@ formatted as (
             {% for agg_type in var('edu:language_instruction:agg_types') %}
                 coalesce(stu_language_instruction.is_english_language_learner_{{agg_type}}, false) as is_english_language_learner_{{agg_type}},
             {% endfor %}
+            {% if custom_language_instruction_program_agg_indicators is not none and custom_language_instruction_program_agg_indicators | length -%}
+                {% for custom_indicator in custom_language_instruction_program_agg_indicators %}
+                coalesce(stu_language_instruction.{{custom_indicator}}, false) as {{custom_indicator}},
+                {% endfor %}
+            {% endif %}
         {% endif %}
 
         {% if var('src:program:homeless:enabled', True) %}
             {% for agg_type in var('edu:homeless:agg_types') %}
                 coalesce(stu_homeless.is_homeless_{{agg_type}}, false) as is_homeless_{{agg_type}},
             {% endfor %}
+            {% if custom_homeless_program_agg_indicators is not none and custom_homeless_program_agg_indicators | length -%}
+                {% for custom_indicator in custom_homeless_program_agg_indicators %}
+                coalesce(stu_homeless.{{custom_indicator}}, false) as {{custom_indicator}},
+                {% endfor %}
+            {% endif %}
         {% endif %}
 
         {% if var('src:program:title_i:enabled', True) %}
             {% for agg_type in var('edu:title_i:agg_types') %}
                 coalesce(stu_title_i_part_a.is_title_i_{{agg_type}}, false) as is_title_i_{{agg_type}},
             {% endfor %}
+            {% if custom_title_i_program_agg_indicators is not none and custom_stitle_i_program_agg_indicators | length -%}
+                {% for custom_indicator in custom_title_i_program_agg_indicators %}
+                coalesce(stu_title_i_part_a.{{custom_indicator}}, false) as {{custom_indicator}},
+                {% endfor %}
+            {% endif %}
         {% endif %}
 
         -- student characteristics


### PR DESCRIPTION
## Description and Motivation
By default in EDU, programs have `is_active` and `is_annual` as indicators that are aggregated by `k_student`. Those are written in build models like [here](https://github.com/edanalytics/edu_wh/blob/239d4b3acdf56a707dea04b4c4bd860c28ad7fd8/models/build/edfi_3/students/bld_ef3__student_program__special_education.sql#L22). This feature branch adds the ability to add arbitrarily many more of those types of student aggregate program indicators, with custom rules.

For example, if you want to add a new indicator for whether a student was in a 504 Plan Program during the school year, you can configure these variable in your dbt_project.yml, assuming your implementation has `program_name` values equal to '504 Plan':

```
  # custom indicators in special ed model at the same agg level as is_special_ed_active & annual
  'edu:special_ed:custom_program_agg_indicators':
    is_504_plan_annual:
      agg_sql: >
        -- if the student had a 504 program enrollment any time during the year  
 
        max(
          program_name = '504 Plan'
        )
```

And the compiled code in the build model will look like this:
```
-- custom special ed program agg indicators
-- if the student had a 504 program enrollment any time during the year
max(
  program_name = '504 Plan'
)
 as is_504_plan_annual,
```

And any student with a program enrollment with name '504 Plan' will now have `is_504_plan_annual` = TRUE in `dim_student`. Plus, those values will be automatically added to `dim_subgroup` and `fct_student_subgroup`.

## Changes to existing models:

- `bld_ef3__student_program__special_education`, this code optionally adds more agg columns by grabbing sql code from the project config:
https://github.com/edanalytics/edu_wh/blob/543a8b6d75e1984d5be85f8f5ffbfb8e5561f258/models/build/edfi_3/students/bld_ef3__student_program__special_education.sql#L36-L41
  - (Same code is repeated for `bld_ef3__student_program__homeless`, `bld_ef3__student_program__language_instruction`, and `bld_ef3__student_program__title_i` )
- `dim_student`, this code adds new custom indicators as columns: https://github.com/edanalytics/edu_wh/blob/543a8b6d75e1984d5be85f8f5ffbfb8e5561f258/models/core_warehouse/dim_student.sql#L93-L96
  - (Same code is repeated for `bld_ef3__student_program__homeless`, `bld_ef3__student_program__language_instruction`, and `bld_ef3__student_program__title_i` )

## New models added:
**None**

## Tests and QC Done:
Tested on Boston with configuration of 504 plan annual & active indicators.

Also tested on SCDE with configuration of homeless unaccompanied youth indicators.

Tested in both Boston and SCDE with an empty & missing config

### If adding configuration, did you test with empty, broken, and nonexistent configuration?
Yes, I tested with no configuration added, and the new code compiles to empty. 


## PR Merge Priority:
(Promised this feature by end of Sept for BPS)
- [ ] Low
- [ ] Medium
- [x] High


## Questions:
This code assumes your configuration will include SQL to aggregate over `k_student`. What if you want to add a `k_student_xyear` aggregation? Should that be included in this branch?