### PR TITLE
Feature/add warehouse models for cohorts

### DIFF
--- a/models/core_warehouse/dim_cohort.sql
+++ b/models/core_warehouse/dim_cohort.sql
@@ -1,0 +1,28 @@
+{{
+  config(
+    post_hook=[
+        "alter table {{ this }} add primary key (k_cohort)",
+    ]
+  )
+}}
+
+with stg_cohorts as (
+    select * from {{ ref('stg_ef3__cohorts') }}
+),
+formatted as (
+    select 
+        stg_cohorts.k_cohort,
+        stg_cohorts.k_lea,
+        stg_cohorts.k_school,
+        stg_cohorts.tenant_code,
+        stg_cohorts.school_year,
+        stg_cohorts.ed_org_id,
+        stg_cohorts.ed_org_type,
+        stg_cohorts.cohort_id,
+        stg_cohorts.cohort_description,
+        stg_cohorts.cohort_scope,
+        stg_cohorts.cohort_type
+    from stg_cohorts
+)
+select * from formatted
+order by tenant_code, school_year desc, k_cohort

--- a/models/core_warehouse/dim_cohort.yml
+++ b/models/core_warehouse/dim_cohort.yml
@@ -16,6 +16,7 @@ models:
 
     config:
       tags: ['cohort']
+      enabled: "{{ var('src:domain:cohort:enabled', True) }}"
     columns:
       - name: k_cohort
         description: Defining key for cohorts. Surrogate key for [`api_year` + `ed_org_id` + `cohort_id`]

