### PR TITLE
Allow custom source for student daily attendance

### DIFF
--- a/models/build/edfi_3/bld_ef3__attendance_sessions.sql
+++ b/models/build/edfi_3/bld_ef3__attendance_sessions.sql
@@ -10,7 +10,7 @@ with dim_session as (
     select * from {{ ref('dim_session') }}
 ),
 fct_student_sch_attend as (
-    select * from {{ ref('fct_student_school_attendance_event') }}
+    select * from {{ ref(var("edu:attendance:daily_attendance_source", 'fct_student_school_attendance_event')) }}
 ),
 joined as (
     select 

--- a/models/core_warehouse/fct_student_daily_attendance.sql
+++ b/models/core_warehouse/fct_student_daily_attendance.sql
@@ -10,7 +10,7 @@
 }}
 
 with fct_student_school_att as (
-    select * from {{ ref('fct_student_school_attendance_event') }}
+    select * from {{ ref(var("edu:attendance:daily_attendance_source", 'fct_student_school_attendance_event')) }}
 ),
 dim_calendar_date as (
     select * from {{ ref('dim_calendar_date') }}

--- a/models/core_warehouse/fct_student_daily_attendance.yml
+++ b/models/core_warehouse/fct_student_daily_attendance.yml
@@ -19,6 +19,8 @@ models:
         - "absentee category" is calculated here for each student & day, and reflected in `absentee_category_rank` (integer) and `absentee_category_label` (string).
         It categorizes students using their **cumulative** attendance rate in comparison to thresholds set by the seed table `absentee_categories`.
       
+     {{ doc(var('edu:custom_docs:fct_student_daily_attendance')) if var('edu:custom_docs:fct_student_daily_attendance', '') }}
+
     config:
       tags: ['core']
     tests:

--- a/models/qc/attendance_freshness.sql
+++ b/models/qc/attendance_freshness.sql
@@ -1,5 +1,5 @@
 with att_events as (
-    select * from {{ ref('fct_student_school_attendance_event') }}
+    select * from {{ ref(var("edu:attendance:daily_attendance_source", 'fct_student_school_attendance_event')) }}
 ),
 dim_calendar as (
     select * from {{ ref('dim_calendar_date') }}


### PR DESCRIPTION
## Description & motivation
These code changes allow us to swap out the source data behind `fct_student_daily_attendance` while retaining that fact model and any current or future downstream models built off of it (e.g., `msr_student_cumulative_attendance`).

Non-breaking change. If no custom model is specified in the dbt_project.yml file, then it will default to the original source: `fct_student_school_attendance_event`.

## Changes to existing models:
Allow for a custom source for all three of these models that reference fct_student_school_attendance_event
- models/build/edfi_3/bld_ef3__attendance_sessions.sql
- models/core_warehouse/fct_student_daily_attendance.sql
- models/qc/attendance_freshness.sql

Add an optional variable to include a custom docs page in fct_student_daily_attendance.yml

## New models created:
none

## Tests and QC done:
Tested in Jeffco with and without a custom source specified in the dbt_project.yml file. Runs successfully.

## PR Merge Priority:
High