### PR TITLE
Fix/att event multi calendars

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@
 ## Under the hood
 ## Fixes
 
+# edu_wh 
+## Fixes
+- Fix model `fct_student_school_attendance_event` to account for the case where a student has multiple enrollments with different calendars at the same school
+
 # edu_wh v0.4.0
 ## New features
 - Add array column `cohort_year_array` to `dim_student`, tracking student cohort designation, and add upstream `bld_ef3__student_cohort_years`

--- a/models/core_warehouse/fct_student_school_attendance_event.sql
+++ b/models/core_warehouse/fct_student_school_attendance_event.sql
@@ -45,7 +45,6 @@ fct_student_school_assoc as (
     the same calendar to be sure.
     */
     select * from {{ ref('fct_student_school_association') }}
-    where is_latest_annual_entry
 ),
 xwalk_att_events as (
     select * from {{ ref('xwalk_attendance_events') }}
@@ -79,8 +78,9 @@ formatted as (
         on stg_stu_sch_attend.k_student = fct_student_school_assoc.k_student
         and stg_stu_sch_attend.k_school = fct_student_school_assoc.k_school
     join dim_calendar_date
-        on fct_student_school_assoc.k_school_calendar = dim_calendar_date.k_school_calendar
-        and stg_stu_sch_attend.attendance_event_date = dim_calendar_date.calendar_date
+         on fct_student_school_assoc.k_school_calendar = dim_calendar_date.k_school_calendar
+         and stg_stu_sch_attend.attendance_event_date = dim_calendar_date.calendar_date
+         and dim_calendar_date.calendar_date between fct_student_school_assoc.entry_date and coalesce(fct_student_school_assoc.exit_withdraw_date,getdate())
     join xwalk_att_events
         on stg_stu_sch_attend.attendance_event_category = xwalk_att_events.attendance_event_descriptor
 )

--- a/models/core_warehouse/fct_student_school_attendance_event.sql
+++ b/models/core_warehouse/fct_student_school_attendance_event.sql
@@ -74,7 +74,7 @@ joined as (
     join dim_calendar_date
          on fct_student_school_assoc.k_school_calendar = dim_calendar_date.k_school_calendar
          and stg_stu_sch_attend.attendance_event_date = dim_calendar_date.calendar_date
-         and dim_calendar_date.calendar_date between fct_student_school_assoc.entry_date and coalesce(fct_student_school_assoc.exit_withdraw_date,getdate())
+         and dim_calendar_date.calendar_date between fct_student_school_assoc.entry_date and coalesce(fct_student_school_assoc.exit_withdraw_date,current_date())
     join xwalk_att_events
         on stg_stu_sch_attend.attendance_event_category = xwalk_att_events.attendance_event_descriptor
 ),

--- a/models/core_warehouse/fct_student_school_attendance_event.sql
+++ b/models/core_warehouse/fct_student_school_attendance_event.sql
@@ -26,23 +26,13 @@ dim_calendar_date as (
 fct_student_school_assoc as (
     /*
     We bring in this table to get the `k_school_calendar` we need to turn
-    `attendance_event_date` into `k_calendar_date`.
-    But these grains aren't guaranteed to align-- a student could have multiple
-    enrollments at the same school in the same year-- so we need to make sure
-    we don't multiply the attendance rows by the number of enrollments.
-    The most accurate way to do this would be to specify the join such that 
-    the attendance_event_date is within the range of the enrollment's entry_date
-    and exit_withdraw_date, because this would account for the case where a 
-    student's multiple enrollments each made use of different calendars.
-    (This would introduce a second problem though: it would not guarantee a
-    single row return if a student had overlapping enrollments at the same 
-    school, which the Ed-Fi model does not prevent.)
-    Different calendars per enrollment at the same school in the same year
-    seems like a sufficiently unlikely edge-case that we use the singular
-    calendar association from the latest enrollment instead, which allows
-    for a simpler join, but we could add a test asserting that a student
-    with multiple enrollments at the same school in the same year all also use
-    the same calendar to be sure.
+    `attendance_event_date` into `k_calendar_date`. Because a student could have
+    multiple enrollments at the same school in the same year, we specify the join
+    such that the attendance_event_date is within the range of the enrolmment's
+    entry_date and exit_withdraw_date. This accounts for the case where a student's
+    multiple enrollments each made use of different calendars. However, if a 
+    student has overlapping enrollments at the same school, multiple rows will
+    be returned for each date. Therefore we must introduce a deduplication step.
     */
     select 
         *,


### PR DESCRIPTION
<!---
Provide Title above, ensure it summarizes the work in the PR. Example PR titles templates:
* "feature/ (or build/): describe new functionality"
* "hotfix/: describe issue fix for immediate release"
* "bugfix/ (or fix/): describe issue fix, not necessary for immediate release"
* "docs/: adding or updating documentation"
-->

## Description & motivation
<!---
High level description your PR, and why you're making it. Is this linked to slack thread, Monday board, open
issue, a continuation to a previous PR? Link it here if relevant (use the "#" symbol for issues/PRs).
-->

This PR addresses an edge case that occured in the BPS Stadium implementation where a student had multiple enrollments associated with different calendars per enrollment, which resulted in a student's attendance event not contributing to their attendance count.

Currently, the attendance_event_date is converted into a k_calendar_date by joining to fct_student_school_association and deduping by selecting enrollments where is_latest_annual_entry is true.

This updated model would instead join so that the attendance_event_date is within the range of the enrollment's entry_date and exit_withdraw_date (and accounts for null exit_withdraw_dates). 

However, if a student has overlapping enrollments at the same school, multiple rows will
be returned for each date, and so an additional deduplication step is introduced.

See the original Monday item [here](https://educationanalytics.monday.com/boards/2610522828/pulses/7737880198).


## Breaking changes introduced by this PR:
<!---
Describe any breaking changes that are introduced. Take a wide approach to what might be 'breaking'. One example of a 'hidden' breaking change could be adding a new column. For most applications, this will not cause error, but if someone has configured a downstream query that references this column name from elsewhere, their query could break.

Make sure to include these breaking changes in the CHANGELOG.md
-->

No breaking changes, but in rare cases could change attendance count.

## PR Merge Priority:
<!---
This checklist helps the reviewers understand the level of priority for merging this PR.
A loose description of merging priority levels is:
Low: A week or more.
Medium: Within 3 days or less.
High: As soon as possible.
-->

- [x] Medium

<!---
If High Priority, explain why as a comment below.
-->

## Changes to existing files:
<!---
Include this section if you are changing any existing files or creating breaking changes to existing files. Label the model name and describe the logic behind the changes made, try to be very descriptive here. For example:
- `fct_student_school_attendance_event` : Change fct_student_school_association join conditions, add deduplication step.
-->

## New files created:
<!---
Include this section if you are creating any new files. Label the model name and describe the logic behind the changes made, try to be very descriptive here. For example:
none
-->

## Tests and QC done:
<!---
Describe any process that confirms that the files do what is expected, include screenshots if relevant. For example:
- dbt run on dev warehouse in Boston
-->

## Future ToDos & Questions:
- Further discussion may be needed on how to pick a winner when there overlapping enrollments with multiple calendars at the same school. The rule implemented here is one option that was presented during planning.

## edu_wh PR Review Checklist:
Make sure the following have been completed before approving this PR:
- [ ] Description of changes has been added to Unreleased section of [CHANGELOG.md](/CHANGELOG.md). Add under `## New Features` for features, etc.
- [ ] If a new configuration xwalk was added:
  - [ ] The code is written such that the xwalk is optional (preferred), and this behavior was tested, OR
  - [ ] The code is written such that the xwalk is required, and the required xwalk is added to edu_project_template, and this PR is flagged as breaking change (not for patch release)
  - [ ] A description for the new xwalk has been added to EDU documentation site [here](https://github.com/edanalytics/edu_docs/blob/main/docs/docs/manage_extend/reference/configure_dbt_xwalks.md) 
- [ ] If a new configuration variable was added:
  - [ ] The code is written such that the variable is optional (preferred), and this behavior was tested, OR
  - [ ] The code is written such that the variable is required, and a default value was added to edu_project_template, and this PR is flagged as breaking change (not for patch release)
  - [ ] A description for the new variable has been added to EDU documentation site [here](https://github.com/edanalytics/edu_docs/blob/main/docs/docs/manage_extend/reference/configure_dbt_vars.md) 
- [ ] Reviewer confirms the grain of all tables are unchanged, OR any changes are expected, communicated, and this PR is flagged as a breaking change (not for patch release)


