### PR TITLE
Update `staff__races` to `staffs__races`

### DIFF
--- a/models/build/edfi_3/staffs/bld_ef3__staff_race_ethnicity.sql
+++ b/models/build/edfi_3/staffs/bld_ef3__staff_race_ethnicity.sql
@@ -1,5 +1,5 @@
 with stg_staff_races as (
-    select * from {{ ref('stg_ef3__staff__races') }}
+    select * from {{ ref('stg_ef3__staffs__races') }}
 ),
 stg_staffs as (
     select * from {{ ref('stg_ef3__staffs') }}


### PR DESCRIPTION
A companion to [this PR in `edu_edi_source`](https://github.com/edanalytics/edu_edfi_source/pull/95), which renames `stg_ef3__staff__races` to `stg_ef3__staffs__races` for consistency with EDU naming conventions..