### PR TITLE
fix missing commas in constraints

### DIFF
--- a/models/core_warehouse/fct_student_discipline_actions_summary.sql
+++ b/models/core_warehouse/fct_student_discipline_actions_summary.sql
@@ -2,7 +2,7 @@
   config(
     post_hook=[
         "alter table {{ this }} add primary key (k_student, k_student_xyear, k_discipline_actions_event)",
-        "alter table {{ this }} add constraint fk_{{ this.name }}_student foreign key (k_student) references {{ ref('dim_student') }}"
+        "alter table {{ this }} add constraint fk_{{ this.name }}_student foreign key (k_student) references {{ ref('dim_student') }}",
         "alter table {{ this }} add constraint fk_{{ this.name }}_discipline_actions foreign key (k_discipline_actions_event) references {{ ref('fct_student_discipline_actions') }}"
     ]
   )

--- a/models/core_warehouse/fct_student_discipline_actions_summary.sql
+++ b/models/core_warehouse/fct_student_discipline_actions_summary.sql
@@ -2,9 +2,7 @@
   config(
     post_hook=[
         "alter table {{ this }} add primary key (k_student, k_student_xyear, k_discipline_actions_event)",
-        "alter table {{ this }} add constraint fk_{{ this.name }}_student foreign key (k_student) references {{ ref('dim_student') }}",
-        "alter table {{ this }} add constraint fk_{{ this.name }}_discipline_actions foreign key (k_discipline_actions_event) references {{ ref('fct_student_discipline_actions') }}"
-    ]
+        "alter table {{ this }} add constraint fk_{{ this.name }}_student foreign key (k_student) references {{ ref('dim_student') }}"]
   )
 }}
 

--- a/models/core_warehouse/fct_student_discipline_incident_behaviors.sql
+++ b/models/core_warehouse/fct_student_discipline_incident_behaviors.sql
@@ -3,7 +3,7 @@
     post_hook=[
         "alter table {{ this }} add primary key (k_student, k_student_xyear, k_discipline_incident, behavior_type)",
         "alter table {{ this }} add constraint fk_{{ this.name }}_student foreign key (k_student) references {{ ref('dim_student') }}",
-        "alter table {{ this }} add constraint fk_{{ this.name }}_school foreign key (k_school) references {{ ref('dim_school') }}"
+        "alter table {{ this }} add constraint fk_{{ this.name }}_school foreign key (k_school) references {{ ref('dim_school') }}",
         "alter table {{ this }} add constraint fk_{{ this.name }}_discipline_incident foreign key (k_discipline_incident) references {{ ref('dim_discipline_incident') }}"
     ]
   )


### PR DESCRIPTION
Missing commas caused execution errors

Faulty extra constraint - k_discipline_action_event isn't the primary key, so can't be an fkey