### PR TITLE
Feature/Include Contacts and Parents data in parent tables due to Ed-Fi rename

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,9 @@
 # Unreleased
 ## New features
+- Add `preferred_first_name`, `preferred_last_name`, and `gender_identity` columns to `dim_parent`.
 
 ## Under the hood
+- Change the source of `dim_parent` to `stg_ef3__contacts` and `fct_student_parent_association` to `stg_ef3__student_contact_associations` due to the rename from parent to contact in Ed-Fi data standard v5.0.
 
 # edu_wh v0.3.3
 ## New features

--- a/models/build/edfi_3/parents/bld_ef3__parent_wide_emails.sql
+++ b/models/build/edfi_3/parents/bld_ef3__parent_wide_emails.sql
@@ -1,12 +1,14 @@
 with stg_parent_emails as (
-    select * from {{ ref('stg_ef3__parents__emails') }}
+    -- parents were renamed to contacts in Data Standard v5.0
+    -- the contacts staging tables contain both parent and contact records
+    select * from {{ ref('stg_ef3__contacts__emails') }}
 ),
 parent_email_types as (
     select * from {{ ref('xwalk_parent_email_types') }}
 ),
 emails_wide as (
   select 
-    k_parent,
+    k_contact as k_parent,
     tenant_code
     {%- if not is_empty_model('xwalk_parent_email_types') -%},
     -- note: this is already deduped to be the most recent record for a parent

--- a/models/build/edfi_3/parents/bld_ef3__parent_wide_phone_numbers.sql
+++ b/models/build/edfi_3/parents/bld_ef3__parent_wide_phone_numbers.sql
@@ -1,12 +1,14 @@
 with stg_parent_phones as (
-    select * from {{ ref('stg_ef3__parents__telephones') }}
+    -- parents were renamed to contacts in Data Standard v5.0
+    -- the contacts staging tables contain both parent and contact records
+    select * from {{ ref('stg_ef3__contacts__telephones') }}
 ),
 parent_phone_number_types as (
     select * from {{ ref('xwalk_parent_phone_number_types') }}
 ),
 phones_wide as (
   select 
-    k_parent,
+    k_contact as k_parent,
     tenant_code
     {%- if not is_empty_model('xwalk_parent_phone_number_types') -%},
     -- note: this is already deduped to be the most recent record for a parent

--- a/models/core_warehouse/dim_parent.sql
+++ b/models/core_warehouse/dim_parent.sql
@@ -40,6 +40,9 @@ formatted as (
         stg_parent.maiden_name,
         stg_parent.personal_title_prefix,
         stg_parent.generation_code_suffix,
+        stg_parent.preferred_first_name,
+        stg_parent,preferred_last_name,
+        stg_parent.gender_identity,
         stg_parent.sex,
         stg_parent.highest_completed_level_of_education,
         {{ accordion_columns(

--- a/models/core_warehouse/dim_parent.sql
+++ b/models/core_warehouse/dim_parent.sql
@@ -7,27 +7,29 @@
 }}
 
 with stg_parent as (
-    select * from {{ ref('stg_ef3__parents') }}
+    -- parents were renamed to contacts in Data Standard v5.0
+    -- the contacts staging tables contain both parent and contact records
+    select * from {{ ref('stg_ef3__contacts') }}
 ),
-parent_phones_wide as (
+contact_phones_wide as (
     select * from {{ ref('bld_ef3__parent_wide_phone_numbers') }}
 ),
-parent_emails_wide as (
+contact_emails_wide as (
     select * from {{ ref('bld_ef3__parent_wide_emails') }}
 ),
 choose_address as (
-    {{ row_pluck(ref('stg_ef3__parents__addresses'),
-                key='k_parent',
+    {{ row_pluck(ref('stg_ef3__contacts__addresses'),
+                key='k_contact',
                 column='address_type',
                 preferred='Home',
                 where='(do_not_publish is null or not do_not_publish)') }}
 ),
 formatted as (
     select 
-        stg_parent.k_parent,
+        stg_parent.k_contact as k_parent,
         stg_parent.tenant_code,
         stg_parent.api_year as school_year,
-        stg_parent.parent_unique_id,
+        stg_parent.contact_unique_id as parent_unique_id,
         stg_parent.person_id,
         stg_parent.login_id,
         stg_parent.person_source_system,
@@ -43,21 +45,21 @@ formatted as (
         {{ accordion_columns(
             source_table='bld_ef3__parent_wide_phone_numbers',
             exclude_columns=["k_parent", "tenant_code"],
-            source_alias='parent_phones_wide'
+            source_alias='contact_phones_wide'
         ) }}
         {{ accordion_columns(
             source_table='bld_ef3__parent_wide_emails',
             exclude_columns=["k_parent", "tenant_code"],
-            source_alias='parent_emails_wide'
+            source_alias='contact_emails_wide'
         ) }}
         choose_address.full_address
     from stg_parent
-    left join parent_phones_wide
-      on stg_parent.k_parent = parent_phones_wide.k_parent
-    left join parent_emails_wide
-      on stg_parent.k_parent = parent_emails_wide.k_parent
+    left join contact_phones_wide
+      on stg_parent.k_contact = contact_phones_wide.k_parent --k_contact has been renamed back to k_parent in the build models
+    left join contact_emails_wide
+      on stg_parent.k_contact = contact_emails_wide.k_parent
     left join choose_address
-        on stg_parent.k_parent = choose_address.k_parent
+        on stg_parent.k_contact = choose_address.k_contact
 )
 select * from formatted
 order by tenant_code, k_parent

--- a/models/core_warehouse/dim_parent.sql
+++ b/models/core_warehouse/dim_parent.sql
@@ -11,10 +11,10 @@ with stg_parent as (
     -- the contacts staging tables contain both parent and contact records
     select * from {{ ref('stg_ef3__contacts') }}
 ),
-contact_phones_wide as (
+parent_phones_wide as (
     select * from {{ ref('bld_ef3__parent_wide_phone_numbers') }}
 ),
-contact_emails_wide as (
+parent_emails_wide as (
     select * from {{ ref('bld_ef3__parent_wide_emails') }}
 ),
 choose_address as (
@@ -41,26 +41,26 @@ formatted as (
         stg_parent.personal_title_prefix,
         stg_parent.generation_code_suffix,
         stg_parent.preferred_first_name,
-        stg_parent,preferred_last_name,
+        stg_parent.preferred_last_name,
         stg_parent.gender_identity,
         stg_parent.sex,
         stg_parent.highest_completed_level_of_education,
         {{ accordion_columns(
             source_table='bld_ef3__parent_wide_phone_numbers',
             exclude_columns=["k_parent", "tenant_code"],
-            source_alias='contact_phones_wide'
+            source_alias='parent_phones_wide'
         ) }}
         {{ accordion_columns(
             source_table='bld_ef3__parent_wide_emails',
             exclude_columns=["k_parent", "tenant_code"],
-            source_alias='contact_emails_wide'
+            source_alias='parent_emails_wide'
         ) }}
         choose_address.full_address
     from stg_parent
-    left join contact_phones_wide
-      on stg_parent.k_contact = contact_phones_wide.k_parent --k_contact has been renamed back to k_parent in the build models
-    left join contact_emails_wide
-      on stg_parent.k_contact = contact_emails_wide.k_parent
+    left join parent_phones_wide
+      on stg_parent.k_contact = parent_phones_wide.k_parent --k_contact has been renamed back to k_parent in the build models
+    left join parent_emails_wide
+      on stg_parent.k_contact = parent_emails_wide.k_parent
     left join choose_address
         on stg_parent.k_contact = choose_address.k_contact
 )

--- a/models/core_warehouse/dim_parent.yml
+++ b/models/core_warehouse/dim_parent.yml
@@ -4,6 +4,9 @@ models:
   - name: dim_parent
     description: >
       Defines parents, some of their key characteristics, and their contact information.
+
+      The Parents resource in Ed-Fi was renamed to Contacts in Data Standard v5.0. This model
+      includes records from both the Parents and Contacts resources.
     config:
       tags: ['core']
     columns:

--- a/models/core_warehouse/dim_parent.yml
+++ b/models/core_warehouse/dim_parent.yml
@@ -34,6 +34,9 @@ models:
         description: The parent's maiden name
       - name: personal_title_prefix
       - name: generation_code_suffix
+      - name: preferred_first_name
+      - name: preferred_last_name
+      - name: gender_identity
       - name: sex
       - name: highest_completed_level_of_education
       - name: full_address

--- a/models/core_warehouse/fct_student_parent_association.sql
+++ b/models/core_warehouse/fct_student_parent_association.sql
@@ -9,7 +9,9 @@
 }}
 
 with stg_stu_parent as (
-    select * from {{ ref('stg_ef3__student_parent_associations') }}
+    -- parents were renamed to contacts in Data Standard v5.0
+    -- the contacts staging tables contain both parent and contact records
+    select * from {{ ref('stg_ef3__student_contact_associations') }}
 ),
 dim_student as (
     select * from {{ ref('dim_student') }}
@@ -37,8 +39,8 @@ formatted as (
         stg_stu_parent.is_living_with,
         stg_stu_parent.is_primary_contact,
         stg_stu_parent.is_legal_guardian
-        {# add any extension columns configured from stg_ef3__student_parent_associations #}
-        {{ edu_edfi_source.extract_extension(model_name='stg_ef3__student_parent_associations', flatten=False) }}
+        {# add any extension columns configured from stg_ef3__student_contact_associations #}
+        {{ edu_edfi_source.extract_extension(model_name='stg_ef3__student_contact_associations', flatten=False) }}
     from stg_stu_parent
     -- subset to only the stu/parent records associated with the most recent student records
     join most_recent_k_student
@@ -47,6 +49,6 @@ formatted as (
     join dim_student 
         on stg_stu_parent.k_student_xyear = dim_student.k_student_xyear
     join dim_parent
-        on stg_stu_parent.k_parent = dim_parent.k_parent
+        on stg_stu_parent.k_contact = dim_parent.k_parent
 )
 select * from formatted

--- a/models/core_warehouse/fct_student_parent_association.yml
+++ b/models/core_warehouse/fct_student_parent_association.yml
@@ -9,6 +9,10 @@ models:
       student record, subsetting to parent associations from that year, then applying the
       information to all other years (for cross-year analytical/reporting purposes).
 
+      The Parents resource in Ed-Fi was renamed to Contacts in Data Standard v5.0. This model
+      includes records from both the StudentParentAssociations and StudentContactAssociations
+      resources.
+
       *Primary Key:* `k_student, k_parent`
     config:
       tags: ['core']

--- a/packages.yml
+++ b/packages.yml
@@ -1,3 +1,3 @@
 packages:
-  - git: "https://github.com/edanalytics/edu_edfi_source"
-    revision: feature/contacts
+  - package: edanalytics/edu_edfi_source
+    version: [">=0.3.5", "<0.4.0"]

--- a/packages.yml
+++ b/packages.yml
@@ -1,3 +1,3 @@
 packages:
   - package: edanalytics/edu_edfi_source
-    version: [">=0.3.5", "<0.4.0"]
+    version: [">=0.3.7", "<0.4.0"]

--- a/packages.yml
+++ b/packages.yml
@@ -1,3 +1,2 @@
 packages:
-  - package: edanalytics/edu_edfi_source
-    version: [">=0.3.7", "<0.4.0"]
+  - local: '~/code/edu/edu_edfi_source'

--- a/packages.yml
+++ b/packages.yml
@@ -1,2 +1,3 @@
 packages:
-  - local: '~/code/edu/edu_edfi_source'
+  - git: "https://github.com/edanalytics/edu_edfi_source"
+    revision: feature/contacts


### PR DESCRIPTION
## Description & motivation
In Data Standard v5.0, Parents were renamed to Contacts. The new Contact entity is identical to the previous Parent entity with the addition of an optional GenderIdentity, PreferredFirstName, and PreferredLastName fields. StudentParentAssociations was also renamed to StudentContactAssociations. The goal of this PR is to get v5.0 data correctly incorporated into the model without doing the full naming shift from parents to contacts.

**Note:** These changes require this [edu_edfi_source feature branch](https://github.com/edanalytics/edu_edfi_source/pull/96) to be merged and released. The `packages.yml` file will need to be updated with this requirement.

## Breaking changes introduced by this PR:
Added three new columns to `dim_parent` that were introduced with the change to Contacts

## PR Merge Priority:
- Medium: needed for Stadium SCDE

## Changes to existing files:
- `fct_student_parent_association`, `bld_ef3__parent_wide_emails`, and `bld_ef3__parent_wide_phone_numbers` : source from the contacts staging tables, rename k_contact back to k_parent
- `dim_parent` : source from the contacts staging tables, rename k_contact back to k_parent, and add three new columns

## Tests and QC done:
Ran in Stadium SCDE; confirmed that grain tests passed and row counts look correct.

## edu_wh PR Review Checklist:
Make sure the following have been completed before approving this PR:
- [x] Description of changes has been added to Unreleased section of [CHANGELOG.md](/CHANGELOG.md). Add under `## New Features` for features, etc.
- [ ] If a new configuration xwalk was added:
  - [ ] The code is written such that the xwalk is optional (preferred), and this behavior was tested, OR
  - [ ] The code is written such that the xwalk is required, and the required xwalk is added to edu_project_template, and this PR is flagged as breaking change (not for patch release)
  - [ ] A description for the new xwalk has been added to EDU documentation site [here](https://github.com/edanalytics/edu_docs/blob/main/docs/docs/manage_extend/reference/configure_dbt_xwalks.md) 
- [ ] If a new configuration variable was added:
  - [ ] The code is written such that the variable is optional (preferred), and this behavior was tested, OR
  - [ ] The code is written such that the variable is required, and a default value was added to edu_project_template, and this PR is flagged as breaking change (not for patch release)
  - [ ] A description for the new variable has been added to EDU documentation site [here](https://github.com/edanalytics/edu_docs/blob/main/docs/docs/manage_extend/reference/configure_dbt_vars.md) 
- [x] Reviewer confirms the grain of all tables are unchanged, OR any changes are expected, communicated, and this PR is flagged as a breaking change (not for patch release)

## Future ToDos & Questions:
We probably want to do a breaking change that completes the rename from Parents to Contacts here and in downstream systems. See the [Slite doc](https://edanalytics.slite.com/app/docs/6LssWAyU-68Kd2?commentId=e4AGDyzf7bo-22&utm_source=slite&utm_medium=email&utm_campaign=notifications&utm_content=MultipleNotifications) for notes on what would be affected and how we might do this (configurable aliasing, etc.)