### PR TITLE
add earned_additional_credits in fct_course_transcript

### DIFF
--- a/models/core_warehouse/fct_course_transcripts.sql
+++ b/models/core_warehouse/fct_course_transcripts.sql
@@ -42,15 +42,13 @@ formatted as (
         course_transcripts.method_credit_earned,
         course_transcripts.earned_credit_type,
         course_transcripts.earned_credit_conversion,
-        {{ edu_edfi_source.extract_descriptor('value:additionalCreditTypeDescriptor::string') }} as earned_additional_credit_type,
-        value:credits as earned_additional_credit,
         course_transcripts.attempted_credit_type,
         course_transcripts.attempted_credit_conversion,
         course_transcripts.assigning_organization_identification_code,
-        course_transcripts.course_catalog_url
+        course_transcripts.course_catalog_url,
+        course_transcripts.v_earned_additional_credits
     from course_transcripts
     join fct_student_academic_record
         on course_transcripts.k_student_academic_record = fct_student_academic_record.k_student_academic_record
-    , lateral flatten(input=>v_earned_additional_credits)
 )
 select * from formatted

--- a/models/core_warehouse/fct_course_transcripts.sql
+++ b/models/core_warehouse/fct_course_transcripts.sql
@@ -42,6 +42,8 @@ formatted as (
         course_transcripts.method_credit_earned,
         course_transcripts.earned_credit_type,
         course_transcripts.earned_credit_conversion,
+        {{ edu_edfi_source.extract_descriptor('value:additionalCreditTypeDescriptor::string') }} as earned_additional_credit_type,
+        value:credits as earned_additional_credit,
         course_transcripts.attempted_credit_type,
         course_transcripts.attempted_credit_conversion,
         course_transcripts.assigning_organization_identification_code,
@@ -49,5 +51,6 @@ formatted as (
     from course_transcripts
     join fct_student_academic_record
         on course_transcripts.k_student_academic_record = fct_student_academic_record.k_student_academic_record
+    , lateral flatten(input=>v_earned_additional_credits)
 )
 select * from formatted

--- a/models/core_warehouse/fct_course_transcripts.yml
+++ b/models/core_warehouse/fct_course_transcripts.yml
@@ -85,10 +85,6 @@ models:
         description: The type of credits or units of value earned by the student for the completion of a course
       - name: earned_credit_conversion
         description: Conversion factor that when multiplied by the number of credits is equivalent to Carnegie units.
-      - name: earned_additional_credit_type
-        description: The type of credits or units of value awarded for the completion of a course.
-      - name: earned_additional_credit
-        description: The value of credits or units of value awarded for the completion of a course
       - name: attempted_credit_type
         description: The type of credits or units of value attempted by the student for the completion of a course
       - name: attempted_credit_conversion
@@ -97,3 +93,8 @@ models:
         description: The organization code or name assigning the course identification code.
       - name: course_catalog_url
         description: The URL for the course catalog that defines the course identification code.
+      - name: v_earned_additional_credits
+        description: >
+          This is an array of additional credits a student attempted and 
+          could earn for successfully completing a given course (e.g., dual credit, AP, IB).
+      

--- a/models/core_warehouse/fct_course_transcripts.yml
+++ b/models/core_warehouse/fct_course_transcripts.yml
@@ -85,6 +85,10 @@ models:
         description: The type of credits or units of value earned by the student for the completion of a course
       - name: earned_credit_conversion
         description: Conversion factor that when multiplied by the number of credits is equivalent to Carnegie units.
+      - name: earned_additional_credit_type
+        description: The type of credits or units of value awarded for the completion of a course.
+      - name: earned_additional_credit
+        description: The value of credits or units of value awarded for the completion of a course
       - name: attempted_credit_type
         description: The type of credits or units of value attempted by the student for the completion of a course
       - name: attempted_credit_conversion


### PR DESCRIPTION
## Description & motivation
based on this Monday [item](https://educationanalytics.monday.com/boards/3556827529/pulses/6532381985). Adding in additional credits in fct_course_transript keeping as variant

## Changes to existing models:
adding `earned_additional_credits` variant

## Tests and QC done:
Tested in `stadium_boston`

## PR Merge Priority:
- [x] Low
- [ ] Medium
- [ ] High