### PR TITLE
remove is_latest_record from dim_subgroup

### DIFF
--- a/models/core_warehouse/dim_subgroup.sql
+++ b/models/core_warehouse/dim_subgroup.sql
@@ -32,7 +32,8 @@ stu_long_subgroup as (
           'display_name',
           'birth_date',
           'race_array',
-          'safe_display_name'
+          'safe_display_name',
+          'is_latest_record'
        ],
        remove = stu_id_cols,
        field_name='subgroup_category',


### PR DESCRIPTION
is_latest_record is not meaningful for dim_subgroup for fct_student_subgroup, so adding it to the list of cols to remove