### PR TITLE
make stu display name sql configurable

### DIFF
--- a/models/build/edfi_3/students/bld_ef3__immutable_stu_demos.sql
+++ b/models/build/edfi_3/students/bld_ef3__immutable_stu_demos.sql
@@ -28,9 +28,8 @@ joined as (
         stg_student.first_name,
         stg_student.middle_name,
         stg_student.last_name,
-        {# stu_display_name logic- prefer SQL from this dbt variable: #}
+        {# stu_display_name logic: prefer SQL from this dbt variable, but default to "concat(...)" #}
         {{ var('edu:stu_demos:display_name_sql',
-          {# default to this if var doesn't exist: #}
           "concat(
             stg_student.last_name, ', ',
             stg_student.first_name,

--- a/models/build/edfi_3/students/bld_ef3__immutable_stu_demos.sql
+++ b/models/build/edfi_3/students/bld_ef3__immutable_stu_demos.sql
@@ -35,6 +35,7 @@ joined as (
             stg_student.first_name,
             coalesce(' ' || left(stg_student.middle_name, 1), '')
             )"
+          )
         }} as display_name,
         concat(display_name, ' (', stg_student.student_unique_id, ')') as safe_display_name,
         stg_student.birth_date,

--- a/models/build/edfi_3/students/bld_ef3__immutable_stu_demos.sql
+++ b/models/build/edfi_3/students/bld_ef3__immutable_stu_demos.sql
@@ -28,7 +28,9 @@ joined as (
         stg_student.first_name,
         stg_student.middle_name,
         stg_student.last_name,
+        {# stu_display_name logic- prefer SQL from this dbt variable: #}
         {{ var('edu:stu_demos:display_name_sql',
+          {# default to this if var doesn't exist: #}
           "concat(
             stg_student.last_name, ', ',
             stg_student.first_name,

--- a/models/build/edfi_3/students/bld_ef3__immutable_stu_demos.sql
+++ b/models/build/edfi_3/students/bld_ef3__immutable_stu_demos.sql
@@ -28,8 +28,13 @@ joined as (
         stg_student.first_name,
         stg_student.middle_name,
         stg_student.last_name,
-        concat(stg_student.last_name, ', ', stg_student.first_name,
-            coalesce(' ' || left(stg_student.middle_name, 1), '')) as display_name,
+        {{ var('edu:stu_demos:display_name_sql',
+          "concat(
+            stg_student.last_name, ', ',
+            stg_student.first_name,
+            coalesce(' ' || left(stg_student.middle_name, 1), '')
+            )"
+        }} as display_name,
         concat(display_name, ' (', stg_student.student_unique_id, ')') as safe_display_name,
         stg_student.birth_date,
         stu_demos.gender,


### PR DESCRIPTION
This adds ability to configure the SQL logic for `stu_display_name` in `dim_student`, but keeps the existing logic by default.

Existing logic: `Lastname, Firstname, MiddleInitial`

Example custom logic: `Lastname, Firstname, Middle Suffix`


Is configuring this necessary, or should we just include generation_code_suffix for all?