### PR TITLE
fix/historic assessments

### DIFF
--- a/models/core_warehouse/fct_student_assessment.sql
+++ b/models/core_warehouse/fct_student_assessment.sql
@@ -29,9 +29,9 @@ student_assessments_wide as (
     select
         student_assessments.k_student_assessment,
         student_assessments.k_assessment,
-        student_assessments.k_student_xyear,
         -- use dim_student.k_student. NOTE, will be null when no corresponding demographics found (e.g. historic year of assessment data)
         dim_student.k_student,
+        student_assessments.k_student_xyear,
         student_assessments.tenant_code,
         student_assessments.student_assessment_identifier,
         student_assessments.serial_number,

--- a/models/core_warehouse/fct_student_assessment.sql
+++ b/models/core_warehouse/fct_student_assessment.sql
@@ -14,6 +14,9 @@ with student_assessments_long_results as (
 student_assessments as (
     select * from {{ ref('stg_ef3__student_assessments') }}
 ),
+dim_student as (
+    select * from {{ ref('dim_student') }}
+),
 object_agg_other_results as (
     select
         k_student_assessment,
@@ -26,11 +29,13 @@ student_assessments_wide as (
     select
         student_assessments.k_student_assessment,
         student_assessments.k_assessment,
-        student_assessments.k_student,
+        student_assessments.k_student_xyear,
+        -- use dim_student.k_student. NOTE, will be null when no corresponding demographics found (e.g. historic year of assessment data)
+        dim_student.k_student,
         student_assessments.tenant_code,
         student_assessments.student_assessment_identifier,
         student_assessments.serial_number,
-        school_year,
+        student_assessments.school_year,
         administration_date,
         administration_end_date,
         event_description,
@@ -58,7 +63,15 @@ student_assessments_wide as (
         and student_assessments_long_results.normalized_score_name != 'other'
     left join object_agg_other_results
         on student_assessments.k_student_assessment = object_agg_other_results.k_student_assessment
-    {{ dbt_utils.group_by(n=18) }}
+    -- left join to allow 'historic' records (assess records with no corresponding stu demographics)
+    left join dim_student
+        on student_assessments.k_student = dim_student.k_student
+    -- FILTER to students who EVER have a record in dim_student
+    where student_assessments.k_student_xyear in (
+        select distinct k_student_xyear
+        from dim_student
+    )
+    {{ dbt_utils.group_by(n=19) }}
 )
 select *
 from student_assessments_wide

--- a/models/core_warehouse/fct_student_assessment.yml
+++ b/models/core_warehouse/fct_student_assessment.yml
@@ -4,24 +4,39 @@ models:
   - name: fct_student_assessment
     description: >
       ##### Overview:
-        This fact table defines student assessment records. The wide score results columns are determined based on the `normalized_score_name`
-        column from the seed table `xwalk_assessment_scores`.
+        This fact table defines student assessment records.
 
       ##### Primary Key:
         `k_student_assessment` -- There is one record per student-assessment event
 
+      ##### Important Business Rules:
+        The wide score results columns are determined based on the `normalized_score_name`
+        column from the seed table `xwalk_assessment_scores`.
+
+        `k_student` is an annualized student identifier, so it will be null unless there is a student record for the relevant school year.
+        We INCLUDE records with null `k_student` to enable analysis of current students' full history of assessments. Therefore,
+        users CAN use `fct_student_assessment` to answer "What is the longitudinal trend in test scores for my current students?"
+
+        However, `k_student_xyear` is a x-year student identifier, and we EXCLUDE records where `k_student_xyear` is null,
+        because we have no way to identify the students. Therefore, users CAN NOT use `fct_student_assessment` to answer 
+        "What is the longitudinal trend in test scores for students who were english learners at the time of the test?",
+        UNLESS every year of assessment data has a corresponding & complete set of identifying data in `dim_student`.
+        Often, this means you should only run longitudinal analysis on years for which you have populated an Ed-Fi ODS, 
+        or a supplementary data source.
+
+
       ##### Example Use Cases:
-      Any scores that are not included in the wide score results columns are listed in the `v_other_results` column. They can be included
-      as wide columns in a query like this:
-      ```
-          SELECT 
-            fsa.*, 
-            fsa.v_other_results:"{NAME OF SCORE}"::int as name_of_score
-          FROM analytics.prod_wh.fct_student_assessment fsa
-          JOIN analytics.prod_wh.dim_assessment da
-            ON fsa.k_assessment = da.k_assessment
-          WHERE da.assessment_identifier = '{ASSESSMENT IDENTIFIER}'
+        Any scores that are not included in the wide score results columns are listed in the `v_other_results` column. They can be included
+        as wide columns in a query like this:
         ```
+            SELECT 
+              fsa.*, 
+              fsa.v_other_results:"{NAME OF SCORE}"::int as name_of_score
+            FROM analytics.prod_wh.fct_student_assessment fsa
+            JOIN analytics.prod_wh.dim_assessment da
+              ON fsa.k_assessment = da.k_assessment
+            WHERE da.assessment_identifier = '{ASSESSMENT IDENTIFIER}'
+          ```
 
       {{ doc(var('edu:custom_docs:fct_student_assessment')) if var('edu:custom_docs:fct_student_assessment', '') }}  
 


### PR DESCRIPTION
## Description & motivation
To align with similar branch for stu academic records https://github.com/edanalytics/edu_wh/pull/95 -- Make `k_student` null in `fct_student_assessment` for records where there's no contemporaneous (stole that word from Erik) dim_student record. Also, remove records if there is no record for the given student in any year (using a lookup via k_student_xyear).

This enables downstream apps to query a full history of student assessment records. But in order to attach them to correct demographics, they'll need to be careful with their query. I made note of this in dbt docs, but should we add an example query, or better yet, a view for this?

## PR Merge Priority:
- [ ] Low
- [x] Medium (for New Rally)
- [ ] High

## Tests and QC done:
Tested on both TX Exchange (dev_raw has historic assessments for dallas) and SC Districts (prod raw has historic SCREADY). `k_student` values are made null for historic years as expected, and rows are dropped for students missing from known demographics.

A quick performance check in SC showed small change for fct_student_assessment (18.03s vs. 18.67s on my laptop).

## Future ToDos & Questions:
- Should we include a convenience view here for those who want a prebuilt demographics join?