### PR TITLE
initial draft

### DIFF
--- a/models/core_warehouse/fct_network_association.sql
+++ b/models/core_warehouse/fct_network_association.sql
@@ -1,0 +1,55 @@
+{{
+  config(
+    post_hook=[
+        "alter table {{ this }} add primary key (k_network, k_ed_org, ed_org_type)",
+        "alter table {{ this }} add constraint fk_{{ this.name }}_network foreign key (k_network) references {{ ref('dim_network') }}",
+    ]
+  )
+}}{# no foreign key constraint for k_ed_org because it could be a key to dim_school or dim_lea #}
+
+with stg_ed_org_network as (
+    select * from {{ ref('stg_ef3__education_organization_network_associations') }}
+),
+dim_network as (
+    select * from {{ ref('dim_network') }}
+),
+
+formatted as (
+    select 
+        dim_network.k_network,
+        case 
+            when education_organization_reference:link:rel::string  = 'School'
+            then stg_ed_org_network.k_school
+            when education_organization_reference:link:rel::string  = 'LocalEducationAgency'
+            then stg_ed_org_network.k_lea
+        end as k_ed_org,
+        case 
+            when education_organization_reference:link:rel::string  = 'School'
+            then 'school'
+            when education_organization_reference:link:rel::string  = 'LocalEducationAgency'
+            then 'lea'
+            else null
+        end as ed_org_type,
+        stg_ed_org_network.tenant_code,
+        stg_ed_org_network.network_id,
+        stg_ed_org_network.ed_org_id,
+        stg_ed_org_network.begin_date,
+        stg_ed_org_network.end_date,
+        -- create indicator for active association
+        iff(
+            -- association has not ended
+            (end_date is null
+                or end_date >= current_date())
+            -- association has begun
+            and begin_date <= current_date(),
+            true, false
+        ) as is_active_association
+    from stg_ed_org_network
+    join dim_network
+        on stg_ed_org_network.k_network = dim_network.k_network
+    where true
+    -- exclude associations that ended before they started
+    and (end_date >= begin_date
+        or end_date is null)
+)
+select * from formatted

--- a/models/core_warehouse/fct_network_association.yml
+++ b/models/core_warehouse/fct_network_association.yml
@@ -1,0 +1,67 @@
+version: 2
+
+models: 
+  - name: fct_network_association
+    description: >
+      ##### Overview:
+        This fact table describes associations between education organizations (LEAs or schools)
+        and networks.
+      
+      ##### Primary Key: 
+        `k_network, k_ed_org, ed_org_type` -- There is one record
+      per network, and education organization.
+
+      ##### Important Business Rules:
+        `is_active_association` is a convenience field to help avoid doing date math
+          
+      ##### Example Use Cases:
+        1. Get everything from dim_school, but only schools in a particular network.
+        ```
+          SELECT
+            dim_school.*
+          FROM dim_school
+            join fct_network_association na on dim_school.k_school=na.k_ed_org and na.ed_org_type='school'
+            join dim_network on dim_network.k_network=na.k_network
+          where dim_network.network_id=123
+        ```  
+          
+
+        {{ doc(var('edu:custom_docs:fct_network_association')) if var('edu:custom_docs:fct_network_association', '') }}
+
+
+    config:
+      tags: ['core']
+    tests:
+      - dbt_utils.unique_combination_of_columns:
+          combination_of_columns:
+            - k_network
+            - k_ed_org
+            - ed_org_type
+    columns:
+      - name: k_network
+        description: > 
+          The education organization network. This key defines a single network
+          (foreign key to dim_network)
+      - name: k_ed_org
+        description: > 
+          The education organization, which could be a school (from dim_school)
+          or an LEA (from dim_lea).
+      - name: ed_org_type
+        description: > 
+          Either the string "school" or the string "lea"
+      - name: tenant_code
+        description: > 
+          The tenant from which this association was derived
+      - name: network_id
+        description: > 
+          The ID of the network (same as dim_network.network_id)
+      - name: ed_org_id
+        description: > 
+          The ID of the LEA or school (same as dim_lea.lea_id or dim_school.school_id)
+      - name: begin_date
+        description: The month, day, and year on which the association begins.
+      - name: end_date
+        description: The month, day, and year on which the association ends (or null if not yet ended).
+      - name: is_active_association
+        description: >
+          Indicator for active associtiation: associations that haven't yey begun or have already ended have False.


### PR DESCRIPTION
This adds a model `fct_network_association` which allows for association of a school or LEA to multiple networks. Mainly we're adding this to enable easier network-level permissioning.