### PR TITLE
add tests for null assessment scores

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,12 @@
 # Unreleased
-- Feature: add tests to check whether assessments and objective assessments have null scores
 ## New features
 ## Under the hood
 ## Fixes
+
+# edu_wh v0.4.2
+## New features
+- Add tests `cfg_assessment_scores` and `cfg_objective_assessment_scores` to find assess/obj assess with no scores configured
+- Add support for custom indicators on `dim_school`
 
 # edu_wh v0.4.1
 ## New features

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 # Unreleased
+- Feature: add tests to check whether assessments and objective assessments have null scores
 ## New features
 ## Under the hood
 ## Fixes

--- a/dbt_project.yml
+++ b/dbt_project.yml
@@ -1,7 +1,7 @@
 config-version: 2
 
 name: 'edu_wh'
-version: '0.4.1'
+version: '0.4.2'
 require-dbt-version: [">=1.0.0", "<2.0.0"]
 
 # This setting configures which "profile" dbt uses for this project.

--- a/tests/config_tests/cfg_assessment_scores.sql
+++ b/tests/config_tests/cfg_assessment_scores.sql
@@ -1,0 +1,26 @@
+with fct_student_assessment  as (
+    select * from analytics.prod_wh.fct_student_assessment
+),
+dim_assessment as (
+    select * from analytics.prod_wh.dim_assessment
+),
+xwalk_assessment_scores as (
+    select * from analytics.prod_seed.xwalk_assessment_scores
+),
+joined as (
+    select distinct
+        dim_assessment.assessment_identifier,
+        fct_student_assessment.tenant_code, 
+        fct_student_assessment.school_year
+    from fct_student_assessment
+    join dim_assessment 
+        on fct_student_assessment.k_assessment = 
+            dim_assessment.k_assessment
+    left join xwalk_assessment_scores
+        on dim_assessment.assessment_identifier = 
+            xwalk_assessment_scores.assessment_identifier
+
+    where xwalk_assessment_scores.assessment_identifier is null
+    order by assessment_identifier
+)
+select * from joined

--- a/tests/config_tests/cfg_assessment_scores.sql
+++ b/tests/config_tests/cfg_assessment_scores.sql
@@ -1,17 +1,27 @@
+{{
+  config(
+      store_failures = true,
+      severity       = 'warn'
+    )
+}}
+
 with fct_student_assessment  as (
-    select * from analytics.prod_wh.fct_student_assessment
+    select * from {{ ref('fct_student_assessment') }}
 ),
+
 dim_assessment as (
-    select * from analytics.prod_wh.dim_assessment
+    select * from {{ ref('dim_assessment') }}
 ),
+
 xwalk_assessment_scores as (
-    select * from analytics.prod_seed.xwalk_assessment_scores
+    select * from {{ ref('xwalk_assessment_scores') }}
 ),
+
 joined as (
     select distinct
-        dim_assessment.assessment_identifier,
         fct_student_assessment.tenant_code, 
-        fct_student_assessment.school_year
+        fct_student_assessment.school_year,
+        dim_assessment.assessment_identifier
     from fct_student_assessment
     join dim_assessment 
         on fct_student_assessment.k_assessment = 
@@ -23,4 +33,5 @@ joined as (
     where xwalk_assessment_scores.assessment_identifier is null
     order by assessment_identifier
 )
+
 select * from joined

--- a/tests/config_tests/cfg_objective_assessment_scores.sql
+++ b/tests/config_tests/cfg_objective_assessment_scores.sql
@@ -1,0 +1,35 @@
+
+{{
+  config(
+      store_failures = true,
+      severity       = 'warn'
+    )
+}}
+with fct_student_objective_assessment  as (
+    select * from {{ ref('fct_student_objective_assessment') }}
+),
+dim_objective_assessment as (
+    select * from {{ ref('dim_objective_assessment') }}
+),
+xwalk_objective_assessment_scores as (
+    select * from {{ ref('xwalk_objective_assessment_scores') }}
+),
+joined as (
+    select distinct
+        dim_objective_assessment.assessment_identifier,
+        dim_objective_assessment.objective_assessment_identification_code,
+        fct_student_objective_assessment.tenant_code, 
+        fct_student_objective_assessment.school_year
+    from fct_student_objective_assessment
+    join dim_objective_assessment 
+        on fct_student_objective_assessment.k_objective_assessment = 
+            dim_objective_assessment.k_objective_assessment
+    left join xwalk_objective_assessment_scores
+        on (dim_objective_assessment.assessment_identifier = 
+            xwalk_objective_assessment_scores.assessment_identifier
+        and dim_objective_assessment.objective_assessment_identification_code = 
+            xwalk_objective_assessment_scores.objective_assessment_identification_code)
+
+    where xwalk_objective_assessment_scores.objective_assessment_identification_code is null
+)
+select * from joined

--- a/tests/config_tests/cfg_objective_assessment_scores.sql
+++ b/tests/config_tests/cfg_objective_assessment_scores.sql
@@ -1,25 +1,28 @@
-
 {{
   config(
       store_failures = true,
       severity       = 'warn'
     )
 }}
+
 with fct_student_objective_assessment  as (
     select * from {{ ref('fct_student_objective_assessment') }}
 ),
+
 dim_objective_assessment as (
     select * from {{ ref('dim_objective_assessment') }}
 ),
+
 xwalk_objective_assessment_scores as (
     select * from {{ ref('xwalk_objective_assessment_scores') }}
 ),
+
 joined as (
     select distinct
-        dim_objective_assessment.assessment_identifier,
-        dim_objective_assessment.objective_assessment_identification_code,
         fct_student_objective_assessment.tenant_code, 
-        fct_student_objective_assessment.school_year
+        fct_student_objective_assessment.school_year,
+        dim_objective_assessment.assessment_identifier,
+        dim_objective_assessment.objective_assessment_identification_code
     from fct_student_objective_assessment
     join dim_objective_assessment 
         on fct_student_objective_assessment.k_objective_assessment = 
@@ -32,4 +35,5 @@ joined as (
 
     where xwalk_objective_assessment_scores.objective_assessment_identification_code is null
 )
+
 select * from joined


### PR DESCRIPTION
## Description & motivation
Adds tests for assessments and objective assessments that will throw a warning if there are any null scores

## Breaking changes introduced by this PR:
None since these are tests that only throw warnings

## PR Merge Priority:
- [x] Low

## New files created:
- `cfg_assessment_scores` : Throws a warning if assessment scores are null 
- `cfg_objective_assessment_scores` : Throws a warning if objective assessment scores are null 

## Tests and QC done:
ran compiled test in snowflake to check functionality

## edu_wh PR Review Checklist:
Make sure the following have been completed before approving this PR:
- [x] Description of changes has been added to Unreleased section of [CHANGELOG.md](/CHANGELOG.md). Add under `## New Features` for features, etc.
