### PR TITLE
bugfix/group_by_snowflake_bug

### DIFF
--- a/models/qc/attendance_freshness.sql
+++ b/models/qc/attendance_freshness.sql
@@ -13,5 +13,5 @@ from att_events
 join dim_calendar
     on att_events.k_calendar_date = dim_calendar.k_calendar_date
 where calendar_date <= current_date()
-group by all
+group by att_events.tenant_code, att_events.k_school, dim_calendar.school_year
 qualify dim_calendar.school_year = max(dim_calendar.school_year) over(partition by att_events.tenant_code)


### PR DESCRIPTION
This model errored inexplicably when run in an account with RLS. According to Erik and Jay, this is a known issue that prev came up in SC, relating to row access policies in snowflake. A workaround is to replace the numbered group by with written out columns