### PR TITLE
Feature/executive absences count

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Unreleased
 ## New features
+## Under the hood
+## Fixes
+
+# edu_wh v0.4.0
+## New features
 - Add array column `cohort_year_array` to `dim_student`, tracking student cohort designation, and add upstream `bld_ef3__student_cohort_years`
 - Add support for custom indicators on `dim_course_section`, and companion audit table for testing uniqueness of custom data sources
 - Add `section_type` descriptor column to `dim_section` (Ed-Fi Data Standard v5.0 addition)
@@ -12,7 +17,6 @@
 ## Fixes
 - Fix model name in yaml documentation file for `dim_graduation_plan`
 - Fix unique key test for recently changed unique key fo `fct_student_school_attendance_event`
-
 
 # edu_wh v0.3.4
 ## Fixes

--- a/dbt_project.yml
+++ b/dbt_project.yml
@@ -1,7 +1,7 @@
 config-version: 2
 
 name: 'edu_wh'
-version: '0.3.4'
+version: '0.4.0'
 require-dbt-version: [">=1.0.0", "<2.0.0"]
 
 # This setting configures which "profile" dbt uses for this project.

--- a/models/core_warehouse/fct_student_consecutive_attendance_count.sql
+++ b/models/core_warehouse/fct_student_consecutive_attendance_count.sql
@@ -1,0 +1,82 @@
+
+{{
+  config(
+    post_hook=[
+        "alter table {{ this }} add primary key (k_student, k_school, calendar_date)",
+        "alter table {{ this }} add constraint fk_{{ this.name }}_student foreign key (k_student) references {{ ref('dim_student') }}",
+        "alter table {{ this }} add constraint fk_{{ this.name }}_school foreign key (k_school) references {{ ref('dim_school') }}"    ]
+  )
+}}
+
+{%- set xwalk_att_events_cols = dbt_utils.get_filtered_columns_in_relation(from = ref('xwalk_attendance_events')) -%}
+
+with fct_student_daily_att as (
+    select * from {{ ref('fct_student_daily_attendance') }}
+),
+xwalk_att_events as (
+    select * from {{ ref('xwalk_attendance_events') }}
+),
+joined_student_daily_att as (
+    select 
+      fct_student_daily_att.*
+    {%- if 'IS_UNEXCUSED' in xwalk_att_events_cols %}
+      , xwalk_att_events.is_unexcused
+    {%- endif %}
+    from fct_student_daily_att
+    join xwalk_att_events
+    on fct_student_daily_att.attendance_event_category = xwalk_att_events.attendance_event_descriptor
+),
+consecutive as (
+    select 
+      *,
+      lag(calendar_date) over (
+        partition by k_student, k_school, attendance_event_category order by calendar_date) as previous_date,
+      case 
+        when previous_date is null then 1
+        when datediff(day, previous_date, calendar_date) = 1 
+          or dayofweek(previous_date) = 5 and dayofweek(calendar_date) = 1 and datediff(day, previous_date, calendar_date) = 3 then 0
+        else 1
+        end as consecutive
+    from joined_student_daily_att 
+    order by k_student, k_school, calendar_date
+),
+consecutive_grouping as (
+    select 
+      *,
+      sum(consecutive) over (partition by k_student, k_school, attendance_event_category order by calendar_date) as consecutive_group
+    from consecutive
+),
+consecutive_absences as (
+    select 
+      k_student,
+      k_student_xyear,
+      k_school,
+      k_calendar_date,
+      calendar_date,
+      k_session,
+      tenant_code,
+      is_absent,
+      is_present,
+      is_enrolled,
+      total_days_enrolled,
+      cumulative_days_absent,
+      cumulative_days_attended,
+      cumulative_days_enrolled,
+      cumulative_attendance_rate,
+      meets_enrollment_threshold,
+      is_chronic_absentee,
+      event_duration,
+      school_attendance_duration,
+      absentee_category_rank,
+      absentee_category_label,
+  {%- if 'IS_UNEXCUSED' in xwalk_att_events_cols %}
+      is_unexcused,
+  {%- endif %}
+      attendance_event_category,
+      row_number() over ( partition by k_student, k_school, attendance_event_category, consecutive_group order by calendar_date) as consecutive_day_number,
+      
+    from consecutive_grouping
+)
+
+select * from consecutive_absences 
+order by k_student, k_school, calendar_date, consecutive_day_number

--- a/models/core_warehouse/fct_student_consecutive_attendance_count.yml
+++ b/models/core_warehouse/fct_student_consecutive_attendance_count.yml
@@ -1,0 +1,66 @@
+version: 2
+
+models: 
+  - name: fct_student_daily_attendance
+    description: >
+     ##### Overview:
+       This fact table provides student daily attendance and their consecutive attendance count, computed using full-day attendance as reported in `studentSchoolAttendanceEvents`.
+
+     ##### Primary Key:
+       k_student, k_school, calendar_date -- There is one record per student, school, and calendar date.
+
+    config:
+      tags: ['core']
+    tests:
+      - dbt_utils.unique_combination_of_columns:
+          combination_of_columns:
+            - k_student
+            - k_school
+            - calendar_date
+    columns:
+      - name: k_student
+      - name: k_school
+      - name: k_calendar_date
+      - name: calendar_date
+      - name: k_session
+      - name: tenant_code
+      - name: attendance_event_category
+        description: >
+          The descriptor value from AttendanceEventDescriptor
+      - name: is_absent
+        description: Indicator for absence. Defined via descriptor mapping in `xwalk_attendance_events`
+      - name: is_present
+        description: Inverse of `is_absent`, for use in calculations. Can be fractional.
+      - name: is_enrolled
+      - name: total_days_enrolled
+      - name: cumulative_days_absent
+        description: >
+          Cumulative count, up to the day specified in the row.
+      - name: cumulative_days_enrolled
+        description: >
+          Cumulative count, up to the day specified in the row.
+      - name: cumulative_days_attended
+        description: >
+          Cumulative count, up to the day specified in the row.
+      - name: cumulative_attendance_rate
+        description: >
+          Cumulative count, up to the day specified in the row.
+      - name: is_chronic_absentee
+        description: >
+          Whether the student was considered chronically absent as of this day.
+          Defined as attendance rate less than {{ var('edu:attendance:chronic_absence_threshold') }}
+          and days enrolled at least {{ var('edu:attendance:chronic_absence_min_days') }}.
+          Configurable in `dbt_project.yml`
+      - name: absentee_category_rank
+        description: >
+          A numeric value categorizing levels of attendance. Defined in the 
+          seed table `absentee_categories`.
+      - name: absentee_category_label
+        description: >
+          A text label categorizing levels of attendance. Defined in the 
+          seed table `absentee_categories`.
+      - name: consecutive_day_number
+        description: >
+          The rolling number of days for each student at a school on a school day per 
+          'attendance_event_category'. This number resets if there is a change in 'attendance_event_category' 
+          for a student record.

