### PR TITLE
measure attendance freshness by school

### DIFF
--- a/models/qc/attendance_freshness.sql
+++ b/models/qc/attendance_freshness.sql
@@ -12,3 +12,4 @@ from att_events
 join dim_calendar
     on att_events.k_calendar_date = dim_calendar.k_calendar_date
 group by all
+having max_date <= current_date()

--- a/models/qc/attendance_freshness.sql
+++ b/models/qc/attendance_freshness.sql
@@ -11,5 +11,5 @@ select
 from att_events
 join dim_calendar
     on att_events.k_calendar_date = dim_calendar.k_calendar_date
+where calendar_date <= current_date()
 group by all
-having max_date <= current_date()

--- a/models/qc/attendance_freshness.sql
+++ b/models/qc/attendance_freshness.sql
@@ -6,8 +6,9 @@ dim_calendar as (
 )
 select
     att_events.tenant_code,
+    att_events.k_school,
     max(calendar_date) as max_date
 from att_events
 join dim_calendar
     on att_events.k_calendar_date = dim_calendar.k_calendar_date
-group by 1
+group by all

--- a/models/qc/attendance_freshness.sql
+++ b/models/qc/attendance_freshness.sql
@@ -7,9 +7,11 @@ dim_calendar as (
 select
     att_events.tenant_code,
     att_events.k_school,
+    dim_calendar.school_year,
     max(calendar_date) as max_date
 from att_events
 join dim_calendar
     on att_events.k_calendar_date = dim_calendar.k_calendar_date
 where calendar_date <= current_date()
 group by all
+qualify dim_calendar.school_year = max(dim_calendar.school_year) over(partition by att_events.tenant_code)

--- a/tests/value_tests/attendance_freshness_test.sql
+++ b/tests/value_tests/attendance_freshness_test.sql
@@ -18,7 +18,8 @@ or if there are errors pushing data from source system to ODS.
       severity       = 'warn'
     )
 }}
-select *
+select *,
+  current_date() - max_date as days_since_last_attendance_event
 from {{ ref('attendance_freshness') }}
 where (current_date() - max_date) > 7
 -- try to avoid warnings when school is out


### PR DESCRIPTION
Our original thought was that attendance would get blocked up at the SIS/District-level, but in practice there is a lot of variance by school, with some schools falling quite a bit behind the rest of the district.

Breaking this down to the school level should make this more useful for diagnostics. This is still compatible with the downstream test, which is agnostic about the columns in this table.