### PR TITLE
Bugfix/attendance unique key

### DIFF
--- a/models/core_warehouse/fct_student_daily_attendance.sql
+++ b/models/core_warehouse/fct_student_daily_attendance.sql
@@ -118,9 +118,6 @@ fill_positive_attendance as (
                 when is_enrolled = 1 then fct_student_school_att.is_absent
                 else 1.0
             end, 0.0) as is_present,
-        {# if certainty order didn't join, default to 999, meaning should be sorted last, we are least certain that it's a "correction" #}
-        {# REVIEW is it better to sort opposite way than set to 999? #}
-        coalesce(fct_student_school_att.attendance_category_certainty_order, 999) as attendance_category_certainty_order,
         fct_student_school_att.event_duration,
         fct_student_school_att.school_attendance_duration
     from stu_enr_att_cal
@@ -151,7 +148,7 @@ positive_attendance_deduped as (
         dbt_utils.deduplicate(
             relation='fill_positive_attendance',
             partition_by='k_student, k_school, calendar_date',
-            order_by='is_enrolled desc, total_instructional_days, attendance_category_certainty_order, k_session'
+            order_by='is_enrolled desc, total_instructional_days, attendance_event_category, k_session'
         )
     }}
 ),

--- a/models/core_warehouse/fct_student_daily_attendance.sql
+++ b/models/core_warehouse/fct_student_daily_attendance.sql
@@ -1,7 +1,7 @@
 {{
   config(
     post_hook=[
-        "alter table {{ this }} add primary key (k_student, k_school, k_calendar_date)",
+        "alter table {{ this }} add primary key (k_student, k_school, calendar_date)",
         "alter table {{ this }} add constraint fk_{{ this.name }}_student foreign key (k_student) references {{ ref('dim_student') }}",
         "alter table {{ this }} add constraint fk_{{ this.name }}_school foreign key (k_school) references {{ ref('dim_school') }}",
         "alter table {{ this }} add constraint fk_{{ this.name }}_calendar_date foreign key (k_calendar_date) references {{ ref('dim_calendar_date') }}",
@@ -161,6 +161,7 @@ cumulatives as (
         positive_attendance_deduped.k_student_xyear,
         positive_attendance_deduped.k_school,
         positive_attendance_deduped.k_calendar_date,
+        positive_attendance_deduped.calendar_date,
         positive_attendance_deduped.k_session,
         positive_attendance_deduped.tenant_code,
         positive_attendance_deduped.attendance_event_category,

--- a/models/core_warehouse/fct_student_school_attendance_event.sql
+++ b/models/core_warehouse/fct_student_school_attendance_event.sql
@@ -61,6 +61,7 @@ formatted as (
         stg_stu_sch_attend.attendance_event_category,
         stg_stu_sch_attend.attendance_event_reason,
         xwalk_att_events.is_absent,
+        xwalk_att_events.attendance_category_certainty_order,
         stg_stu_sch_attend.event_duration,
         stg_stu_sch_attend.school_attendance_duration,
         stg_stu_sch_attend.arrival_time,

--- a/models/core_warehouse/fct_student_school_attendance_event.sql
+++ b/models/core_warehouse/fct_student_school_attendance_event.sql
@@ -61,7 +61,6 @@ formatted as (
         stg_stu_sch_attend.attendance_event_category,
         stg_stu_sch_attend.attendance_event_reason,
         xwalk_att_events.is_absent,
-        xwalk_att_events.attendance_category_certainty_order,
         stg_stu_sch_attend.event_duration,
         stg_stu_sch_attend.school_attendance_duration,
         stg_stu_sch_attend.arrival_time,

--- a/models/core_warehouse/fct_student_school_attendance_event.sql
+++ b/models/core_warehouse/fct_student_school_attendance_event.sql
@@ -1,7 +1,7 @@
 {{
   config(
     post_hook=[
-        "alter table {{ this }} add primary key (k_student, k_school, k_calendar_date)",
+        "alter table {{ this }} add primary key (k_student, k_school, k_session, attendance_event_category, k_calendar_date)",
         "alter table {{ this }} add constraint fk_{{ this.name }}_student foreign key (k_student) references {{ ref('dim_student') }}",
         "alter table {{ this }} add constraint fk_{{ this.name }}_school foreign key (k_school) references {{ ref('dim_school') }}",
     ]

--- a/models/core_warehouse/fct_student_section_attendance_event.sql
+++ b/models/core_warehouse/fct_student_section_attendance_event.sql
@@ -1,7 +1,7 @@
 {{
   config(
     post_hook=[
-        "alter table {{ this }} add primary key (k_student, k_course_section, attendance_event_date)",
+        "alter table {{ this }} add primary key (k_student, k_course_section, attendance_event_category, attendance_event_date)",
         "alter table {{ this }} add constraint fk_{{ this.name }}_student foreign key (k_student) references {{ ref('dim_student') }}",
         "alter table {{ this }} add constraint fk_{{ this.name }}_course_section foreign key (k_course_section) references {{ ref('dim_course_section') }}",
     ]

--- a/tests/value_tests/attendance_event_duplicates.sql
+++ b/tests/value_tests/attendance_event_duplicates.sql
@@ -3,9 +3,11 @@
 This test finds records where there are multiple attendance event records per student-school-calendar date.
 These duplicates are handled in fct_student_daily_attendance, but they may point to data quality issues that 
 could be addressed in the source system or ODS.
+
 **When is this important to resolve?**
 When the duplicates are signs of source system errors, e.g. Absent is corrected with Tardy, then Absent record should
 actually be deleted from ODS. The warehouse does its best to handle these cases, but correcting in ODS is always preferred.
+
 **How to resolve?**
 Depends on the case, but once issue is diagnosed, you might resolve that issue and also clean up ODS by deleting the "corrected"
 records.
@@ -22,6 +24,9 @@ with fct_student_school_attendance_event as (
 dim_calendar_date as (
     select * from {{ ref('dim_calendar_date') }}
 ),
+dim_school_calendar as (
+    select * from {{ ref('dim_school_calendar') }}
+),
 dim_session as (
     select * from {{ ref('dim_session') }}
 )
@@ -29,10 +34,10 @@ select
   fct.k_student, 
   fct.k_school, 
   dim_calendar_date.calendar_date, 
+  dim_school_calendar.calendar_code,
   fct.attendance_event_category, 
   fct.is_absent,
-  fct.attendance_category_certainty_order, 
-  fct.attendance_category_certainty_order = min(fct.attendance_category_certainty_order) over(partition by fct.k_student, fct.k_school, dim_calendar_date.calendar_date) as is_preferred_category,
+  fct.attendance_event_category = min(fct.attendance_event_category) over(partition by fct.k_student, fct.k_school, dim_calendar_date.calendar_date) as is_preferred_category_by_dedupe,
   fct.k_session,
   count(*) over(partition by fct.k_student, fct.k_school, dim_calendar_date.calendar_date) as n_duplicates,
   count(distinct fct.attendance_event_category) over(partition by fct.k_student, fct.k_school, dim_calendar_date.calendar_date) as n_unique_attendance_event_categories,
@@ -41,5 +46,7 @@ select
 from fct_student_school_attendance_event fct
 join dim_calendar_date
   on fct.k_calendar_date = dim_calendar_date.k_calendar_date
+join dim_school_calendar
+  on dim_calendar_date.k_school_calendar = dim_school_calendar.k_school_calendar
 qualify 1 < count(*) over(partition by fct.k_student, fct.k_school, dim_calendar_date.calendar_date)
-order by fct.k_student, fct.k_school, calendar_date, attendance_category_certainty_order
+order by fct.k_student, fct.k_school, calendar_date, attendance_event_category

--- a/tests/value_tests/attendance_event_duplicates.sql
+++ b/tests/value_tests/attendance_event_duplicates.sql
@@ -1,0 +1,45 @@
+/*
+**What is this test?**
+This test finds records where there are multiple attendance event records per student-school-calendar date.
+These duplicates are handled in fct_student_daily_attendance, but they may point to data quality issues that 
+could be addressed in the source system or ODS.
+**When is this important to resolve?**
+When the duplicates are signs of source system errors, e.g. Absent is corrected with Tardy, then Absent record should
+actually be deleted from ODS. The warehouse does its best to handle these cases, but correcting in ODS is always preferred.
+**How to resolve?**
+Depends on the case, but once issue is diagnosed, you might resolve that issue and also clean up ODS by deleting the "corrected"
+records.
+*/
+{{
+  config(
+      store_failures = true,
+      severity       = 'warn'
+    )
+}}
+with fct_student_school_attendance_event as (
+    select * from {{ ref('fct_student_school_attendance_event') }}
+),
+dim_calendar_date as (
+    select * from {{ ref('dim_calendar_date') }}
+),
+dim_session as (
+    select * from {{ ref('dim_session') }}
+)
+select 
+  fct.k_student, 
+  fct.k_school, 
+  dim_calendar_date.calendar_date, 
+  fct.attendance_event_category, 
+  fct.is_absent,
+  fct.attendance_category_certainty_order, 
+  fct.attendance_category_certainty_order = min(fct.attendance_category_certainty_order) over(partition by fct.k_student, fct.k_school, dim_calendar_date.calendar_date) as is_preferred_category,
+  fct.k_session,
+  count(*) over(partition by fct.k_student, fct.k_school, dim_calendar_date.calendar_date) as n_duplicates,
+  count(distinct fct.attendance_event_category) over(partition by fct.k_student, fct.k_school, dim_calendar_date.calendar_date) as n_unique_attendance_event_categories,
+  count(distinct fct.is_absent) over(partition by fct.k_student, fct.k_school, dim_calendar_date.calendar_date) as n_unique_is_absent_values,
+  count(distinct fct.k_session) over(partition by fct.k_student, fct.k_school, dim_calendar_date.calendar_date) as n_unique_sessions
+from fct_student_school_attendance_event fct
+join dim_calendar_date
+  on fct.k_calendar_date = dim_calendar_date.k_calendar_date
+qualify 1 < count(*) over(partition by fct.k_student, fct.k_school, dim_calendar_date.calendar_date)
+order by fct.k_student, fct.k_school, calendar_date, attendance_category_certainty_order


### PR DESCRIPTION
<!---
Provide Title above, ensure it summarizes the work in the PR. Example PR titles templates:
* "feature/ (or build/): describe new functionality"
* "hotfix/: describe issue fix for immediate release"
* "bugfix/ (or fix/): describe issue fix, not necessary for immediate release"
* "docs/: adding or updating documentation"
-->

## Description & motivation
<!---
High level description your PR, and why you're making it. Is this linked to slack thread, Monday board, open
issue, a continuation to a previous PR? Link it here if relevant (use the "#" symbol for issues/PRs).
-->
This aligns with [edu_edfi_source PR here](https://github.com/edanalytics/edu_edfi_source/pull/53) to fix a bug in our processing of stu-school/section-attendance. We previously omitted session & attendance_event_category from the unique key, but both of those are needed to align with Ed-Fi. With the fix to edu_edfi_source, we will now keep more records in stg, so this edu_wh PR handles those extra duplicates by:


a) updating unique key of `fct_student_school_attendance_event` & `fct_student_section_attendance_event`
b) adjusting `fct_student_daily_attendance` to order on `attendance_event_category` & `k_session`. This is alphabetical, meaning it will be arbitrary, but consistent. This is an improvement over the previous rule, where consistency was not enforced. But we could consider a future improvement where the rule is configurable (e.g. prefer certain categories over others)

More detail on b): `attendance_event_category_certainty_order` is configurable in xwalk, and the idea is to allow implementations to prefer certain events that seem likely to be corrections in the data. For example, if we have records for both "Absent" and "Tardy", it's likely that "Tardy" was a correction, and should be preferred. However, if we have "Absent" and "In Attendance", it's likely that "Absent" was a correction. This configuration allows the code to work for both positive and negative attendance.

## Dependencies
-  [edu_edfi_source PR here](https://github.com/edanalytics/edu_edfi_source/pull/53) 
- update to xwalk_attendance_events required - example [here](https://github.com/edanalytics/stadium_boston/pull/60/files)

## PR Merge Priority:
<!---
This checklist helps the reviewers understand the level of priority for merging this PR.
A loose description of merging priority levels is:
Low: A week or more.
Medium: Within 3 days or less.
High: As soon as possible.
-->
- [x] Low
- [ ] Medium
- [ ] High

<!---
If High Priority, explain why as a comment below.
-->

## Changes to existing files:
<!---
Include this section if you are changing any existing files or creating breaking changes to existing files. Label the model name and describe the logic behind the changes made, try to be very descriptive here. For example:
- `stg_model` : Describe any changes made to `stg_model` and why the changes where made.
- `src_staging` : Describe any changes made to `src_staging` and why the changes where made.
-->
 - `fct_student_school_attendance_event`: update unique key post hook, and add new column from xwalk
 - `fct_student_section_attendance_event`: update unique key post hook
 - `fct_student_daily_attendance`:
   - add a join to `dim_session`, so we can fill in `total_instructional_days` for positive attendance records. Previously `total_instructional_days` was only populated for _filled positive attendance records_, which meant those were preferred in the dedupe order. But in cases where have a "real" absence record and "filled" attendance record, we want to prefer the "real" one.
   - add `attendance_event_category_certainty_order` and `k_session` to the order by, so we prefer "more certain" records, and if exact tie, take first `k_session` (arbitrary but consistent)
   - **add `calendar_date` as a column in table, and replace `k_calendar_date` with `calendar_date` in the primary key definition (to match the actual dedupe rule)**
## New files created:
<!---
Include this section if you are creating any new files. Label the model name and describe the logic behind the changes made, try to be very descriptive here. For example:
- `stg_new_model` : Describe the purpose of `stg_new_model` and the logic behind creating the model.
- `src_new_staging` : Describe the purpose of `src_new_staging`.
-->
 - new audit table `attendance_event_duplicates` -- helpful view of the duplicates that are now let through on k_student + k_school + calendar_date, and some diagnostic columns that show how these are handled downstream in fct_student_daily_attendance. This could be used by implementations so they are aware of the rule change, and can expose potential data quality issues
## Tests and QC done:
<!---
Describe any process that confirms that the files do what is expected, include screenshots if relevant. For example:
- Analyst replication confirmed that updates to `stg_model` new counts were correct.
- Executed a dbt project run and ensured it was successful.
-->
Tested on Boston, and the impact on stu_daily_attendance was minimal. ~700 stu-daily records changed from absent -> not absent, because Tardy is sorted above Unexcused Absence in drafted xwalk for boston [here](https://github.com/edanalytics/stadium_boston/pull/60/files)
## Future ToDos & Questions:
<!---
[Optional] Include any future steps and questions related to this PR.
-->
Please review the method for ordering on `attendance_event_category_certainty_order`. Is there a better name for this column? Are there edge cases that need to be addressed? Is the order of columns in the order by correct?