### PR TITLE
Enable/disable sped primary disability model based on sped program flag

### DIFF
--- a/models/build/edfi_3/students/_edfi_3__students.yml
+++ b/models/build/edfi_3/students/_edfi_3__students.yml
@@ -36,6 +36,10 @@ models:
     config:
       tags: ['special_ed']
       enabled: "{{ var('src:program:special_ed:enabled', True) }}"
+  - name: bld_ef3__student_program__special_education__primary_disability
+    config:
+      tags: ['special_ed']
+      enabled: "{{ var('src:program:special_ed:enabled', True) }}"
   - name: bld_ef3__student_program__special_education__program_services
     config:
       tags: ['special_ed']


### PR DESCRIPTION
## Description & motivation
The build model `bld_ef3__student_program__special_education__primary_disability` needs to be disabled if the special education programs table is disabled. This follows the same logic as the sped program services build model `bld_ef3__student_program__special_education__program_services`.

## Changes to existing models:
- `models/build/edfi_3/students/_edfi_3__students.yml` - added config for `bld_ef3__student_program__special_education__primary_disability`

## New models created:
none

## Tests and QC done:
- Tested in Jeffco. This just started breaking in Jeffco and I'm honestly not sure how it wasn't an issue until now.

## PR Merge Priority:
<!---
This checklist helps the reviewers understand the level of priority for merging this PR.
-->
High