--- a/models/core_warehouse/dim_cohort.yml
+++ b/models/core_warehouse/dim_cohort.yml
@@ -1,0 +1,46 @@
+version: 2
+
+models:
+  - name: dim_cohort
+    description: >
+      ##### Overview:
+        This dimension table defines cohorts that exist at the school and LEA level. It can be referenced by any or all of these fact tables, 
+        if they are populated in the ODS and enabled by this Stadium implementation:
+
+        - [fct_student_cohort_association](#!/model/model.edu_wh.fct_student_cohort_association)
+        - [fct_staff_cohort_association](#!/model/model.edu_wh.fct_staff_cohort_association)
+
+      ##### Primary Key:
+        `k_cohort` -- There is one record per cohort, education organization, and year
+
+
+    config:
+      tags: ['core']
+    columns:
+      - name: k_cohort
+        description: Defining key for cohorts. Surrogate key for [`api_year` + `ed_org_id` + `cohort_id`]
+        tests: 
+          - unique
+      - name: k_lea
+        description: Association to the LEA with the cohort.
+      - name: k_school
+        description: Association to the school with the cohort.
+      - name: tenant_code
+      - name: school_year
+        description: > 
+          School year specified by Spring year.
+          e.g., the 2021-2022 year would be 2022.
+      - name: ed_org_id
+        description: The identifier for the educational organization with the cohort.
+      - name: ed_org_type
+        description: >
+          The type of educational organization
+          e.g., School or LocalEducationAgency.
+      - name: cohort_id
+        description: The identifier for the cohort.
+      - name: cohort_description
+        description: The description of the cohort and its purpose
+      - name: cohort_scope
+        description: The scope of cohort (e.g., school, district, classroom)
+      - name: cohort_type
+        description: The type or category of the cohort (e.g., academic intervention, classroom breakout).

--- a/models/core_warehouse/dim_cohort.yml
+++ b/models/core_warehouse/dim_cohort.yml
@@ -15,7 +15,7 @@ models:
 
 
     config:
-      tags: ['core']
+      tags: ['cohort']
     columns:
       - name: k_cohort
         description: Defining key for cohorts. Surrogate key for [`api_year` + `ed_org_id` + `cohort_id`]

--- a/models/core_warehouse/fct_student_cohort_association.sql
+++ b/models/core_warehouse/fct_student_cohort_association.sql
@@ -1,0 +1,47 @@
+{{
+  config(
+    post_hook=[
+        "alter table {{ this }} add primary key (k_student, k_student_xyear, k_cohort, cohort_begin_date)",
+        "alter table {{ this }} add constraint fk_{{ this.name }}_student foreign key (k_student) references {{ ref('dim_student') }}",
+        "alter table {{ this }} add constraint fk_{{ this.name }}_cohort foreign key (k_cohort) references {{ ref('dim_cohort') }}",
+    ]
+  )
+}}
+
+with stage as (
+    select * from {{ ref('stg_ef3__student_cohort_associations') }}
+),
+
+dim_student as (
+    select * from {{ ref('dim_student') }}
+),
+
+dim_cohort as (
+    select * from {{ ref('dim_cohort') }}
+),
+
+formatted as (
+    select
+        dim_student.k_student,
+        dim_student.k_student_xyear,
+        dim_cohort.k_cohort,
+        dim_cohort.k_lea,
+        dim_cohort.k_school,
+
+        stage.tenant_code,
+        stage.school_year,
+        stage.cohort_begin_date,
+        stage.cohort_end_date
+
+        {{ edu_edfi_source.extract_extension(model_name='stg_ef3__student_cohort_associations', flatten=False) }}
+
+    from stage
+
+        inner join dim_student
+            on stage.k_student = dim_student.k_student
+
+        inner join dim_cohort
+            on stage.k_cohort = dim_cohort.k_cohort
+)
+
+select * from formatted

--- a/models/core_warehouse/fct_student_cohort_association.sql
+++ b/models/core_warehouse/fct_student_cohort_association.sql
@@ -1,7 +1,7 @@
 {{
   config(
     post_hook=[
-        "alter table {{ this }} add primary key (k_student, k_student_xyear, k_cohort, cohort_begin_date)",
+        "alter table {{ this }} add primary key (k_student, k_cohort, cohort_begin_date)",
         "alter table {{ this }} add constraint fk_{{ this.name }}_student foreign key (k_student) references {{ ref('dim_student') }}",
         "alter table {{ this }} add constraint fk_{{ this.name }}_cohort foreign key (k_cohort) references {{ ref('dim_cohort') }}",
     ]

--- a/models/core_warehouse/fct_student_cohort_association.yml
+++ b/models/core_warehouse/fct_student_cohort_association.yml
@@ -7,15 +7,17 @@ models:
         Student cohort enrollment information.
 
       ##### Primary Key:
-        `k_student, k_cohort`
+        `k_student, k_cohort, cohort_begin_date`
 
     config:
       tags: ['cohort']
+      enabled: "{{ var('src:domain:cohort:enabled', True) }}"
     tests:
       - dbt_utils.unique_combination_of_columns:
           combination_of_columns:
             - k_student
             - k_cohort
+            - cohort_begin_date
     columns:
       - name: k_student
       - name: k_student_xyear

--- a/models/core_warehouse/fct_student_cohort_association.yml
+++ b/models/core_warehouse/fct_student_cohort_association.yml
@@ -7,9 +7,7 @@ models:
         Student cohort enrollment information.
 
       ##### Primary Key:
-        `k_cohort` -- There is one record per cohort, education organization, and year
-
-      *Primary Key:* `k_student, k_cohort`
+        `k_student, k_cohort`
 
     config:
       tags: ['core']
@@ -28,3 +26,4 @@ models:
       - name: school_year
       - name: cohort_begin_date
       - name: cohort_end_date
+      - name: is_active_cohort_association

--- a/models/core_warehouse/fct_student_cohort_association.yml
+++ b/models/core_warehouse/fct_student_cohort_association.yml
@@ -1,0 +1,30 @@
+version: 2
+
+models:
+  - name: fct_student_cohort_association
+    description: >
+      ##### Overview:
+        Student cohort enrollment information.
+
+      ##### Primary Key:
+        `k_cohort` -- There is one record per cohort, education organization, and year
+
+      *Primary Key:* `k_student, k_cohort`
+
+    config:
+      tags: ['core']
+    tests:
+      - dbt_utils.unique_combination_of_columns:
+          combination_of_columns:
+            - k_student
+            - k_cohort
+    columns:
+      - name: k_student
+      - name: k_student_xyear
+      - name: k_cohort
+      - name: k_lea
+      - name: k_school
+      - name: tenant_code
+      - name: school_year
+      - name: cohort_begin_date
+      - name: cohort_end_date

--- a/models/core_warehouse/fct_student_cohort_association.yml
+++ b/models/core_warehouse/fct_student_cohort_association.yml
@@ -10,7 +10,7 @@ models:
         `k_student, k_cohort`
 
     config:
-      tags: ['core']
+      tags: ['cohort']
     tests:
       - dbt_utils.unique_combination_of_columns:
           combination_of_columns:


### PR DESCRIPTION
## Description & motivation
Adds warehouse models for cohorts, per the [EDU Project Development](https://educationanalytics.monday.com/boards/3556827529/pulses/5009936520) board.

Requires a field added to `stg_ef3__cohorts` in this [PR.](https://github.com/edanalytics/edu_edfi_source/pull/46)

## PR Merge Priority:
- [x] Low

## New files created:
- `dim_cohort.sql` 
- `fct_student_cohort_association.sql`

## Tests and QC done:
- Ran the models successfully in GSN and South Carolina

## Future ToDos:
No implementations have data for staffCohortAssociations yet. I added a [Monday task](https://educationanalytics.monday.com/boards/3556827529/pulses/5305893276) to build `fct_staff_cohort_association` once we have a use case.
