### PR TITLE
Add incident_time to dim_discipline_incidents.

### DIFF
--- a/models/core_warehouse/dim_discipline_incidents.sql
+++ b/models/core_warehouse/dim_discipline_incidents.sql
@@ -28,6 +28,7 @@ formatted as (
         stg_discipline_incidents.tenant_code,
         stg_discipline_incidents.incident_id,
         stg_discipline_incidents.incident_date,
+        stg_discipline_incidents.incident_time,
         -- adding an indicator for multiple behaviors for an incident
         case
             when array_size(stg_discipline_incidents.v_behaviors) > 1


### PR DESCRIPTION
For whatever reason, `incident_time` is absent in `dim_discipline_incidents`. We should have a discussion about whether to combine `incident_date` and `incident_time` into a single column or to leave them separate.