### PR TITLE
Fix: Add 'Unknown' race to `bld_ef3__stu_race_ethnicity`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,8 @@
 # Unreleased
 ## New features
 ## Under the hood
-## Fixes 
+## Fixes
+  - Modify the join in `bld_ef3__stu_race_ethnicity` so that students with unknown race are included
 
 # edu_wh v0.3.2
 ## New features

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 ## New features
 ## Under the hood
 ## Fixes
-  - Modify the join in `bld_ef3__stu_race_ethnicity` so that students with unknown race are included
+  - Modify the join in `bld_ef3__stu_race_ethnicity` so that people with unknown race are included
 
 # edu_wh v0.3.2
 ## New features

--- a/models/build/edfi_3/students/bld_ef3__stu_race_ethnicity.sql
+++ b/models/build/edfi_3/students/bld_ef3__stu_race_ethnicity.sql
@@ -28,7 +28,9 @@ select
         else '{{ var("edu:stu_demos:race_unknown_code") }}'
     end as race_ethnicity,
     stg_stu_ed_org.has_hispanic_latino_ethnicity
-from build_array
-join stg_stu_ed_org
-    on build_array.k_student = stg_stu_ed_org.k_student
-    and build_array.ed_org_id = stg_stu_ed_org.ed_org_id
+from stg_stu_ed_org
+-- this join order is necessary because students with missing race/ethnicity 
+--     data are not included in stg_ef3__stu_ed_org__races -> build_array
+left join build_array
+    on stg_stu_ed_org.k_student = build_array.k_student
+    and stg_stu_ed_org.ed_org_id = build_array.ed_org_id


### PR DESCRIPTION
## Description & motivation
Due to the way the join was written previously, people with an empty array of race/ethnicity information were dropped from the result set instead of being assigned "Unknown" `race_ethnicity`. This change fixes that bug.

Based on [this task](https://educationanalytics.monday.com/boards/3556827529/views/80997541/pulses/6013044494)

## No changes to existing models

## Tests and QC done:
Tested on the Jeffco project implementation. After the update, new types of records became visible with `race_array = null`: 

![Screenshot 2024-04-29 at 11 15 51](https://github.com/edanalytics/edu_wh/assets/11447044/c81019e3-8426-445f-9e39-c6dbdf21a77a)


## PR Merge Priority:
- [x] Low
- [ ] Medium
- [ ] High