### PR TITLE
draft of optionally not requiring stu_ed_org to reach dim_student

### DIFF
--- a/models/build/edfi_3/students/bld_ef3__immutable_stu_demos.sql
+++ b/models/build/edfi_3/students/bld_ef3__immutable_stu_demos.sql
@@ -44,7 +44,7 @@ joined as (
         stu_races.race_array,
         stu_races.has_hispanic_latino_ethnicity
     from stg_student
-    join stu_demos
+    {% if not var('edu:stu_demos:require_strict', True) %}left {% endif %}join stu_demos
         on stg_student.k_student = stu_demos.k_student
     left join stu_races
         on stu_demos.k_student = stu_races.k_student

--- a/models/core_warehouse/dim_student.sql
+++ b/models/core_warehouse/dim_student.sql
@@ -193,7 +193,7 @@ formatted as (
 
     from stg_student
 
-    join stu_demos
+    {% if not var('edu:stu_demos:require_strict', True) %}left {% endif %}join stu_demos
         on stg_student.k_student = stu_demos.k_student
     join stu_immutable_demos
         on stu_demos.{{demos_join_var}} = stu_immutable_demos.{{demos_join_var}}


### PR DESCRIPTION
Concept: for some downstream reporting purposes, it is confusing for a record not to be in, e.g. 'enrollment' because the student is not in stuEdOrg -- this is an implicit requirement that is hard for folks to understand. We may decide to remove this logic and _always_ left join in the future, but this branch puts it behind an optional flag to let us try it out before committing.