### PR TITLE
Bring custom columns from discipline xwalks

### DIFF
--- a/models/core_warehouse/fct_student_discipline_actions.sql
+++ b/models/core_warehouse/fct_student_discipline_actions.sql
@@ -106,6 +106,9 @@ join_descriptor_interpretation as (
         xwalk_discipline_actions.is_iss,
         xwalk_discipline_actions.is_exp,
         xwalk_discipline_actions.is_minor,
+        -- bring in any additional custom columns from xwalk, does nothing if there are no extra columns
+        {{ accordion_columns('xwalk_discipline_actions',
+            exclude_columns=['discipline_action','severity_order','is_oss','is_iss','is_exp','is_minor']) }}
         xwalk_discipline_actions.severity_order,
         -- for a specific discipline event (which can include multiple disciplines)
         -- flag the most severe discipline

--- a/models/core_warehouse/fct_student_discipline_incident_behaviors.sql
+++ b/models/core_warehouse/fct_student_discipline_incident_behaviors.sql
@@ -63,6 +63,8 @@ formatted as (
                 then true
             else false
         end as is_most_severe_behavior,
+        -- bring in any additional custom columns from xwalk, does nothing if there are no extra columns
+        {{ accordion_columns('xwalk_discipline_behaviors', exclude_columns=['behavior_type', 'severity_order']) }}
         -- there is typically only a single value here, choosing the first option for analytical use cases
         participation_codes.participation_codes_array[0]::string as participation_code,
         participation_codes.participation_codes_array


### PR DESCRIPTION
## Description & motivation
Use accordion_columns macro to allow us to bring in custom columns from xwalk tables. Will bring in all columns in the xwalk (outside of the standard model columns). Will do nothing if there are no additional columns outside of the standard, so this is a non-breaking change.

Issue: https://educationanalytics.monday.com/boards/3556827529/pulses/5089328641

## Changes to existing models:
- `models/core_warehouse/fct_student_discipline_actions.sql`: add accordion_columns macro
- `models/core_warehouse/fct_student_discipline_incident_behaviors.sql`: add accordion_columns macro

## New models created:
none

## Tests and QC done:
- Tested in Jeffco both with and without custom columns in the xwalks.
- Tested in Boston with no custom columns and confirmed dbt still ran successfully.

## PR Merge Priority:
<!---
This checklist helps the reviewers understand the level of priority for merging this PR.
-->
Low

