### PR TITLE
Modified dim_school.sql to support custom data sources

### DIFF
--- a/models/core_warehouse/dim_school.sql
+++ b/models/core_warehouse/dim_school.sql
@@ -19,6 +19,8 @@
     ]
   )
 }}
+{# Load custom data sources from var #}
+{% set custom_data_sources = var("edu:schools:custom_data_sources", []) %}
 
 with stg_school as (
     select * from {{ ref('stg_ef3__schools') }}
@@ -94,6 +96,15 @@ formatted as (
         choose_address.county_fips_code,
         choose_address.latitude,
         choose_address.longitude
+
+        -- custom data sources
+        {% if custom_data_sources is not none and custom_data_sources | length -%}
+          {%- for source in custom_data_sources -%}
+            {%- for indicator in custom_data_sources[source] -%}
+              , {{ custom_data_sources[source][indicator]['where'] }} as {{ indicator }}
+            {%- endfor -%}
+          {%- endfor -%}
+        {%- endif %}
     from stg_school
     join dim_lea 
         on stg_school.k_lea = dim_lea.k_lea
@@ -103,6 +114,13 @@ formatted as (
         on stg_school.k_school = choose_address.k_school
     left join bld_network_associations
         on stg_school.k_school = bld_network_associations.k_school
+    -- custom data sources
+    {% if custom_data_sources is not none and custom_data_sources | length -%}
+      {%- for source in custom_data_sources -%}
+        left join {{ ref(source) }}
+          on stg_school.k_school = {{ source }}.k_school
+      {% endfor %}
+    {%- endif %}
 )
 select * from formatted
 order by tenant_code, k_school


### PR DESCRIPTION
## Description & motivation
TDOE needed to add additional columns to dim_school. In our case it was to be able to summarize the grade levels that a school teaches, so, something that looks like "K-12". Realistically, this could be added to dim_school as a base column as it is a universally useful column, but not all states may treat grades the same so I just added the custom data source standard implementation as that would definitely be universally useful.

## Breaking changes introduced by this PR:
I do not think there would be any breaking changes.

## PR Merge Priority:
- [X] Low
- [ ] Medium
- [ ] High

## Changes to existing files:
dim_school: Simply added the standard implementation for custom data sources.

## New files created:
None.

## Tests and QC done:
Testing done within stadium_tennessee fork. Everything works as expected.

## edu_wh PR Review Checklist:
Make sure the following have been completed before approving this PR:
- [ ] Description of changes has been added to Unreleased section of [CHANGELOG.md](/CHANGELOG.md). Add under `## New Features` for features, etc.
- [ ] If a new configuration xwalk was added:
  - [ ] The code is written such that the xwalk is optional (preferred), and this behavior was tested, OR
  - [ ] The code is written such that the xwalk is required, and the required xwalk is added to edu_project_template, and this PR is flagged as breaking change (not for patch release)
  - [ ] A description for the new xwalk has been added to EDU documentation site [here](https://github.com/edanalytics/edu_docs/blob/main/docs/docs/manage_extend/reference/configure_dbt_xwalks.md) 
- [ ] If a new configuration variable was added:
  - [ ] The code is written such that the variable is optional (preferred), and this behavior was tested, OR
  - [ ] The code is written such that the variable is required, and a default value was added to edu_project_template, and this PR is flagged as breaking change (not for patch release)
  - [ ] A description for the new variable has been added to EDU documentation site [here](https://github.com/edanalytics/edu_docs/blob/main/docs/docs/manage_extend/reference/configure_dbt_vars.md) 
- [ ] Reviewer confirms the grain of all tables are unchanged, OR any changes are expected, communicated, and this PR is flagged as a breaking change (not for patch release)

<!---## Future ToDos & Questions:-->
N/A
