### PR TITLE
Add has_hispanic_latino_ethnicity to dim_student

### DIFF
--- a/models/build/edfi_3/students/bld_ef3__immutable_stu_demos.sql
+++ b/models/build/edfi_3/students/bld_ef3__immutable_stu_demos.sql
@@ -34,7 +34,8 @@ joined as (
         stg_student.birth_date,
         stu_demos.gender,
         stu_races.race_ethnicity,
-        stu_races.race_array
+        stu_races.race_array,
+        stu_races.has_hispanic_latino_ethnicity
     from stg_student
     join stu_demos
         on stg_student.k_student = stu_demos.k_student

--- a/models/build/edfi_3/students/bld_ef3__stu_race_ethnicity.sql
+++ b/models/build/edfi_3/students/bld_ef3__stu_race_ethnicity.sql
@@ -26,7 +26,8 @@ select
         when array_size(race_array) = 1
             then race_array[0]
         else '{{ var("edu:stu_demos:race_unknown_code") }}'
-    end as race_ethnicity
+    end as race_ethnicity,
+    stg_stu_ed_org.has_hispanic_latino_ethnicity
 from build_array
 join stg_stu_ed_org
     on build_array.k_student = stg_stu_ed_org.k_student

--- a/models/core_warehouse/dim_student.sql
+++ b/models/core_warehouse/dim_student.sql
@@ -98,6 +98,7 @@ formatted as (
         stu_grade.entry_grade_level as grade_level,
         stu_grade.grade_level_integer,
         stu_immutable_demos.race_ethnicity,
+        stu_immutable_demos.has_hispanic_latino_ethnicity,
 
         -- student programs
         {% if var('src:program:special_ed:enabled', True) %}
@@ -188,8 +189,7 @@ formatted as (
         stg_student.api_year = max(stg_student.api_year) over(partition by stg_student.k_student_xyear) as is_latest_record,
        
         stu_immutable_demos.race_array,
-        stu_immutable_demos.safe_display_name,
-        stu_immutable_demos.has_hispanic_latino_ethnicity
+        stu_immutable_demos.safe_display_name
 
     from stg_student
 

--- a/models/core_warehouse/dim_student.sql
+++ b/models/core_warehouse/dim_student.sql
@@ -188,7 +188,8 @@ formatted as (
         stg_student.api_year = max(stg_student.api_year) over(partition by stg_student.k_student_xyear) as is_latest_record,
        
         stu_immutable_demos.race_array,
-        stu_immutable_demos.safe_display_name
+        stu_immutable_demos.safe_display_name,
+        stu_immutable_demos.has_hispanic_latino_ethnicity
 
     from stg_student
 

--- a/models/core_warehouse/dim_student.yml
+++ b/models/core_warehouse/dim_student.yml
@@ -72,3 +72,5 @@ models:
         description: A list of the student's races.
       - name: safe_display_name
         description: Display name with student ID, safe for use in grouping operations in a BI tool, to avoid combining students with the same name.
+      - name: has_hispanic_latino_ethnicity
+        description: The student's status for having Hispanic/Latino ethnicity

--- a/models/core_warehouse/dim_student.yml
+++ b/models/core_warehouse/dim_student.yml
@@ -73,4 +73,4 @@ models:
       - name: safe_display_name
         description: Display name with student ID, safe for use in grouping operations in a BI tool, to avoid combining students with the same name.
       - name: has_hispanic_latino_ethnicity
-        description: The student's status for having Hispanic/Latino ethnicity
+        description: An indication that the individual traces his or her origin or descent to Mexico, Puerto Rico, Cuba, Central, and South America, and other Spanish cultures, regardless of race. The term, "Spanish origin," can be used in addition to "Hispanic or Latino."


### PR DESCRIPTION
## feature/hispanic_eth_indicator

## Description & motivation:
This PR would add the has_hispanic_latino_ethnicity field to dim_student.  Addresses a request from the [Boston Stadium implementation](https://educationanalytics.monday.com/boards/2610522828/pulses/5838180248) and is an item on the [EDU Project Development](https://educationanalytics.monday.com/boards/3556827529/pulses/6109566542) board.

## PR Merge Priority:
- [ ] Low </br>
- [x] Medium </br>
- [ ] High </br>

## Changes to existing models:
In edu_wh
- `bld_ef3__stu_race_ethnicity` : Bring has_hispanic_latino_ethnicity column in from stg_ef3__student_education_organization_associations
- `bld_ef3__immutable_stu_demos` : Bring has_hispanic_latino_ethnicity column in from bld_ef3__stu_race_ethnicity
- `dim_student`: Bring has_hispanic_latino_ethnicity column in from bld_ef3__immutable_stu_demos

## Tests and QC done:
- Executed a dbt project run and ensured it was successful.
