### PR TITLE
Feature/assessment sy

### DIFF
--- a/dbt_project.yml
+++ b/dbt_project.yml
@@ -78,6 +78,3 @@ vars:
   'edu:discipline:non_offender_codes': ['Victim', 'Witness', 'Reporter']
 
   'edu:schools:custom_indicators': Null
-
-  'edu:school_year:start_month': '08'
-  'edu:school_year:start_day': '01'

--- a/dbt_project.yml
+++ b/dbt_project.yml
@@ -78,3 +78,6 @@ vars:
   'edu:discipline:non_offender_codes': ['Victim', 'Witness', 'Reporter']
 
   'edu:schools:custom_indicators': Null
+
+  'edu:school_year:start_month': '08'
+  'edu:school_year:start_day': '01'

--- a/macros/derive_school_year.sql
+++ b/macros/derive_school_year.sql
@@ -1,19 +1,10 @@
 {# 
 This macro takes derives school years from a date column.
+
+The date column will be compared to the default school year start day and month.
 #}
 
 {% macro derive_school_year(date_column) %}
-
-    {# {% set date_lower_bound = 
-            "concat_ws('/', '{{var('edu:school_year:start_month')}}', 
-                           '{{var('edu:school_year:start_day')}}', 
-                           year(date_column::date))::date" %}
-
-    {% set date_upper_bound = 
-            "concat_ws('/', '{{var('edu:school_year:start_month')}}', 
-                           '{{var('edu:school_year:start_day')}}', 
-                           (year(date_column::date)::int + 1))::date" %} #}
-
     case
         when {{date_column}}::date >= 
             concat_ws('/', '{{var("edu:school_year:start_month")}}', 
@@ -26,5 +17,4 @@ This macro takes derives school years from a date column.
             then (year({{date_column}}::date)::int + 1)
         else year({{date_column}}::date)
     end
-
 {% endmacro %}

--- a/macros/derive_school_year.sql
+++ b/macros/derive_school_year.sql
@@ -5,6 +5,7 @@ The date column will be compared to the default school year start day and month.
 #}
 
 {% macro derive_school_year(date_column) %}
+    {% if var("edu:school_year:start_month", None) and var("edu:school_year:start_day", None) %}
     case
         when {{date_column}}::date >= 
             concat_ws('/', '{{var("edu:school_year:start_month")}}', 
@@ -17,4 +18,7 @@ The date column will be compared to the default school year start day and month.
             then (year({{date_column}}::date)::int + 1)
         else year({{date_column}}::date)
     end
+    {% else %}
+    null
+    {% endif %}
 {% endmacro %}

--- a/macros/derive_school_year.sql
+++ b/macros/derive_school_year.sql
@@ -1,0 +1,30 @@
+{# 
+This macro takes derives school years from a date column.
+#}
+
+{% macro derive_school_year(date_column) %}
+
+    {# {% set date_lower_bound = 
+            "concat_ws('/', '{{var('edu:school_year:start_month')}}', 
+                           '{{var('edu:school_year:start_day')}}', 
+                           year(date_column::date))::date" %}
+
+    {% set date_upper_bound = 
+            "concat_ws('/', '{{var('edu:school_year:start_month')}}', 
+                           '{{var('edu:school_year:start_day')}}', 
+                           (year(date_column::date)::int + 1))::date" %} #}
+
+    case
+        when {{date_column}}::date >= 
+            concat_ws('/', '{{var("edu:school_year:start_month")}}', 
+                           '{{var("edu:school_year:start_day")}}', 
+                           year({{date_column}}::date))::date
+            and {{date_column}}::date < 
+            concat_ws('/', '{{var("edu:school_year:start_month")}}', 
+                           '{{var("edu:school_year:start_day")}}', 
+                           (year({{date_column}}::date)::int + 1))::date
+            then (year({{date_column}}::date)::int + 1)
+        else year({{date_column}}::date)
+    end
+
+{% endmacro %}

--- a/models/core_warehouse/fct_student_assessment.sql
+++ b/models/core_warehouse/fct_student_assessment.sql
@@ -76,7 +76,7 @@ student_assessments_wide as (
     {% if var('edu:school_year:assessment_dates_xwalk_enabled', False) %}
     left join {{ ref('xwalk_assessment_school_year_dates') }} dates_xwalk
         -- note: between means A >= X AND A <= Y, so date upper/lower bounds should not overlap across years
-        on student_assessments.administration_date between start_date::date and end_date::date
+        on student_assessments.administration_date between dates_xwalk.start_date::date and dates_xwalk.end_date::date 
         -- we want to allow for the school year cutoffs to differ by assessment 
         -- but also allow those fields to remain null if xwalk is desired but not to differ across assessments
         and ifnull(dates_xwalk.assessment_identifier, '1') = iff(dates_xwalk.assessment_identifier is null, '1', student_assessments.assessment_identifier)

--- a/models/core_warehouse/fct_student_assessment.sql
+++ b/models/core_warehouse/fct_student_assessment.sql
@@ -35,8 +35,11 @@ student_assessments_wide as (
         student_assessments.tenant_code,
         student_assessments.student_assessment_identifier,
         student_assessments.serial_number,
-        {% if var('edu:school_year:dates_xwalk_enabled', False) %}
-        coalesce(student_assessments.school_year, dates_xwalk.school_year, {{derive_school_year('student_assessments.administration_date')}}) as school_year,
+        {% if var('edu:school_year:assessment_dates_xwalk_enabled', False) %}
+        iff(dates_xwalk.override_existing,
+            coalesce(dates_xwalk.school_year, student_assessments.school_year, {{derive_school_year('student_assessments.administration_date')}}),
+            coalesce(student_assessments.school_year, dates_xwalk.school_year, {{derive_school_year('student_assessments.administration_date')}}))
+        as school_year,
         {% else %}
         coalesce(student_assessments.school_year, {{derive_school_year('student_assessments.administration_date')}}) as school_year,
         {% endif %}
@@ -70,11 +73,10 @@ student_assessments_wide as (
     -- left join to allow 'historic' records (assess records with no corresponding stu demographics)
     left join dim_student
         on student_assessments.k_student = dim_student.k_student
-    -- todo: if we are going to have multiple xwalks, should there be multiple vars? specific to assessment for ex.
-    {% if var('edu:school_year:dates_xwalk_enabled', False) %}
-    left join {{ ref('assessment_school_year_dates') }} dates_xwalk
+    {% if var('edu:school_year:assessment_dates_xwalk_enabled', False) %}
+    left join {{ ref('xwalk_assessment_school_year_dates') }} dates_xwalk
         -- note: between means A >= X AND A <= Y, so date upper/lower bounds should not overlap across years
-        on student_assessments.administration_date between date_lower_bound::date and date_upper_bound::date
+        on student_assessments.administration_date between start_date::date and end_date::date
         -- we want to allow for the school year cutoffs to differ by assessment 
         -- but also allow those fields to remain null if xwalk is desired but not to differ across assessments
         and ifnull(dates_xwalk.assessment_identifier, '1') = iff(dates_xwalk.assessment_identifier is null, '1', student_assessments.assessment_identifier)

--- a/models/core_warehouse/fct_student_assessment.sql
+++ b/models/core_warehouse/fct_student_assessment.sql
@@ -36,9 +36,9 @@ student_assessments_wide as (
         student_assessments.student_assessment_identifier,
         student_assessments.serial_number,
         {% if var('edu:school_year:dates_xwalk_enabled', False) %}
-        coalesce(student_assessments.school_year, dates_xwalk.school_year, {{derive_school_year('administration_date')}}) as school_year,
+        coalesce(student_assessments.school_year, dates_xwalk.school_year, {{derive_school_year('student_assessments.administration_date')}}) as school_year,
         {% else %}
-        coalesce(student_assessments.school_year, {{derive_school_year('administration_date')}}) as school_year,
+        coalesce(student_assessments.school_year, {{derive_school_year('student_assessments.administration_date')}}) as school_year,
         {% endif %}
         administration_date,
         administration_end_date,

--- a/models/core_warehouse/fct_student_assessment.sql
+++ b/models/core_warehouse/fct_student_assessment.sql
@@ -35,7 +35,11 @@ student_assessments_wide as (
         student_assessments.tenant_code,
         student_assessments.student_assessment_identifier,
         student_assessments.serial_number,
-        student_assessments.school_year,
+        {% if var('edu:school_year:dates_xwalk_enabled', False) %}
+        coalesce(student_assessments.school_year, dates_xwalk.school_year, {{derive_school_year('administration_date')}}) as school_year,
+        {% else %}
+        coalesce(student_assessments.school_year, {{derive_school_year('administration_date')}}) as school_year,
+        {% endif %}
         administration_date,
         administration_end_date,
         event_description,
@@ -66,6 +70,16 @@ student_assessments_wide as (
     -- left join to allow 'historic' records (assess records with no corresponding stu demographics)
     left join dim_student
         on student_assessments.k_student = dim_student.k_student
+    -- todo: if we are going to have multiple xwalks, should there be multiple vars? specific to assessment for ex.
+    {% if var('edu:school_year:dates_xwalk_enabled', False) %}
+    left join {{ ref('assessment_school_year_dates') }} dates_xwalk
+        -- note: between means A >= X AND A <= Y, so date upper/lower bounds should not overlap across years
+        on student_assessments.administration_date between date_lower_bound::date and date_upper_bound::date
+        -- we want to allow for the school year cutoffs to differ by assessment 
+        -- but also allow those fields to remain null if xwalk is desired but not to differ across assessments
+        and ifnull(dates_xwalk.assessment_identifier, '1') = iff(dates_xwalk.assessment_identifier is null, '1', student_assessments.assessment_identifier)
+        and ifnull(dates_xwalk.namespace, '1') = iff(dates_xwalk.namespace is null, '1', student_assessments.namespace)
+    {% endif %}
     -- FILTER to students who EVER have a record in dim_student
     where student_assessments.k_student_xyear in (
         select distinct k_student_xyear

--- a/models/core_warehouse/fct_student_objective_assessment.sql
+++ b/models/core_warehouse/fct_student_objective_assessment.sql
@@ -36,9 +36,9 @@ student_obj_assessments_wide as (
         student_obj_assessments.k_student_xyear,
         student_obj_assessments.tenant_code,
         {% if var('edu:school_year:dates_xwalk_enabled', False) %}
-        coalesce(student_obj_assessments.school_year, dates_xwalk.school_year, {{derive_school_year('administration_date')}}) as school_year,
+        coalesce(student_obj_assessments.school_year, dates_xwalk.school_year, {{derive_school_year('student_obj_assessments.administration_date')}}) as school_year,
         {% else %}
-        coalesce(student_obj_assessments.school_year, {{derive_school_year('administration_date')}}) as school_year,
+        coalesce(student_obj_assessments.school_year, {{derive_school_year('student_obj_assessments.administration_date')}}) as school_year,
         {% endif %}
         administration_date,
         administration_end_date,

--- a/tests/config_tests/cfg_assess_school_year_overlapping_dates.sql
+++ b/tests/config_tests/cfg_assess_school_year_overlapping_dates.sql
@@ -1,0 +1,46 @@
+/*
+**What is this test?**
+This test finds records of overlapping dates in xwalk used to derive school year
+from assessment administration dates.
+
+**When is this important to resolve?**
+When any overlapping dates are found.
+
+**How to resolve?**
+Adjust dates to make mutually exclusive.
+*/
+
+{{
+  config(
+      store_failures = true,
+      severity       = 'error'
+    )
+}}
+with xwalk_assess_dates as (
+    select * from  {{ ref('xwalk_assessment_school_year_dates') }}
+),
+overlapping_dates as (
+    select
+      dates1.assessment_identifier,
+      dates1.namespace,
+      dates1.school_year as school_year_1,
+      dates2.school_year as school_year_2,
+      dates1.start_date as start_date_1,
+      dates1.end_date as end_date_1,
+      dates2.start_date as start_date_2,
+      dates2.end_date as end_date_2
+    from xwalk_assess_dates as dates1
+    -- self join to find overlap within the xwalk
+    join xwalk_assess_dates as dates2
+      on equal_null(dates1.assessment_identifier, dates2.assessment_identifier)
+      and equal_null(dates1.namespace, dates2.namespace)
+      and dates1.school_year != dates2.school_year
+      -- join where overlapping, inclusive, bc code uses 'between' which is inclusive on thresholds
+      and (
+        dates1.start_date <= dates2.end_date
+        and
+        dates1.end_date >= dates2.start_date
+      )
+)
+
+select * from overlapping_dates


### PR DESCRIPTION
## Description & motivation
School year is not a required field in the student assessment entity of Ed-Fi, but it is commonly used/necessary for certain reporting, including Podium. This feature adds a customizable school year calculation using administration dates.

## Changes to existing files:
- `fct_student_assessment` : Adds a coalesce around `school_year` with a calculation using `administration_date` from either a macro call or a new xwalk.
- `fct_student_objective_assessment` : Same as above.
- `dbt_project`: Adds default values for school year start day and month.

## New files created:
- `derive_school_year` : This macro is broadly written to be used for any case where a school year needs to be calculated from a date. The logic uses the variables `school_year:start_month` and `school_year:start_day` to test whether a date falls within the school year of that date, or year + 1.

## Tests and QC done:
I tested this feature with a few different scenarios:
- Using the default variable values set in `edu_wh` without the xwalk variable and without the xwalk existing in the implementation repo. The code ran successfully and filled in school years correctly when they were null. 
- Using new variable values set in the implementation repo. The code ran successfully and filled in school years correctly (using the new variable date cutoffs) when they were null. 
- Using the xwalk (& setting the xwalk variable to true). I left the `assessment_identifier` and `namespace` columns null to test the optional join on those columns. The code ran successfully and filled in school years correctly when they were null. 
- Using the xwalk (& setting the xwalk variable to true). I filled in the `assessment_identifier` and `namespace` columns with an assessment that _never_ has null school years. The code ran successfully and none of the school years were overwritten. 
- Using the xwalk (& setting the xwalk variable to true). I filled in the `assessment_identifier` and `namespace` columns with an assessment that _only_ has null school years. The code ran successfully and filled in school years correctly when they were null. 

## Future ToDos & Questions:
See comment below with drawbacks.

## PR Merge Priority:
- Medium