--- a/packages.yml
+++ b/packages.yml
@@ -1,3 +1,3 @@
 packages:
   - package: edanalytics/edu_edfi_source
-    version: [">=0.3.5", "<0.4.0"]
+    version: [">=0.4.0", "<0.5.0"]


### PR DESCRIPTION
<!---
Provide Title above, ensure it summarizes the work in the PR. Example PR titles templates:
* "feature/ (or build/): describe new functionality"
* "hotfix/: describe issue fix for immediate release"
* "bugfix/ (or fix/): describe issue fix, not necessary for immediate release"
* "docs/: adding or updating documentation"
-->

## Description & motivation
<!---
High level description your PR, and why you're making it. Is this linked to slack thread, Monday board, open
issue, a continuation to a previous PR? Link it here if relevant (use the "#" symbol for issues/PRs).
-->
This model adds a column to `fct_student_daily_attendance` that calculates the consecutive count for each type of attendance that is ordered by calendar date per student.
 
This column takes care of periodic weekend school day attendances or lack thereof.  If there is no school day on a weekend and no change of `attendance_event_category` from Friday to Monday, it still considered as consecutive.

## Breaking changes introduced by this PR:
<!---
Describe any breaking changes that are introduced. Take a wide approach to what might be 'breaking'. One example of a 'hidden' breaking change could be adding a new column. For most applications, this will not cause error, but if someone has configured a downstream query that references this column name from elsewhere, their query could break.

Make sure to include these breaking changes in the CHANGELOG.md
-->

## PR Merge Priority:
<!---
This checklist helps the reviewers understand the level of priority for merging this PR.
A loose description of merging priority levels is:
Low: A week or more.
Medium: Within 3 days or less.
High: As soon as possible.
-->
- [ ] Low
- [ ] Medium
- [x] High

<!---
If High Priority, explain why as a comment below.
-->

## Changes to existing files:
<!---
Include this section if you are changing any existing files or creating breaking changes to existing files. Label the model name and describe the logic behind the changes made, try to be very descriptive here. For example:
- `stg_model` : Describe any changes made to `stg_model` and why the changes where made.
- `src_staging` : Describe any changes made to `src_staging` and why the changes where made.
-->

## New files created:
<!---
Include this section if you are creating any new files. Label the model name and describe the logic behind the changes made, try to be very descriptive here. For example:
- `stg_new_model` : Describe the purpose of `stg_new_model` and the logic behind creating the model.
- `src_new_staging` : Describe the purpose of `src_new_staging`.
-->
- `fct_student_consecutive_attendance_count.sql`
- `fct_student_consecutive_attendance_count.yml`

## Tests and QC done:
<!---
Describe any process that confirms that the files do what is expected, include screenshots if relevant. For example:
- Analyst replication confirmed that updates to `stg_model` new counts were correct.
- Executed a dbt project run and ensured it was successful.
-->
- QC against `fct_student_daily_attendance` model: no records are dropped in this new model

## edu_wh PR Review Checklist:
Make sure the following have been completed before approving this PR:
- [ ] Description of changes has been added to Unreleased section of [CHANGELOG.md](/CHANGELOG.md). Add under `## New Features` for features, etc.
- [ ] If a new configuration xwalk was added:
  - [ ] The code is written such that the xwalk is optional (preferred), and this behavior was tested, OR
  - [ ] The code is written such that the xwalk is required, and the required xwalk is added to edu_project_template, and this PR is flagged as breaking change (not for patch release)
  - [ ] A description for the new xwalk has been added to EDU documentation site [here](https://github.com/edanalytics/edu_docs/blob/main/docs/docs/manage_extend/reference/configure_dbt_xwalks.md) 
- [ ] If a new configuration variable was added:
  - [ ] The code is written such that the variable is optional (preferred), and this behavior was tested, OR
  - [ ] The code is written such that the variable is required, and a default value was added to edu_project_template, and this PR is flagged as breaking change (not for patch release)
  - [ ] A description for the new variable has been added to EDU documentation site [here](https://github.com/edanalytics/edu_docs/blob/main/docs/docs/manage_extend/reference/configure_dbt_vars.md) 
- [ ] Reviewer confirms the grain of all tables are unchanged, OR any changes are expected, communicated, and this PR is flagged as a breaking change (not for patch release)

<!---## Future ToDos & Questions:-->
<!---
[Optional] Include any future steps and questions related to this PR.
-->
