### PR TITLE
Feature/Databricks support

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -59,6 +59,8 @@ Describe any process that confirms that the files do what is expected, include s
 ## edu_wh PR Review Checklist:
 Make sure the following have been completed before approving this PR:
 - [ ] Description of changes has been added to Unreleased section of [CHANGELOG.md](/CHANGELOG.md). Add under `## New Features` for features, etc.
+- [ ] Code has been tested/checked for Databricks and Snowflake compatibility - EA engineers see Databricks checklist [here](https://edanalytics.slite.com/app/docs/LRjXFxVRAWA5ST) 
+- [ ] Reviewer confirms the grain of all tables are unchanged, OR any changes are expected, communicated, and this PR is flagged as a breaking change (not for patch release)
 - [ ] If a new configuration xwalk was added:
   - [ ] The code is written such that the xwalk is optional (preferred), and this behavior was tested, OR
   - [ ] The code is written such that the xwalk is required, and the required xwalk is added to edu_project_template, and this PR is flagged as breaking change (not for patch release)
@@ -67,7 +69,6 @@ Make sure the following have been completed before approving this PR:
   - [ ] The code is written such that the variable is optional (preferred), and this behavior was tested, OR
   - [ ] The code is written such that the variable is required, and a default value was added to edu_project_template, and this PR is flagged as breaking change (not for patch release)
   - [ ] A description for the new variable has been added to EDU documentation site [here](https://github.com/edanalytics/edu_docs/blob/main/docs/docs/manage_extend/reference/configure_dbt_vars.md) 
-- [ ] Reviewer confirms the grain of all tables are unchanged, OR any changes are expected, communicated, and this PR is flagged as a breaking change (not for patch release)
 
 <!---## Future ToDos & Questions:-->
 <!---

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,6 @@
 # Unreleased
 ## New features
-- Add support for Databricks
-
+- Add Databricks platform compatibility
 ## Under the hood
 - The following 'breaking' under the hood changes were introduced for databricks compatibility:
   - All columns which are part of the primary key of a table are set explicitly as not null
@@ -10,6 +9,7 @@
   - Changed column order in `fct_student_assessment` and `fct_student_objective_assessment`
   - Changed `dim_class_period.start_time` and `end_time` from time data types to strings
 ## Fixes
+- Potentially breaking for queryers: `bld_ef3__combine_gpas` (and downstream `fct_student_gpa`) `gpa_type` `'Unknown'` values have been made more specific: `'Cumulative, unknown weighting'` and `'Non-cumulative, unknown weighting'` to respect the grain of the table.
 
 # edu_wh v0.4.4
 ## New features

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Unreleased
 ## New features
+- Add support for Databricks
+
 ## Under the hood
 ## Fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,12 @@
 - Add support for Databricks
 
 ## Under the hood
+- The following 'breaking' under the hood changes were introduced for databricks compatibility:
+  - All columns which are part of the primary key of a table are set explicitly as not null
+  - The primary key of `fct_student_gpa` has been changed to remove is_cumulative, but the logic was adjusted so that the effective grain is the same
+  - Added `fct_staff_school_association.k_staff_school_association` and updated the primary key
+  - Changed column order in `fct_student_assessment` and `fct_student_objective_assessment`
+  - Changed `dim_class_period.start_time` and `end_time` from time data types to strings
 ## Fixes
 
 # edu_wh v0.4.4

--- a/models/build/edfi_3/assessments/bld_ef3__assessment_performance_levels.sql
+++ b/models/build/edfi_3/assessments/bld_ef3__assessment_performance_levels.sql
@@ -7,8 +7,8 @@ build_object as (
         api_year,
         k_assessment,
         {{
-            json_array_agg(
-                json_object_construct(
+            edu_edfi_source.json_array_agg(
+                edu_edfi_source.json_object_construct(
                     [['performance_level_name', 'performance_level_name'],
                      ['performance_level_value', 'performance_level_value']]
                 ),

--- a/models/build/edfi_3/assessments/bld_ef3__assessment_performance_levels.sql
+++ b/models/build/edfi_3/assessments/bld_ef3__assessment_performance_levels.sql
@@ -6,8 +6,14 @@ build_object as (
         tenant_code,
         api_year,
         k_assessment,
-        array_agg(object_construct('performance_level_name', performance_level_name,
-                                   'performance_level_value', performance_level_value)) as performance_levels_array
+        {{
+            json_array_agg(
+                json_object_construct(
+                    [['performance_level_name', 'performance_level_name'],
+                     ['performance_level_value', 'performance_level_value']]
+                ),
+            is_terminal=True)
+        }} as performance_levels_array
     from stg_assessment_perf_levels
     group by 1,2,3
 )

--- a/models/build/edfi_3/assessments/bld_ef3__objective_assessment_performance_levels.sql
+++ b/models/build/edfi_3/assessments/bld_ef3__objective_assessment_performance_levels.sql
@@ -7,8 +7,8 @@ build_object as (
         api_year,
         k_objective_assessment,
         {{
-            json_array_agg(
-                json_object_construct(
+            edu_edfi_source.json_array_agg(
+                edu_edfi_source.json_object_construct(
                     [['performance_level_name', 'performance_level_name'],
                      ['performance_level_value', 'performance_level_value']]
                 ),

--- a/models/build/edfi_3/assessments/bld_ef3__objective_assessment_performance_levels.sql
+++ b/models/build/edfi_3/assessments/bld_ef3__objective_assessment_performance_levels.sql
@@ -6,8 +6,14 @@ build_object as (
         tenant_code,
         api_year,
         k_objective_assessment,
-        array_agg(object_construct('performance_level_name', performance_level_name,
-                                   'performance_level_value', performance_level_value)) as performance_levels_array
+        {{
+            json_array_agg(
+                json_object_construct(
+                    [['performance_level_name', 'performance_level_name'],
+                     ['performance_level_value', 'performance_level_value']]
+                ),
+            is_terminal=True)
+        }} as performance_levels_array
     from stg_obj_assessment_perf_levels
     group by 1,2,3
 )

--- a/models/build/edfi_3/bld_ef3__combine_gpas.sql
+++ b/models/build/edfi_3/bld_ef3__combine_gpas.sql
@@ -20,7 +20,7 @@ format_deprecated_gpas as (
         tenant_code,
         api_year,
         k_student_academic_record,
-        'Unknown'      as gpa_type,
+        'Cumulative, unknown weighting' as gpa_type,
         cumulative_gpa as gpa_value,
         true           as is_cumulative,
         null           as max_gpa_value
@@ -30,10 +30,10 @@ format_deprecated_gpas as (
         tenant_code,
         api_year,
         k_student_academic_record,
-        'Unknown'      as gpa_type,
-        session_gpa    as gpa_value,
-        false          as is_cumulative,
-        null           as max_gpa_value
+        'Non-cumulative, unknown weighting' as gpa_type,
+        session_gpa as gpa_value,
+        false       as is_cumulative,
+        null        as max_gpa_value
     from deprecated_gpas
 )
 select * from format_current_gpas

--- a/models/build/edfi_3/courses/bld_ef3__course_char__combined_long.sql
+++ b/models/build/edfi_3/courses/bld_ef3__course_char__combined_long.sql
@@ -7,7 +7,7 @@ with section_chars as (
         k_course_section,
         array_agg({{ edu_edfi_source.extract_descriptor('value:sectionCharacteristicDescriptor::string') }}) as section_characteristic
     from {{ ref('stg_ef3__sections') }}
-        , lateral flatten(v_section_characteristics, outer => true)
+        {{ json_flatten('v_section_characteristics', outer=True) }}
     group by 1,2
 ), 
 offering_chars as (
@@ -16,7 +16,7 @@ offering_chars as (
         k_course_offering,
         array_agg({{ edu_edfi_source.extract_descriptor('value:courseLevelCharacteristicDescriptor::string') }}) as offering_characteristic
     from {{ ref('stg_ef3__course_offerings') }}
-        , lateral flatten(v_course_level_characteristics, outer => true)
+        {{ json_flatten('v_course_level_characteristics', outer=True) }}
     group by 1,2
 ),
 course_chars as (
@@ -26,7 +26,7 @@ course_chars as (
         k_course,
         array_agg({{ edu_edfi_source.extract_descriptor('value:courseLevelCharacteristicDescriptor::string') }}) as course_characteristic
     from {{ ref('stg_ef3__courses') }}
-        , lateral flatten(v_level_characteristics, outer => true)
+        {{ json_flatten('v_level_characteristics', outer=True) }}
     group by 1,2,3
 ),
 joined as (
@@ -50,4 +50,4 @@ select
     k_course_section,
     value::string as course_level_characteristic
 from joined 
- , lateral flatten(combined_chars)
+ {{ json_flatten('combined_chars') }}

--- a/models/build/edfi_3/courses/bld_ef3__course_char__combined_long.sql
+++ b/models/build/edfi_3/courses/bld_ef3__course_char__combined_long.sql
@@ -35,7 +35,7 @@ offering_chars as (
         {{ edu_edfi_source.extract_descriptor('value:courseLevelCharacteristicDescriptor::string') }} as characteristic
     from offerings
     join sections
-        on sections.k_course_offering = offerings.k_course_offering
+        on offerings.k_course_offering = sections.k_course_offering
         {{ edu_edfi_source.json_flatten('offerings.v_course_level_characteristics', outer=True) }}
 ),
 course_chars as (
@@ -50,7 +50,7 @@ course_chars as (
     join offerings
         on courses.k_course = offerings.k_course
     join sections
-        on sections.k_course_offering = offerings.k_course_offering
+        on offerings.k_course_offering = sections.k_course_offering
         {{ edu_edfi_source.json_flatten('courses.v_level_characteristics', outer=True) }}
 ),
 unioned as (

--- a/models/build/edfi_3/staffs/bld_ef3__staff_race_ethnicity.sql
+++ b/models/build/edfi_3/staffs/bld_ef3__staff_race_ethnicity.sql
@@ -21,10 +21,10 @@ select
         when stg_staffs.has_hispanic_latino_ethnicity
             {# default to stu var if staff var not defined #}
             then '{{ var("edu:staff_demos:hispanic_latino_code", var("edu:stu_demos:hispanic_latino_code")) }}'
-        when {{ edu_edfi_source.json_array_size('race_array') }} > 1
+        when array_size(race_array) > 1
             {# default to stu var if staff var not defined #}
             then '{{ var("edu:staff_demos:multiple_races_code", var("edu:stu_demos:multiple_races_code")) }}'
-        when {{ edu_edfi_source.json_array_size('race_array') }} = 1
+        when array_size(race_array) = 1
             then race_array[0]
             {# default to stu var if staff var not defined #}
         else '{{ var("edu:staff_demos:race_unknown_code", var("edu:stu_demos:race_unknown_code")) }}'

--- a/models/build/edfi_3/staffs/bld_ef3__staff_race_ethnicity.sql
+++ b/models/build/edfi_3/staffs/bld_ef3__staff_race_ethnicity.sql
@@ -21,10 +21,10 @@ select
         when stg_staffs.has_hispanic_latino_ethnicity
             {# default to stu var if staff var not defined #}
             then '{{ var("edu:staff_demos:hispanic_latino_code", var("edu:stu_demos:hispanic_latino_code")) }}'
-        when {{ json_array_size('race_array') }} > 1
+        when {{ edu_edfi_source.json_array_size('race_array') }} > 1
             {# default to stu var if staff var not defined #}
             then '{{ var("edu:staff_demos:multiple_races_code", var("edu:stu_demos:multiple_races_code")) }}'
-        when {{ json_array_size('race_array') }} = 1
+        when {{ edu_edfi_source.json_array_size('race_array') }} = 1
             then race_array[0]
             {# default to stu var if staff var not defined #}
         else '{{ var("edu:staff_demos:race_unknown_code", var("edu:stu_demos:race_unknown_code")) }}'

--- a/models/build/edfi_3/staffs/bld_ef3__staff_race_ethnicity.sql
+++ b/models/build/edfi_3/staffs/bld_ef3__staff_race_ethnicity.sql
@@ -21,10 +21,10 @@ select
         when stg_staffs.has_hispanic_latino_ethnicity
             {# default to stu var if staff var not defined #}
             then '{{ var("edu:staff_demos:hispanic_latino_code", var("edu:stu_demos:hispanic_latino_code")) }}'
-        when array_size(race_array) > 1
+        when {{ json_array_size('race_array') }} > 1
             {# default to stu var if staff var not defined #}
             then '{{ var("edu:staff_demos:multiple_races_code", var("edu:stu_demos:multiple_races_code")) }}'
-        when array_size(race_array) = 1
+        when {{ json_array_size('race_array') }} = 1
             then race_array[0]
             {# default to stu var if staff var not defined #}
         else '{{ var("edu:staff_demos:race_unknown_code", var("edu:stu_demos:race_unknown_code")) }}'

--- a/models/build/edfi_3/students/bld_ef3__stu_race_ethnicity.sql
+++ b/models/build/edfi_3/students/bld_ef3__stu_race_ethnicity.sql
@@ -23,9 +23,9 @@ select
     case 
         when stg_stu_ed_org.has_hispanic_latino_ethnicity
             then '{{ var("edu:stu_demos:hispanic_latino_code") }}'
-        when {{ edu_edfi_source.json_array_size('race_array') }} > 1
+        when array_size(race_array) > 1
             then '{{ var("edu:stu_demos:multiple_races_code") }}'
-        when {{ edu_edfi_source.json_array_size('race_array') }} = 1
+        when array_size(race_array) = 1
             then race_array[0]
         else '{{ var("edu:stu_demos:race_unknown_code") }}'
     end as race_ethnicity,

--- a/models/build/edfi_3/students/bld_ef3__stu_race_ethnicity.sql
+++ b/models/build/edfi_3/students/bld_ef3__stu_race_ethnicity.sql
@@ -23,9 +23,9 @@ select
     case 
         when stg_stu_ed_org.has_hispanic_latino_ethnicity
             then '{{ var("edu:stu_demos:hispanic_latino_code") }}'
-        when array_size(race_array) > 1
+        when {{ json_array_size('race_array') }} > 1
             then '{{ var("edu:stu_demos:multiple_races_code") }}'
-        when array_size(race_array) = 1
+        when {{ json_array_size('race_array') }} = 1
             then race_array[0]
         else '{{ var("edu:stu_demos:race_unknown_code") }}'
     end as race_ethnicity,

--- a/models/build/edfi_3/students/bld_ef3__stu_race_ethnicity.sql
+++ b/models/build/edfi_3/students/bld_ef3__stu_race_ethnicity.sql
@@ -23,9 +23,9 @@ select
     case 
         when stg_stu_ed_org.has_hispanic_latino_ethnicity
             then '{{ var("edu:stu_demos:hispanic_latino_code") }}'
-        when {{ json_array_size('race_array') }} > 1
+        when {{ edu_edfi_source.json_array_size('race_array') }} > 1
             then '{{ var("edu:stu_demos:multiple_races_code") }}'
-        when {{ json_array_size('race_array') }} = 1
+        when {{ edu_edfi_source.json_array_size('race_array') }} = 1
             then race_array[0]
         else '{{ var("edu:stu_demos:race_unknown_code") }}'
     end as race_ethnicity,

--- a/models/build/edfi_3/students/bld_ef3__student_cohort_years.sql
+++ b/models/build/edfi_3/students/bld_ef3__student_cohort_years.sql
@@ -7,8 +7,8 @@ build_object as (
         api_year,
         k_student,
         {{
-            json_array_agg(
-                json_object_construct(
+            edu_edfi_source.json_array_agg(
+                edu_edfi_source.json_object_construct(
                     [['cohort_year_type', 'cohort_year_type'],
                      ['school_year', 'school_year'],
                      ['academic_term', 'academic_term']]

--- a/models/build/edfi_3/students/bld_ef3__student_cohort_years.sql
+++ b/models/build/edfi_3/students/bld_ef3__student_cohort_years.sql
@@ -6,9 +6,15 @@ build_object as (
         tenant_code,
         api_year,
         k_student,
-        array_agg(object_construct('cohort_year_type', cohort_year_type, 
-                                    'school_year', school_year,
-                                    'academic_term', academic_term)) as cohort_year_array
+        {{
+            json_array_agg(
+                json_object_construct(
+                    [['cohort_year_type', 'cohort_year_type'],
+                     ['school_year', 'school_year'],
+                     ['academic_term', 'academic_term']]
+                ),
+            is_terminal=True)
+        }} as cohort_year_array
     from student_cohort_years
     group by 1,2,3
 )

--- a/models/build/edfi_3/students/bld_ef3__student_program__homeless__program_services.sql
+++ b/models/build/edfi_3/students/bld_ef3__student_program__homeless__program_services.sql
@@ -12,7 +12,7 @@ wide as (
         k_lea,
         k_school,
         program_enroll_begin_date,
-        array_agg(program_service) within group (order by program_service) as program_services
+        array_agg(program_service) as program_services
 
     from stage_program_services
 

--- a/models/build/edfi_3/students/bld_ef3__student_program__homeless__program_services.sql
+++ b/models/build/edfi_3/students/bld_ef3__student_program__homeless__program_services.sql
@@ -12,7 +12,7 @@ wide as (
         k_lea,
         k_school,
         program_enroll_begin_date,
-        array_agg(program_service) as program_services
+        {{ edu_edfi_source.json_array_agg('program_service', order_by='program_service', is_terminal=True) }} as program_services
 
     from stage_program_services
 

--- a/models/build/edfi_3/students/bld_ef3__student_program__language_instruction__program_services.sql
+++ b/models/build/edfi_3/students/bld_ef3__student_program__language_instruction__program_services.sql
@@ -12,7 +12,7 @@ wide as (
         k_lea,
         k_school,
         program_enroll_begin_date,
-        array_agg(program_service) within group (order by program_service) as program_services
+        array_agg(program_service) as program_services
 
     from stage_program_services
 

--- a/models/build/edfi_3/students/bld_ef3__student_program__language_instruction__program_services.sql
+++ b/models/build/edfi_3/students/bld_ef3__student_program__language_instruction__program_services.sql
@@ -12,7 +12,7 @@ wide as (
         k_lea,
         k_school,
         program_enroll_begin_date,
-        array_agg(program_service) as program_services
+        {{ edu_edfi_source.json_array_agg('program_service', order_by='program_service', is_terminal=True) }} as program_services
 
     from stage_program_services
 

--- a/models/build/edfi_3/students/bld_ef3__student_program__special_education__program_services.sql
+++ b/models/build/edfi_3/students/bld_ef3__student_program__special_education__program_services.sql
@@ -12,7 +12,7 @@ wide as (
         k_lea,
         k_school,
         program_enroll_begin_date,
-        array_agg(program_service) within group (order by program_service) as program_services
+        array_agg(program_service) as program_services
 
     from stage_program_services
 

--- a/models/build/edfi_3/students/bld_ef3__student_program__special_education__program_services.sql
+++ b/models/build/edfi_3/students/bld_ef3__student_program__special_education__program_services.sql
@@ -12,7 +12,7 @@ wide as (
         k_lea,
         k_school,
         program_enroll_begin_date,
-        array_agg(program_service) as program_services
+        {{ edu_edfi_source.json_array_agg('program_service', order_by='program_service', is_terminal=True) }} as program_services
 
     from stage_program_services
 

--- a/models/build/edfi_3/students/bld_ef3__student_program__title_i_part_a__program_services.sql
+++ b/models/build/edfi_3/students/bld_ef3__student_program__title_i_part_a__program_services.sql
@@ -12,7 +12,7 @@ wide as (
         k_lea,
         k_school,
         program_enroll_begin_date,
-        array_agg(program_service) within group (order by program_service) as program_services
+        array_agg(program_service) as program_services
 
     from stage_program_services
 

--- a/models/build/edfi_3/students/bld_ef3__student_program__title_i_part_a__program_services.sql
+++ b/models/build/edfi_3/students/bld_ef3__student_program__title_i_part_a__program_services.sql
@@ -12,7 +12,7 @@ wide as (
         k_lea,
         k_school,
         program_enroll_begin_date,
-        array_agg(program_service) as program_services
+        {{ edu_edfi_source.json_array_agg('program_service', order_by='program_service', is_terminal=True) }} as program_services
 
     from stage_program_services
 

--- a/models/core_warehouse/dim_assessment.sql
+++ b/models/core_warehouse/dim_assessment.sql
@@ -1,6 +1,7 @@
 {{
   config(
     post_hook=[
+        "alter table {{ this }} alter column k_assessment set not null",
         "alter table {{ this }} add primary key (k_assessment)"
     ]
   )

--- a/models/core_warehouse/dim_calendar_date.sql
+++ b/models/core_warehouse/dim_calendar_date.sql
@@ -44,9 +44,9 @@ formatted as (
         stg_calendar_date.school_year,
         stg_calendar_date.calendar_date,
         case 
-            when {{ edu_edfi_source.json_array_size('summarize_calendar_events.calendar_events_array') }} = 1
+            when array_size(summarize_calendar_events.calendar_events_array) = 1
                 then summarize_calendar_events.calendar_events_array[0]
-            when {{ edu_edfi_source.json_array_size('summarize_calendar_events.calendar_events_array') }} > 1
+            when array_size(summarize_calendar_events.calendar_events_array) > 1
                 then 'Multiple'
             else null
         end as calendar_event,

--- a/models/core_warehouse/dim_calendar_date.sql
+++ b/models/core_warehouse/dim_calendar_date.sql
@@ -43,9 +43,9 @@ formatted as (
         stg_calendar_date.school_year,
         stg_calendar_date.calendar_date,
         case 
-            when {{ json_array_size('summarize_calendar_events.calendar_events_array') }} = 1
+            when {{ edu_edfi_source.json_array_size('summarize_calendar_events.calendar_events_array') }} = 1
                 then summarize_calendar_events.calendar_events_array[0]
-            when {{ json_array_size('summarize_calendar_events.calendar_events_array') }} > 1
+            when {{ edu_edfi_source.json_array_size('summarize_calendar_events.calendar_events_array') }} > 1
                 then 'Multiple'
             else null
         end as calendar_event,

--- a/models/core_warehouse/dim_calendar_date.sql
+++ b/models/core_warehouse/dim_calendar_date.sql
@@ -68,7 +68,7 @@ augmented as (
         row_number() over(partition by k_school_calendar, is_school_day
                           order by calendar_date) as day_of_school_year,
         dayname(calendar_date) as week_day,
-        week(calendar_date) as week_of_calendar_year
+        weekofyear(calendar_date) as week_of_calendar_year
     from formatted
 ),
 -- find the week of the first day of school, for calculating week of school year

--- a/models/core_warehouse/dim_calendar_date.sql
+++ b/models/core_warehouse/dim_calendar_date.sql
@@ -43,9 +43,9 @@ formatted as (
         stg_calendar_date.school_year,
         stg_calendar_date.calendar_date,
         case 
-            when array_size(summarize_calendar_events.calendar_events_array) = 1
+            when {{ json_array_size('summarize_calendar_events.calendar_events_array') }} = 1
                 then summarize_calendar_events.calendar_events_array[0]
-            when array_size(summarize_calendar_events.calendar_events_array) > 1
+            when {{ json_array_size('summarize_calendar_events.calendar_events_array') }} > 1
                 then 'Multiple'
             else null
         end as calendar_event,

--- a/models/core_warehouse/dim_calendar_date.sql
+++ b/models/core_warehouse/dim_calendar_date.sql
@@ -1,6 +1,7 @@
 {{
   config(
     post_hook=[
+        "alter table {{ this }} alter column k_calendar_date set not null",
         "alter table {{ this }} add primary key (k_calendar_date)",
         "alter table {{ this }} add constraint fk_{{ this.name }}_school_calendar foreign key (k_school_calendar) references {{ ref('dim_school_calendar') }}",
         "alter table {{ this }} add constraint fk_{{ this.name }}_school foreign key (k_school) references {{ ref('dim_school') }}",

--- a/models/core_warehouse/dim_class_period.sql
+++ b/models/core_warehouse/dim_class_period.sql
@@ -1,6 +1,7 @@
 {{
   config(
     post_hook=[
+        "alter table {{ this }} alter column k_class_period set not null",
         "alter table {{ this }} add primary key (k_class_period)",
     ]
   )

--- a/models/core_warehouse/dim_class_period.sql
+++ b/models/core_warehouse/dim_class_period.sql
@@ -30,17 +30,17 @@ formatted as (
             -- convert to military time for time math, if it isn't
             -- (assume class periods will not be scheduled between 1 and 6 AM)
             case 
-                when left({{ edu_edfi_source.json_ci_get('meeting_time', 'startTime') }}::string, 2)::int between 1 and 6
-                then concat(left({{ edu_edfi_source.json_ci_get('meeting_time', 'startTime') }}, 2)::int + 12, right({{ edu_edfi_source.json_ci_get('meeting_time', 'startTime') }}::string, 6))
-                else {{ edu_edfi_source.json_ci_get('meeting_time', 'startTime') }}::string
+                when left(meeting_time:startTime::string, 2)::int between 1 and 6
+                then concat(left(meeting_time:startTime, 2)::int + 12, right(meeting_time:startTime::string, 6))
+                else meeting_time:startTime::string
             end
         end as start_time,
         case when {{ edu_edfi_source.json_array_size('v_meeting_times') }} = 1
         then 
             case 
-                when left({{ edu_edfi_source.json_ci_get('meeting_time', 'endTime') }}::string, 2)::int between 1 and 6
-                then concat(left({{ edu_edfi_source.json_ci_get('meeting_time', 'endTime') }}::string, 2)::int + 12, right({{ edu_edfi_source.json_ci_get('meeting_time', 'endTime') }}::string, 6))
-                else {{ edu_edfi_source.json_ci_get('meeting_time', 'endTime') }}::string
+                when left(meeting_time:endTime::string, 2)::int between 1 and 6
+                then concat(left(meeting_time:endTime::string, 2)::int + 12, right(meeting_time:endTime::string, 6))
+                else meeting_time:endTime::string
             end
         end as end_time,
         timediff(MINUTE, concat('2020-01-01 ', start_time)::timestamp, concat('2020-01-01 ', end_time)::timestamp) as period_duration

--- a/models/core_warehouse/dim_class_period.sql
+++ b/models/core_warehouse/dim_class_period.sql
@@ -23,7 +23,7 @@ formatted as (
         class_periods.class_period_name,
         class_periods.is_official_attendance_period,
         -- if there is only one start time, extract it, else leave null
-        case when array_size(v_meeting_times) = 1
+        case when {{ json_array_size('v_meeting_times') }} = 1
         then
             -- convert to military time for time math, if it isn't
             -- (assume class periods will not be scheduled between 1 and 6 AM)
@@ -33,7 +33,7 @@ formatted as (
                 else v_meeting_times[0]['startTime']::time
             end
         end as start_time,
-        case when array_size(v_meeting_times) = 1
+        case when {{ json_array_size('v_meeting_times') }} = 1
         then 
             case 
                 when date_part(hour, v_meeting_times[0]['endTime']::time) between 1 and 6

--- a/models/core_warehouse/dim_class_period.sql
+++ b/models/core_warehouse/dim_class_period.sql
@@ -37,7 +37,7 @@ formatted as (
         then 
             case 
                 when left(v_meeting_times[0].endTime::string, 2)::int between 1 and 6
-                then concat(left(v_meeting_times[0].endTime::string, 2)::int + 12, right(v_meeting_times[0].startTime::string, 6))
+                then concat(left(v_meeting_times[0].endTime::string, 2)::int + 12, right(v_meeting_times[0].endTime::string, 6))
                 else v_meeting_times[0].endTime::string
             end
         end as end_time,

--- a/models/core_warehouse/dim_class_period.sql
+++ b/models/core_warehouse/dim_class_period.sql
@@ -23,25 +23,25 @@ formatted as (
         class_periods.class_period_name,
         class_periods.is_official_attendance_period,
         -- if there is only one start time, extract it, else leave null
-        case when {{ json_array_size('v_meeting_times') }} = 1
+        case when {{ edu_edfi_source.json_array_size('v_meeting_times') }} = 1
         then
             -- convert to military time for time math, if it isn't
             -- (assume class periods will not be scheduled between 1 and 6 AM)
             case 
-                when date_part(hour, v_meeting_times[0]['startTime']::time) between 1 and 6
-                then timeadd(hours, 12, v_meeting_times[0]['startTime']::time)
-                else v_meeting_times[0]['startTime']::time
+                when date_part('HOUR', v_meeting_times[0].startTime::time) between 1 and 6
+                then dateadd(HOUR, 12, v_meeting_times[0].startTime::time)
+                else v_meeting_times[0].startTime::time
             end
         end as start_time,
-        case when {{ json_array_size('v_meeting_times') }} = 1
+        case when {{ edu_edfi_source.json_array_size('v_meeting_times') }} = 1
         then 
             case 
-                when date_part(hour, v_meeting_times[0]['endTime']::time) between 1 and 6
-                then timeadd(hours, 12, v_meeting_times[0]['endTime']::time)
-                else v_meeting_times[0]['endTime']::time
+                when date_part('HOUR', v_meeting_times[0].endTime::time) between 1 and 6
+                then dateadd(HOUR, 12, v_meeting_times[0].endTime::time)
+                else v_meeting_times[0].endTime::time
             end
         end as end_time,
-        timediff(minutes, start_time, end_time) as period_duration
+        timediff(MINUTE, start_time, end_time) as period_duration
 
         -- custom indicators
         {% if custom_data_sources is not none and custom_data_sources | length -%}

--- a/models/core_warehouse/dim_classroom.sql
+++ b/models/core_warehouse/dim_classroom.sql
@@ -1,6 +1,7 @@
 {{
   config(
     post_hook=[
+        "alter table {{ this }} alter column k_classroom set not null",
         "alter table {{ this }} add primary key (k_classroom)",
         "alter table {{ this }} add constraint fk_{{ this.name }}_school foreign key (k_school) references {{ ref('dim_school') }}",
     ]

--- a/models/core_warehouse/dim_cohort.sql
+++ b/models/core_warehouse/dim_cohort.sql
@@ -1,6 +1,7 @@
 {{
   config(
     post_hook=[
+        "alter table {{ this }} alter column k_cohort set not null",
         "alter table {{ this }} add primary key (k_cohort)",
     ]
   )

--- a/models/core_warehouse/dim_course.sql
+++ b/models/core_warehouse/dim_course.sql
@@ -1,6 +1,7 @@
 {{
   config(
     post_hook=[
+        "alter table {{ this }} alter column k_course set not null",
         "alter table {{ this }} add primary key (k_course)",
     ]
   )

--- a/models/core_warehouse/dim_course_section.sql
+++ b/models/core_warehouse/dim_course_section.sql
@@ -1,6 +1,7 @@
 {{
   config(
     post_hook=[
+        "alter table {{ this }} alter column k_course_section set not null",
         "alter table {{ this }} add primary key (k_course_section)",
         "alter table {{ this }} add constraint fk_{{ this.name }}_course foreign key (k_course) references {{ ref('dim_course') }}",
         "alter table {{ this }} add constraint fk_{{ this.name }}_school foreign key (k_school) references {{ ref('dim_school') }}",

--- a/models/core_warehouse/dim_discipline_incident.sql
+++ b/models/core_warehouse/dim_discipline_incident.sql
@@ -1,6 +1,7 @@
 {{
   config(
     post_hook=[
+        "alter table {{ this }} alter column k_discipline_incident set not null",
         "alter table {{ this }} add primary key (k_discipline_incident)",
         "alter table {{ this }} add constraint fk_{{ this.name }}_school foreign key (k_school) references {{ ref('dim_school') }}",
     ]

--- a/models/core_warehouse/dim_discipline_incident.sql
+++ b/models/core_warehouse/dim_discipline_incident.sql
@@ -31,7 +31,7 @@ formatted as (
         stg_discipline_incidents.incident_time,
         -- adding an indicator for multiple behaviors for an incident
         case
-            when array_size(stg_discipline_incidents.v_behaviors) > 1
+            when {{ json_array_size('stg_discipline_incidents.v_behaviors') }} > 1
                 then true
             else false 
         end as has_multiple_behaviors,

--- a/models/core_warehouse/dim_discipline_incident.sql
+++ b/models/core_warehouse/dim_discipline_incident.sql
@@ -16,8 +16,14 @@ dim_school as (
 behaviors as (
     select
         k_discipline_incident,
-        array_agg(object_construct('behavior_type', behavior_type,
-                                   'behavior_detailed_description', behavior_detailed_description)) as behavior_array
+        {{
+            json_array_agg(
+                json_object_construct(
+                    [['behavior_type', 'behavior_type'],
+                     ['behavior_detailed_description', 'behavior_detailed_description']]
+                ),
+            is_terminal=True)
+        }} as behavior_array
     from {{ ref('stg_ef3__discipline_incidents__behaviors') }}
     group by k_discipline_incident
 ),

--- a/models/core_warehouse/dim_discipline_incident.sql
+++ b/models/core_warehouse/dim_discipline_incident.sql
@@ -17,8 +17,8 @@ behaviors as (
     select
         k_discipline_incident,
         {{
-            json_array_agg(
-                json_object_construct(
+            edu_edfi_source.json_array_agg(
+                edu_edfi_source.json_object_construct(
                     [['behavior_type', 'behavior_type'],
                      ['behavior_detailed_description', 'behavior_detailed_description']]
                 ),
@@ -37,7 +37,7 @@ formatted as (
         stg_discipline_incidents.incident_time,
         -- adding an indicator for multiple behaviors for an incident
         case
-            when {{ json_array_size('stg_discipline_incidents.v_behaviors') }} > 1
+            when {{ edu_edfi_source.json_array_size('stg_discipline_incidents.v_behaviors') }} > 1
                 then true
             else false 
         end as has_multiple_behaviors,

--- a/models/core_warehouse/dim_esc.sql
+++ b/models/core_warehouse/dim_esc.sql
@@ -1,6 +1,7 @@
 {{
   config(
     post_hook=[
+        "alter table {{ this }} alter column k_esc set not null",
         "alter table {{ this }} add primary key (k_esc)",
     ]
   )

--- a/models/core_warehouse/dim_grading_period.sql
+++ b/models/core_warehouse/dim_grading_period.sql
@@ -1,6 +1,7 @@
 {{
   config(
     post_hook=[
+        "alter table {{ this }} alter column k_grading_period set not null",
         "alter table {{ this }} add primary key (k_grading_period)",
         "alter table {{ this }} add constraint fk_{{ this.name }}_school foreign key (k_school) references {{ ref('dim_school') }}",
     ]

--- a/models/core_warehouse/dim_graduation_plan.sql
+++ b/models/core_warehouse/dim_graduation_plan.sql
@@ -1,6 +1,7 @@
 {{
   config(
     post_hook=[
+        "alter table {{ this }} alter column k_graduation_plan set not null",
         "alter table {{ this }} add primary key (k_graduation_plan)"
     ]
   )

--- a/models/core_warehouse/dim_lea.sql
+++ b/models/core_warehouse/dim_lea.sql
@@ -1,6 +1,7 @@
 {{
   config(
     post_hook=[
+        "alter table {{ this }} alter column k_lea set not null",
         "alter table {{ this }} add primary key (k_lea)",
     ]
   )

--- a/models/core_warehouse/dim_learning_standard.sql
+++ b/models/core_warehouse/dim_learning_standard.sql
@@ -1,6 +1,7 @@
 {{
   config(
     post_hook=[
+        "alter table {{ this }} alter column k_learning_standard set not null",
         "alter table {{ this }} add primary key (k_learning_standard)"
     ]
   )

--- a/models/core_warehouse/dim_network.sql
+++ b/models/core_warehouse/dim_network.sql
@@ -1,6 +1,7 @@
 {{
   config(
     post_hook=[
+        "alter table {{ this }} alter column k_network set not null",
         "alter table {{ this }} add primary key (k_network)",
     ]
   )

--- a/models/core_warehouse/dim_objective_assessment.sql
+++ b/models/core_warehouse/dim_objective_assessment.sql
@@ -1,6 +1,7 @@
 {{
   config(
     post_hook=[
+        "alter table {{ this }} alter column k_objective_assessment set not null",
         "alter table {{ this }} add primary key (k_objective_assessment)",
         "alter table {{ this }} add constraint fk_{{ this.name }}_assessment foreign key (k_assessment) references {{ ref('dim_assessment') }}"
     ]

--- a/models/core_warehouse/dim_parent.sql
+++ b/models/core_warehouse/dim_parent.sql
@@ -1,6 +1,7 @@
 {{
   config(
     post_hook=[
+        "alter table {{ this }} alter column k_parent set not null",
         "alter table {{ this }} add primary key (k_parent)",
     ]
   )

--- a/models/core_warehouse/dim_program.sql
+++ b/models/core_warehouse/dim_program.sql
@@ -1,6 +1,7 @@
 {{
   config(
     post_hook=[
+        "alter table {{ this }} alter column k_program set not null",
         "alter table {{ this }} add primary key (k_program)",
     ]
   )

--- a/models/core_warehouse/dim_school.sql
+++ b/models/core_warehouse/dim_school.sql
@@ -2,6 +2,7 @@
 {{
   config(
     post_hook=[
+        "alter table {{ this }} alter column k_school set not null",
         "alter table {{ this }} add primary key (k_school)",
 
         "{% set network_types = dbt_utils.get_column_values(

--- a/models/core_warehouse/dim_school_calendar.sql
+++ b/models/core_warehouse/dim_school_calendar.sql
@@ -1,6 +1,7 @@
 {{
   config(
     post_hook=[
+        "alter table {{ this }} alter column k_school_calendar set not null",
         "alter table {{ this }} add primary key (k_school_calendar)",
         "alter table {{ this }} add constraint fk_{{ this.name }}_school foreign key (k_school) references {{ ref('dim_school') }}",
     ]

--- a/models/core_warehouse/dim_session.sql
+++ b/models/core_warehouse/dim_session.sql
@@ -1,6 +1,7 @@
 {{
   config(
     post_hook=[
+        "alter table {{ this }} alter column k_session set not null",
         "alter table {{ this }} add primary key (k_session)",
         "alter table {{ this }} add constraint fk_{{ this.name }}_school foreign key (k_school) references {{ ref('dim_school') }}",
     ]

--- a/models/core_warehouse/dim_staff.sql
+++ b/models/core_warehouse/dim_staff.sql
@@ -1,6 +1,7 @@
 {{
   config(
     post_hook=[
+        "alter table {{ this }} alter column k_staff set not null",
         "alter table {{ this }} add primary key (k_staff)",
     ]
   )

--- a/models/core_warehouse/dim_student.sql
+++ b/models/core_warehouse/dim_student.sql
@@ -1,6 +1,7 @@
 {{
   config(
     post_hook=[
+        "alter table {{ this }} alter column k_student set not null",
         "alter table {{ this }} add primary key (k_student)",
     ]
   )

--- a/models/core_warehouse/dim_subgroup.sql
+++ b/models/core_warehouse/dim_subgroup.sql
@@ -1,8 +1,13 @@
 {{
   config(
+    post_hook=[
+        "alter table {{ this }} alter column k_subgroup set not null",
+        "alter table {{ this }} add primary key (k_subgroup)",
+    ],
     tags=['bypass_rls']
     )
 }}
+
 with dim_student as (
     select * from {{ ref('dim_student') }}
 ),

--- a/models/core_warehouse/dim_subgroup.sql
+++ b/models/core_warehouse/dim_subgroup.sql
@@ -20,6 +20,7 @@ xwalk_subgroup_category_display_names as (
 stu_long_subgroup as (
     {{ dbt_utils.unpivot(
        relation=ref('dim_student'),
+       cast_to='string',
        exclude=[
           'k_student',
           'k_student_xyear',

--- a/models/core_warehouse/fct_course_transcripts.sql
+++ b/models/core_warehouse/fct_course_transcripts.sql
@@ -1,6 +1,9 @@
 {{
   config(
     post_hook=[
+        "alter table {{ this }} alter column k_course set not null",
+        "alter table {{ this }} alter column k_student_academic_record set not null",
+        "alter table {{ this }} alter column course_attempt_result set not null",
         "alter table {{ this }} add primary key (k_course, k_student_academic_record, course_attempt_result)",
         "alter table {{ this }} add constraint fk_{{ this.name }}_course foreign key (k_course) references {{ ref('dim_course') }}",
         "alter table {{ this }} add constraint fk_{{ this.name }}_academic_record foreign key (k_student_academic_record) references {{ ref('fct_student_academic_record') }}",

--- a/models/core_warehouse/fct_staff_section_association.sql
+++ b/models/core_warehouse/fct_staff_section_association.sql
@@ -1,6 +1,8 @@
 {{
   config(
     post_hook=[
+        "alter table {{ this }} alter column k_staff set not null",
+        "alter table {{ this }} alter column k_course_section set not null",
         "alter table {{ this }} add primary key (k_staff, k_course_section)",
         "alter table {{ this }} add constraint fk_{{ this.name }}_staff foreign key (k_staff) references {{ ref('dim_staff') }}",
         "alter table {{ this }} add constraint fk_{{ this.name }}_section foreign key (k_course_section) references {{ ref('dim_course_section') }}",

--- a/models/core_warehouse/fct_student_academic_record.sql
+++ b/models/core_warehouse/fct_student_academic_record.sql
@@ -1,6 +1,7 @@
 {{
   config(
     post_hook=[
+        "alter table {{ this }} alter column k_student_academic_record set not null",
         "alter table {{ this }} add primary key (k_student_academic_record)",
         "alter table {{ this }} add constraint fk_{{ this.name }}_student foreign key (k_student) references {{ ref('dim_student') }}",
     ]

--- a/models/core_warehouse/fct_student_assessment.sql
+++ b/models/core_warehouse/fct_student_assessment.sql
@@ -1,6 +1,7 @@
 {{
   config(
     post_hook=[
+        "alter table {{ this }} alter column k_student_assessment set not null",
         "alter table {{ this }} add primary key (k_student_assessment)",
         "alter table {{ this }} add constraint fk_{{ this.name }}_assessment foreign key (k_assessment) references {{ ref('dim_assessment') }}",
         "alter table {{ this }} add constraint fk_{{ this.name }}_student foreign key (k_student) references {{ ref('dim_student') }}"

--- a/models/core_warehouse/fct_student_assessment.sql
+++ b/models/core_warehouse/fct_student_assessment.sql
@@ -21,7 +21,7 @@ dim_student as (
 object_agg_other_results as (
     select
         k_student_assessment,
-        object_agg(original_score_name, score_result::variant) as v_other_results
+        {{ edu_edfi_source.json_object_agg('original_score_name', 'score_result') }} as v_other_results
     from student_assessments_long_results
     where normalized_score_name = 'other'
     group by 1
@@ -53,8 +53,7 @@ student_assessments_wide as (
         platform_type,
         reason_not_tested,
         retest_indicator,
-        when_assessed_grade_level,
-        v_other_results
+        when_assessed_grade_level
         {%- if not is_empty_model('xwalk_assessment_scores') -%},
         {{ dbt_utils.pivot(
             'normalized_score_name',
@@ -71,8 +70,6 @@ student_assessments_wide as (
     left join student_assessments_long_results
         on student_assessments.k_student_assessment = student_assessments_long_results.k_student_assessment
         and student_assessments_long_results.normalized_score_name != 'other'
-    left join object_agg_other_results
-        on student_assessments.k_student_assessment = object_agg_other_results.k_student_assessment
     -- left join to allow 'historic' records (assess records with no corresponding stu demographics)
     left join dim_student
         on student_assessments.k_student = dim_student.k_student
@@ -90,7 +87,12 @@ student_assessments_wide as (
         select distinct k_student_xyear
         from dim_student
     )
-    {{ dbt_utils.group_by(n=19) }}
+    {{ dbt_utils.group_by(n=18) }}
 )
-select *
+-- add v_other_results to the end because variant columns cannot be included in a group by in Databricks
+select 
+    student_assessments_wide.*, 
+    v_other_results
 from student_assessments_wide
+left join object_agg_other_results
+    on student_assessments_wide.k_student_assessment = object_agg_other_results.k_student_assessment

--- a/models/core_warehouse/fct_student_cohort_association.sql
+++ b/models/core_warehouse/fct_student_cohort_association.sql
@@ -1,6 +1,9 @@
 {{
   config(
     post_hook=[
+        "alter table {{ this }} alter column k_student set not null",
+        "alter table {{ this }} alter column k_cohort set not null",
+        "alter table {{ this }} alter column cohort_begin_date set not null",
         "alter table {{ this }} add primary key (k_student, k_cohort, cohort_begin_date)",
         "alter table {{ this }} add constraint fk_{{ this.name }}_student foreign key (k_student) references {{ ref('dim_student') }}",
         "alter table {{ this }} add constraint fk_{{ this.name }}_cohort foreign key (k_cohort) references {{ ref('dim_cohort') }}",

--- a/models/core_warehouse/fct_student_daily_attendance.sql
+++ b/models/core_warehouse/fct_student_daily_attendance.sql
@@ -1,6 +1,9 @@
 {{
   config(
     post_hook=[
+        "alter table {{ this }} alter column k_student set not null",
+        "alter table {{ this }} alter column k_school set not null",
+        "alter table {{ this }} alter column calendar_date set not null",
         "alter table {{ this }} add primary key (k_student, k_school, calendar_date)",
         "alter table {{ this }} add constraint fk_{{ this.name }}_student foreign key (k_student) references {{ ref('dim_student') }}",
         "alter table {{ this }} add constraint fk_{{ this.name }}_school foreign key (k_school) references {{ ref('dim_school') }}",

--- a/models/core_warehouse/fct_student_diploma.sql
+++ b/models/core_warehouse/fct_student_diploma.sql
@@ -68,5 +68,6 @@ dedupe_diplomas as (
             )
         }}
 )
-{{ edu_edfi_source.star('dedupe_diplomas', except=['academic_term'])}}
+select {{ edu_edfi_source.star('dedupe_diplomas', except=['academic_term'])}}
+from dedupe_diplomas
 order by tenant_code, k_student

--- a/models/core_warehouse/fct_student_diploma.sql
+++ b/models/core_warehouse/fct_student_diploma.sql
@@ -68,5 +68,5 @@ dedupe_diplomas as (
             )
         }}
 )
-select dedupe_diplomas.* exclude (academic_term) from dedupe_diplomas
+{{ edu_edfi_source.star('dedupe_diplomas', except=['academic_term'])}}
 order by tenant_code, k_student

--- a/models/core_warehouse/fct_student_discipline_actions.sql
+++ b/models/core_warehouse/fct_student_discipline_actions.sql
@@ -1,6 +1,9 @@
 {{
   config(
     post_hook=[
+        "alter table {{ this }} alter column k_student set not null",
+        "alter table {{ this }} alter column k_discipline_actions_event set not null",
+        "alter table {{ this }} alter column discipline_action set not null",
         "alter table {{ this }} add primary key (k_student, k_discipline_actions_event, discipline_action)",
         "alter table {{ this }} add constraint fk_{{ this.name }}_student foreign key (k_student) references {{ ref('dim_student') }}",
         "alter table {{ this }} add constraint fk_{{ this.name }}_school foreign key (k_school) references {{ ref('dim_school') }}",

--- a/models/core_warehouse/fct_student_discipline_actions.sql
+++ b/models/core_warehouse/fct_student_discipline_actions.sql
@@ -32,7 +32,7 @@ flatten_staff_keys as (
         index,
         {{ edu_edfi_source.gen_skey('k_staff', alt_ref='value:staffReference') }}
     from stg_discipline_actions
-        , lateral flatten(v_staffs)
+        {{ json_flatten('v_staffs') }}
 ),
 agg_staff_keys as (
     select 
@@ -98,7 +98,7 @@ formatted as (
         on stg_discipline_actions.k_student = agg_staff_keys.k_student
         and stg_discipline_actions.discipline_action_id = agg_staff_keys.discipline_action_id
         and stg_discipline_actions.discipline_date = agg_staff_keys.discipline_date
-    , lateral flatten(input=>v_disciplines)
+    {{ json_flatten('v_disciplines') }}
     -- brule: one or the other school must be populated
     where (assignment_school_id is not null or responsibility_school_id is not null)
 ),

--- a/models/core_warehouse/fct_student_discipline_actions.sql
+++ b/models/core_warehouse/fct_student_discipline_actions.sql
@@ -32,7 +32,7 @@ flatten_staff_keys as (
         index,
         {{ edu_edfi_source.gen_skey('k_staff', alt_ref='value:staffReference') }}
     from stg_discipline_actions
-        {{ json_flatten('v_staffs') }}
+        {{ edu_edfi_source.json_flatten('v_staffs') }}
 ),
 agg_staff_keys as (
     select 
@@ -98,7 +98,7 @@ formatted as (
         on stg_discipline_actions.k_student = agg_staff_keys.k_student
         and stg_discipline_actions.discipline_action_id = agg_staff_keys.discipline_action_id
         and stg_discipline_actions.discipline_date = agg_staff_keys.discipline_date
-    {{ json_flatten('v_disciplines') }}
+    {{ edu_edfi_source.json_flatten('v_disciplines') }}
     -- brule: one or the other school must be populated
     where (assignment_school_id is not null or responsibility_school_id is not null)
 ),

--- a/models/core_warehouse/fct_student_discipline_actions.sql
+++ b/models/core_warehouse/fct_student_discipline_actions.sql
@@ -29,7 +29,6 @@ flatten_staff_keys as (
         k_student_xyear,
         discipline_action_id,
         discipline_date,
-        index,
         {{ edu_edfi_source.gen_skey('k_staff', alt_ref='value:staffReference') }}
     from stg_discipline_actions
         {{ edu_edfi_source.json_flatten('v_staffs') }}
@@ -42,7 +41,7 @@ agg_staff_keys as (
         discipline_date,
         -- staff associations are most often singular.
         -- keep the first such association, but also produce an array in case of multiple
-        max(case when index = 0 then k_staff else null end) as k_staff_single,
+        max(k_staff) as k_staff_single,
         array_agg(k_staff) as k_staff_array
     from flatten_staff_keys
     group by 1,2,3,4

--- a/models/core_warehouse/fct_student_discipline_actions_summary.sql
+++ b/models/core_warehouse/fct_student_discipline_actions_summary.sql
@@ -1,6 +1,9 @@
 {{
   config(
     post_hook=[
+        "alter table {{ this }} alter column k_student set not null",
+        "alter table {{ this }} alter column k_student_xyear set not null",
+        "alter table {{ this }} alter column k_discipline_actions_event set not null",
         "alter table {{ this }} add primary key (k_student, k_student_xyear, k_discipline_actions_event)",
         "alter table {{ this }} add constraint fk_{{ this.name }}_student foreign key (k_student) references {{ ref('dim_student') }}"]
   )

--- a/models/core_warehouse/fct_student_discipline_incident_behaviors.sql
+++ b/models/core_warehouse/fct_student_discipline_incident_behaviors.sql
@@ -71,7 +71,7 @@ formatted as (
         -- bring in any additional custom columns from xwalk, does nothing if there are no extra columns
         {{ accordion_columns('xwalk_discipline_behaviors', exclude_columns=['behavior_type', 'severity_order']) }}
         -- there is typically only a single value here, choosing the first option for analytical use cases
-        participation_codes.participation_codes_array[0]::string as participation_code,
+        {{ edu_edfi_source.json_get_first('participation_codes.participation_codes_array', 'string') }} as participation_code,
         participation_codes.participation_codes_array
         {# add any extension columns configured from stg_ef3__student_discipline_incident_behavior_associations #}
         {{ edu_edfi_source.extract_extension(model_name='stg_ef3__student_discipline_incident_behavior_associations', flatten=False) }}

--- a/models/core_warehouse/fct_student_discipline_incident_behaviors.sql
+++ b/models/core_warehouse/fct_student_discipline_incident_behaviors.sql
@@ -29,7 +29,7 @@ participation_codes as (
         k_student,
         k_student_xyear,
         k_discipline_incident,
-        array_agg(distinct participation_code) as participation_codes_array
+        {{ edu_edfi_source.json_array_agg('distinct participation_code', order_by='participation_code', is_terminal=True) }} as participation_codes_array
     from {{ ref('stg_ef3__student_discipline_incident_behavior_associations__participation_codes') }}
     group by k_student, k_student_xyear, k_discipline_incident
 ),

--- a/models/core_warehouse/fct_student_discipline_incident_behaviors.sql
+++ b/models/core_warehouse/fct_student_discipline_incident_behaviors.sql
@@ -29,7 +29,7 @@ participation_codes as (
         k_student,
         k_student_xyear,
         k_discipline_incident,
-        array_agg(distinct participation_code) within group (order by participation_code asc) as participation_codes_array
+        array_agg(distinct participation_code) as participation_codes_array
     from {{ ref('stg_ef3__student_discipline_incident_behavior_associations__participation_codes') }}
     group by k_student, k_student_xyear, k_discipline_incident
 ),

--- a/models/core_warehouse/fct_student_discipline_incident_behaviors.sql
+++ b/models/core_warehouse/fct_student_discipline_incident_behaviors.sql
@@ -1,6 +1,10 @@
 {{
   config(
     post_hook=[
+        "alter table {{ this }} alter column k_student set not null",
+        "alter table {{ this }} alter column k_student_xyear set not null",
+        "alter table {{ this }} alter column k_discipline_incident set not null",
+        "alter table {{ this }} alter column behavior_type set not null",
         "alter table {{ this }} add primary key (k_student, k_student_xyear, k_discipline_incident, behavior_type)",
         "alter table {{ this }} add constraint fk_{{ this.name }}_student foreign key (k_student) references {{ ref('dim_student') }}",
         "alter table {{ this }} add constraint fk_{{ this.name }}_school foreign key (k_school) references {{ ref('dim_school') }}",

--- a/models/core_warehouse/fct_student_discipline_incident_non_offenders.sql
+++ b/models/core_warehouse/fct_student_discipline_incident_non_offenders.sql
@@ -43,7 +43,7 @@ formatted as (
         stg_stu_discipline_incident_non_offenders.incident_id,
         false as is_offender,
         -- there is typically only a single value here, choosing the first option for analytical use cases
-        participation_codes.participation_codes_array[0]::string as participation_code,
+        {{ edu_edfi_source.json_get_first('participation_codes.participation_codes_array', 'string') }} as participation_code,
         participation_codes.participation_codes_array
         {# add any extension columns configured from stg_ef3__student_discipline_incident_non_offender_associations #}
         {{ edu_edfi_source.extract_extension(model_name='stg_ef3__student_discipline_incident_non_offender_associations', flatten=False) }}

--- a/models/core_warehouse/fct_student_discipline_incident_non_offenders.sql
+++ b/models/core_warehouse/fct_student_discipline_incident_non_offenders.sql
@@ -25,7 +25,7 @@ participation_codes as (
         k_student,
         k_student_xyear,
         k_discipline_incident,
-        array_agg(participation_code) as participation_codes_array
+        {{ edu_edfi_source.json_array_agg('participation_code', order_by='participation_code', is_terminal=True) }} as participation_codes_array
     from {{ ref('stg_ef3__student_discipline_incident_non_offender_associations__participation_codes') }}
     group by k_student, k_student_xyear, k_discipline_incident
 ),

--- a/models/core_warehouse/fct_student_discipline_incident_non_offenders.sql
+++ b/models/core_warehouse/fct_student_discipline_incident_non_offenders.sql
@@ -25,7 +25,7 @@ participation_codes as (
         k_student,
         k_student_xyear,
         k_discipline_incident,
-        array_agg(participation_code) within group (order by participation_code asc) as participation_codes_array
+        array_agg(participation_code) as participation_codes_array
     from {{ ref('stg_ef3__student_discipline_incident_non_offender_associations__participation_codes') }}
     group by k_student, k_student_xyear, k_discipline_incident
 ),

--- a/models/core_warehouse/fct_student_discipline_incident_non_offenders.sql
+++ b/models/core_warehouse/fct_student_discipline_incident_non_offenders.sql
@@ -1,6 +1,9 @@
 {{
   config(
     post_hook=[
+        "alter table {{ this }} alter column k_student set not null",
+        "alter table {{ this }} alter column k_student_xyear set not null",
+        "alter table {{ this }} alter column k_discipline_incident set not null",
         "alter table {{ this }} add primary key (k_student, k_student_xyear, k_discipline_incident)",
         "alter table {{ this }} add constraint fk_{{ this.name }}_student foreign key (k_student) references {{ ref('dim_student') }}",
         "alter table {{ this }} add constraint fk_{{ this.name }}_school foreign key (k_school) references {{ ref('dim_school') }}"

--- a/models/core_warehouse/fct_student_discipline_incident_summary.sql
+++ b/models/core_warehouse/fct_student_discipline_incident_summary.sql
@@ -1,6 +1,9 @@
 {{
   config(
     post_hook=[
+        "alter table {{ this }} alter column k_student set not null",
+        "alter table {{ this }} alter column k_student_xyear set not null",
+        "alter table {{ this }} alter column k_discipline_incident set not null",
         "alter table {{ this }} add primary key (k_student, k_student_xyear, k_discipline_incident)",
         "alter table {{ this }} add constraint fk_{{ this.name }}_student foreign key (k_student) references {{ ref('dim_student') }}",
         "alter table {{ this }} add constraint fk_{{ this.name }}_discipline_incidents foreign key (k_discipline_incident) references {{ ref('dim_discipline_incident') }}"

--- a/models/core_warehouse/fct_student_gpa.sql
+++ b/models/core_warehouse/fct_student_gpa.sql
@@ -1,7 +1,9 @@
 {{
   config(
     post_hook=[
-        "alter table {{ this }} add primary key (k_student_academic_record, gpa_type, is_cumulative)",
+        "alter table {{ this }} alter column k_student_academic_record set not null",
+        "alter table {{ this }} alter column gpa_type set not null",
+        "alter table {{ this }} add primary key (k_student_academic_record, gpa_type)",
         "alter table {{ this }} add constraint fk_{{ this.name }}_academic_record foreign key (k_student_academic_record) references {{ ref('fct_student_academic_record') }}",
         "alter table {{ this }} add constraint fk_{{ this.name }}_student foreign key (k_student) references {{ ref('dim_student') }}",
     ]

--- a/models/core_warehouse/fct_student_gpa.yml
+++ b/models/core_warehouse/fct_student_gpa.yml
@@ -7,8 +7,11 @@ models:
         Represents a historical record of student grade point averages, including cumulative and non-cumulative measures.
 
       ##### Primary Key:
-        `k_student_academic_record, gpa_type, is_cumulative` -- There is one record per student, education organization (usually school 
-        or LEA), academic term, GPA type (such as weighted or unweighted), and cumulative/non-cumulative indicator.
+        `k_student_academic_record, gpa_type` -- There is one record per student, education organization (usually school 
+        or LEA), academic term, and GPA type (such as weighted or unweighted). 
+        
+        Prior to Data Standard 5, session and cumulative GPAs were optionally included in fields on the student academic record. In these cases,
+        the `gpa_type` field will be set to 'Cumulative, unknown weighting' or 'Non-cumulative, unknown weighting'.
 
       ##### Important Business Rules:
         `k_student` is an annualized student identifier, so it will be null unless there is a student record for the relevant school year.

--- a/models/core_warehouse/fct_student_grades.sql
+++ b/models/core_warehouse/fct_student_grades.sql
@@ -1,6 +1,11 @@
 {{
   config(
     post_hook=[
+        "alter table {{ this }} alter column k_grading_period set not null",
+        "alter table {{ this }} alter column k_student set not null",
+        "alter table {{ this }} alter column k_school set not null",
+        "alter table {{ this }} alter column k_course_section set not null",
+        "alter table {{ this }} alter column grade_type set not null",
         "alter table {{ this }} add primary key (k_grading_period, k_student, k_school, k_course_section, grade_type)",
         "alter table {{ this }} add constraint fk_{{ this.name }}_grading_period foreign key (k_grading_period) references {{ ref('dim_grading_period') }}",
         "alter table {{ this }} add constraint fk_{{ this.name }}_student foreign key (k_student) references {{ ref('dim_student') }}",

--- a/models/core_warehouse/fct_student_homeless_program_association.sql
+++ b/models/core_warehouse/fct_student_homeless_program_association.sql
@@ -1,6 +1,10 @@
 {{
   config(
     post_hook=[
+        "alter table {{ this }} alter column k_student set not null",
+        "alter table {{ this }} alter column k_student_xyear set not null",
+        "alter table {{ this }} alter column k_program set not null",
+        "alter table {{ this }} alter column program_enroll_begin_date set not null",
         "alter table {{ this }} add primary key (k_student, k_student_xyear, k_program, program_enroll_begin_date)",
         "alter table {{ this }} add constraint fk_{{ this.name }}_student foreign key (k_student) references {{ ref('dim_student') }}",
         "alter table {{ this }} add constraint fk_{{ this.name }}_program foreign key (k_program) references {{ ref('dim_program') }}",

--- a/models/core_warehouse/fct_student_language_instruction_program_association.sql
+++ b/models/core_warehouse/fct_student_language_instruction_program_association.sql
@@ -1,6 +1,10 @@
 {{
   config(
     post_hook=[
+        "alter table {{ this }} alter column k_student set not null",
+        "alter table {{ this }} alter column k_student_xyear set not null",
+        "alter table {{ this }} alter column k_program set not null",
+        "alter table {{ this }} alter column program_enroll_begin_date set not null",
         "alter table {{ this }} add primary key (k_student, k_student_xyear, k_program, program_enroll_begin_date)",
         "alter table {{ this }} add constraint fk_{{ this.name }}_student foreign key (k_student) references {{ ref('dim_student') }}",
         "alter table {{ this }} add constraint fk_{{ this.name }}_program foreign key (k_program) references {{ ref('dim_program') }}",

--- a/models/core_warehouse/fct_student_learning_standard_grades.sql
+++ b/models/core_warehouse/fct_student_learning_standard_grades.sql
@@ -1,6 +1,12 @@
 {{
   config(
     post_hook=[
+        "alter table {{ this }} alter column k_grading_period set not null",
+        "alter table {{ this }} alter column k_student set not null",
+        "alter table {{ this }} alter column k_school set not null",
+        "alter table {{ this }} alter column k_course_section set not null",
+        "alter table {{ this }} alter column grade_type set not null",
+        "alter table {{ this }} alter column k_learning_standard set not null",
         "alter table {{ this }} add primary key (k_grading_period, k_student, k_school, k_course_section, grade_type, k_learning_standard)",
         "alter table {{ this }} add constraint fk_{{ this.name }}_grading_period foreign key (k_grading_period) references {{ ref('dim_grading_period') }}",
         "alter table {{ this }} add constraint fk_{{ this.name }}_student foreign key (k_student) references {{ ref('dim_student') }}",

--- a/models/core_warehouse/fct_student_objective_assessment.sql
+++ b/models/core_warehouse/fct_student_objective_assessment.sql
@@ -22,7 +22,7 @@ dim_student as (
 object_agg_other_results as (
     select
         k_student_objective_assessment,
-        object_agg(original_score_name, score_result::variant) as v_other_results
+        {{ edu_edfi_source.json_object_agg('original_score_name', 'score_result') }} as v_other_results
     from student_obj_assessments_long_results
     where normalized_score_name = 'other'
     group by 1
@@ -53,8 +53,7 @@ student_obj_assessments_wide as (
         platform_type,
         reason_not_tested,
         retest_indicator,
-        when_assessed_grade_level,
-        v_other_results
+        when_assessed_grade_level
         {%- if not is_empty_model('xwalk_objective_assessment_scores') -%},
         {{ dbt_utils.pivot(
             'normalized_score_name',
@@ -71,8 +70,6 @@ student_obj_assessments_wide as (
     left join student_obj_assessments_long_results
         on student_obj_assessments.k_student_objective_assessment = student_obj_assessments_long_results.k_student_objective_assessment
         and student_obj_assessments_long_results.normalized_score_name != 'other'
-    left join object_agg_other_results
-        on student_obj_assessments.k_student_objective_assessment = object_agg_other_results.k_student_objective_assessment
     -- left join to allow 'historic' records (assess records with no corresponding stu demographics)
     left join dim_student
         on student_obj_assessments.k_student = dim_student.k_student
@@ -90,7 +87,12 @@ student_obj_assessments_wide as (
         select distinct k_student_xyear
         from dim_student
     )
-    {{ dbt_utils.group_by(n=19) }}
+    {{ dbt_utils.group_by(n=18) }}
 )
-select *
+-- add v_other_results to the end because variant columns cannot be included in a group by in Databricks
+select 
+    student_obj_assessments_wide.*,
+    v_other_results
 from student_obj_assessments_wide
+left join object_agg_other_results
+    on student_obj_assessments_wide.k_student_objective_assessment = object_agg_other_results.k_student_objective_assessment

--- a/models/core_warehouse/fct_student_objective_assessment.sql
+++ b/models/core_warehouse/fct_student_objective_assessment.sql
@@ -1,6 +1,7 @@
 {{
   config(
     post_hook=[
+        "alter table {{ this }} alter column k_student_objective_assessment set not null",
         "alter table {{ this }} add primary key (k_student_objective_assessment)",
         "alter table {{ this }} add constraint fk_{{ this.name }}_objective_assessment foreign key (k_objective_assessment) references {{ ref('dim_objective_assessment') }}",
         "alter table {{ this }} add constraint fk_{{ this.name }}_assessment foreign key (k_assessment) references {{ ref('dim_assessment') }}",

--- a/models/core_warehouse/fct_student_parent_association.sql
+++ b/models/core_warehouse/fct_student_parent_association.sql
@@ -1,6 +1,8 @@
 {{
   config(
     post_hook=[
+        "alter table {{ this }} alter column k_student set not null",
+        "alter table {{ this }} alter column k_parent set not null",
         "alter table {{ this }} add primary key (k_student, k_parent)",
         "alter table {{ this }} add constraint fk_{{ this.name }}_student foreign key (k_student) references {{ ref('dim_student') }}",
         "alter table {{ this }} add constraint fk_{{ this.name }}_parent foreign key (k_parent) references {{ ref('dim_parent') }}",

--- a/models/core_warehouse/fct_student_program_association.sql
+++ b/models/core_warehouse/fct_student_program_association.sql
@@ -1,6 +1,10 @@
 {{
   config(
     post_hook=[
+        "alter table {{ this }} alter column k_student set not null",
+        "alter table {{ this }} alter column k_student_xyear set not null",
+        "alter table {{ this }} alter column k_program set not null",
+        "alter table {{ this }} alter column program_enroll_begin_date set not null",
         "alter table {{ this }} add primary key (k_student, k_student_xyear, k_program, program_enroll_begin_date)",
         "alter table {{ this }} add constraint fk_{{ this.name }}_student foreign key (k_student) references {{ ref('dim_student') }}",
         "alter table {{ this }} add constraint fk_{{ this.name }}_program foreign key (k_program) references {{ ref('dim_program') }}",

--- a/models/core_warehouse/fct_student_program_service.sql
+++ b/models/core_warehouse/fct_student_program_service.sql
@@ -1,6 +1,10 @@
 {{
   config(
     post_hook=[
+        "alter table {{ this }} alter column k_student set not null",
+        "alter table {{ this }} alter column k_program set not null",
+        "alter table {{ this }} alter column program_enroll_begin_date set not null",
+        "alter table {{ this }} alter column program_service set not null",
         "alter table {{ this }} add primary key (k_student, k_program, program_enroll_begin_date, program_service)",
         "alter table {{ this }} add constraint fk_{{ this.name }}_student foreign key (k_student) references {{ ref('dim_student') }}",
         "alter table {{ this }} add constraint fk_{{ this.name }}_program foreign key (k_program) references {{ ref('dim_program') }}",

--- a/models/core_warehouse/fct_student_school_association.sql
+++ b/models/core_warehouse/fct_student_school_association.sql
@@ -1,6 +1,9 @@
 {{
   config(
     post_hook=[
+        "alter table {{ this }} alter column k_student set not null",
+        "alter table {{ this }} alter column k_school set not null",
+        "alter table {{ this }} alter column entry_date set not null",
         "alter table {{ this }} add primary key (k_student, k_school, entry_date)",
         "alter table {{ this }} add constraint fk_{{ this.name }}_student foreign key (k_student) references {{ ref('dim_student') }}",
         "alter table {{ this }} add constraint fk_{{ this.name }}_school foreign key (k_school) references {{ ref('dim_school') }}",

--- a/models/core_warehouse/fct_student_school_attendance_event.sql
+++ b/models/core_warehouse/fct_student_school_attendance_event.sql
@@ -108,7 +108,7 @@ formatted as (
         school_attendance_duration,
         arrival_time,
         departure_time,
-        educational_environment,
+        educational_environment
         {# add any extension columns configured from stg_ef3__student_school_attendance_events #}
         {{ edu_edfi_source.extract_extension(model_name='stg_ef3__student_school_attendance_events', flatten=False) }}
     from deduped

--- a/models/core_warehouse/fct_student_school_attendance_event.sql
+++ b/models/core_warehouse/fct_student_school_attendance_event.sql
@@ -1,6 +1,11 @@
 {{
   config(
     post_hook=[
+        "alter table {{ this }} alter column k_student set not null",
+        "alter table {{ this }} alter column k_school set not null",
+        "alter table {{ this }} alter column k_session set not null",
+        "alter table {{ this }} alter column attendance_event_category set not null",
+        "alter table {{ this }} alter column k_calendar_date set not null",
         "alter table {{ this }} add primary key (k_student, k_school, k_session, attendance_event_category, k_calendar_date)",
         "alter table {{ this }} add constraint fk_{{ this.name }}_student foreign key (k_student) references {{ ref('dim_student') }}",
         "alter table {{ this }} add constraint fk_{{ this.name }}_school foreign key (k_school) references {{ ref('dim_school') }}",

--- a/models/core_warehouse/fct_student_section_association.sql
+++ b/models/core_warehouse/fct_student_section_association.sql
@@ -1,6 +1,9 @@
 {{
   config(
     post_hook=[
+        "alter table {{ this }} alter column k_student set not null",
+        "alter table {{ this }} alter column k_course_section set not null",
+        "alter table {{ this }} alter column begin_date set not null",
         "alter table {{ this }} add primary key (k_student, k_course_section, begin_date)",
         "alter table {{ this }} add constraint fk_{{ this.name }}_student foreign key (k_student) references {{ ref('dim_student') }}",
         "alter table {{ this }} add constraint fk_{{ this.name }}_course_section foreign key (k_course_section) references {{ ref('dim_course_section') }}",

--- a/models/core_warehouse/fct_student_section_attendance_event.sql
+++ b/models/core_warehouse/fct_student_section_attendance_event.sql
@@ -1,6 +1,10 @@
 {{
   config(
     post_hook=[
+        "alter table {{ this }} alter column k_student set not null",
+        "alter table {{ this }} alter column k_course_section set not null",
+        "alter table {{ this }} alter column attendance_event_category set not null",
+        "alter table {{ this }} alter column attendance_event_date set not null",
         "alter table {{ this }} add primary key (k_student, k_course_section, attendance_event_category, attendance_event_date)",
         "alter table {{ this }} add constraint fk_{{ this.name }}_student foreign key (k_student) references {{ ref('dim_student') }}",
         "alter table {{ this }} add constraint fk_{{ this.name }}_course_section foreign key (k_course_section) references {{ ref('dim_course_section') }}",

--- a/models/core_warehouse/fct_student_special_education_program_association.sql
+++ b/models/core_warehouse/fct_student_special_education_program_association.sql
@@ -1,6 +1,10 @@
 {{
   config(
     post_hook=[
+        "alter table {{ this }} alter column k_student set not null",
+        "alter table {{ this }} alter column k_student_xyear set not null",
+        "alter table {{ this }} alter column k_program set not null",
+        "alter table {{ this }} alter column program_enroll_begin_date set not null",
         "alter table {{ this }} add primary key (k_student, k_student_xyear, k_program, program_enroll_begin_date)",
         "alter table {{ this }} add constraint fk_{{ this.name }}_student foreign key (k_student) references {{ ref('dim_student') }}",
         "alter table {{ this }} add constraint fk_{{ this.name }}_program foreign key (k_program) references {{ ref('dim_program') }}",

--- a/models/core_warehouse/fct_student_subgroup.sql
+++ b/models/core_warehouse/fct_student_subgroup.sql
@@ -12,6 +12,7 @@ dim_subgroup as (
 stu_long_subgroup as (
     {{ dbt_utils.unpivot(
        relation=ref('dim_student'),
+       cast_to='string',
        exclude=[
           'k_student',
           'k_student_xyear',

--- a/models/core_warehouse/fct_student_subgroup.sql
+++ b/models/core_warehouse/fct_student_subgroup.sql
@@ -1,3 +1,14 @@
+{{
+  config(
+    post_hook=[
+        "alter table {{ this }} alter column k_student set not null",
+        "alter table {{ this }} alter column k_subgroup set not null",
+        "alter table {{ this }} add primary key (k_student, k_subgroup)",
+        "alter table {{ this }} add constraint fk_{{ this.name }}_student foreign key (k_student) references {{ ref('dim_student') }}",
+    ]
+    )
+}}
+
 with dim_student as (
     select * from {{ ref('dim_student') }}
 ),

--- a/models/core_warehouse/fct_student_title_i_part_a_program_association.sql
+++ b/models/core_warehouse/fct_student_title_i_part_a_program_association.sql
@@ -1,6 +1,10 @@
 {{
   config(
     post_hook=[
+        "alter table {{ this }} alter column k_student set not null",
+        "alter table {{ this }} alter column k_student_xyear set not null",
+        "alter table {{ this }} alter column k_program set not null",
+        "alter table {{ this }} alter column program_enroll_begin_date set not null",
         "alter table {{ this }} add primary key (k_student, k_student_xyear, k_program, program_enroll_begin_date)",
         "alter table {{ this }} add constraint fk_{{ this.name }}_student foreign key (k_student) references {{ ref('dim_student') }}",
         "alter table {{ this }} add constraint fk_{{ this.name }}_program foreign key (k_program) references {{ ref('dim_program') }}",

--- a/models/core_warehouse/msr_student_cumulative_attendance.sql
+++ b/models/core_warehouse/msr_student_cumulative_attendance.sql
@@ -1,6 +1,9 @@
 {{
   config(
     post_hook=[
+        "alter table {{ this }} alter column k_student set not null",
+        "alter table {{ this }} alter column k_school set not null",
+        "alter table {{ this }} alter column school_year set not null",
         "alter table {{ this }} add primary key (k_student, k_school, school_year)",
         "alter table {{ this }} add constraint fk_{{ this.name }}_student foreign key (k_student) references {{ ref('dim_student') }}",
         "alter table {{ this }} add constraint fk_{{ this.name }}_school foreign key (k_school) references {{ ref('dim_school') }}",

--- a/tests/integrity_tests/custom_course_section_sources_are_unique_on_k_course_section.sql
+++ b/tests/integrity_tests/custom_course_section_sources_are_unique_on_k_course_section.sql
@@ -44,10 +44,11 @@ Update the model used as a custom data source to ensure it is unique on k_course
 
 {%- else %}
   -- if no custom data sources configured, force test to return a zero row table
-  select top 0 *
+  select *
   from (select
           null as data_source,
           null as k_course_section,
           null as n_records
        ) blank_subquery
+  limit 0
 {%- endif %}

--- a/tests/integrity_tests/custom_course_sources_are_unique_on_k_course.sql
+++ b/tests/integrity_tests/custom_course_sources_are_unique_on_k_course.sql
@@ -44,10 +44,11 @@ Update the model used as a custom data source to ensure it is unique on k_course
 
 {%- else %}
   -- if no custom data sources configured, force test to return a zero row table
-  select top 0 *
+  select *
   from (select
           null as data_source,
           null as k_course,
           null as n_records
        ) blank_subquery
+  limit 0
 {%- endif %}

--- a/tests/integrity_tests/custom_demo_sources_are_unique_on_k_student.sql
+++ b/tests/integrity_tests/custom_demo_sources_are_unique_on_k_student.sql
@@ -44,10 +44,11 @@ Update the model used as a custom data source to ensure it is unique on k_studen
 
 {%- else %}
   -- if no custom data sources configured, force test to return a zero row table
-  select top 0 *
+  select *
   from (select
           null as data_source,
           null as k_student,
           null as n_records
        ) blank_subquery
+  limit 0
 {%- endif %}

--- a/tests/integrity_tests/grade_level_override_unique_on_k_student.sql
+++ b/tests/integrity_tests/grade_level_override_unique_on_k_student.sql
@@ -28,10 +28,11 @@ Update the model used as a grade_level_override source to ensure it is unique on
   having count(*) > 1
 {%- else %}
   -- if no custom grade_level_override configured, force test to return a zero row table
-  select top 0 *
+  select *
   from (select
           null as data_source,
           null as k_student,
           null as n_records
        ) blank_subquery
+  limit 0
 {%- endif %}

--- a/tests/value_tests/attendance_freshness_test.sql
+++ b/tests/value_tests/attendance_freshness_test.sql
@@ -19,8 +19,8 @@ or if there are errors pushing data from source system to ODS.
     )
 }}
 select *,
-  current_date() - max_date as days_since_last_attendance_event
+  datediff(DAY, max_date, current_date()) as days_since_last_attendance_event
 from {{ ref('attendance_freshness') }}
-where (current_date() - max_date) > 7
+where datediff(DAY, max_date, current_date()) > 7
 -- try to avoid warnings when school is out
-and monthname(current_date()) not in ('Jul', 'Aug')
+  and month(current_date()) not in (7, 8)


### PR DESCRIPTION
## Description & motivation
This PR, along with [these changes in `edu_edfi_source`](https://github.com/edanalytics/edu_edfi_source/pull/129), makes EDU compatible with Databricks.

## Breaking changes introduced by this PR:
There are several changes that might qualify as breaking, but don't actually require any migration. 
- All columns which are part of the primary key of a table are set explicitly as not null
- The primary key of `fct_student_gpa` has been changed to remove `is_cumulative`, but the logic was adjusted so that the effective grain is the same
- Added `fct_staff_school_association.k_staff_school_association` and updated the primary key
- Changed column order in `fct_student_assessment` and ``fct_student_objective_assessment`
- Changed `dim_class_period.start_time` and `end_time` from time data types to strings

## Changes to existing files:
- Databricks requires that every column which is part of the primary key must be set as not null and enforces this constraint. This was only a challenge in two models:
  - In `fct_student_gpa`, `is_cumulative` was part of the primary key due to changes in the model. Refactored to remove it from the primary key and instead ensure that `gpa_type` accounts for the deprecated behavior
  - In `fct_staff_school_association`, `staff_classification` and `begin_date` are sometimes null due to how we left join data from `staffEdOrg` onto the `staffSchool` data. Created a surrogate key to get around this issue
- Most other changes are a straightforward substitution of a macro call in place of Snowflake-specific array behavior or to account for syntax differences. See the documentation of these macros in `edu_edfi_source` for more details.  
- `fct_student_assessment` was rearranged slightly to add v_other_results on at the end because variant columns can't be included in a group by in Databricks
- `fct_student_discipline_actions` was updated with slightly simpler logic to select one `k_staff` for the singular field in case there are multiple. We use max() to consistently select one instead of the first one in the array. This avoids reliance on `index`, which is called `pos` in Databricks.
- `dim_class_period` was updated to handle the conversion to 24 hour time with string manipulation and the period duration calculation via the timestamp type instead of time type, which Databricks doesn't have.
- `bld_ef3__course_char__combined_long` was refactored to avoid array concatenation, which works differently in Databricks. The rewrite does not slow down the model much (adds ~1 sec in SC).
- Small changes in a few custom tests to use syntax supported by both platforms

## Tests and QC done:
- Ran in Databricks on demo data; confirmed that all models ran and did some light checking on contents
- Ran in CA and SC; confirmed that affected models are unchanged by comparing row counts and relevant column values

## edu_wh PR Review Checklist:
Make sure the following have been completed before approving this PR:
- [ ] Description of changes has been added to Unreleased section of [CHANGELOG.md](/CHANGELOG.md). Add under `## New Features` for features, etc.
- [ ] If a new configuration xwalk was added:
  - [ ] The code is written such that the xwalk is optional (preferred), and this behavior was tested, OR
  - [ ] The code is written such that the xwalk is required, and the required xwalk is added to edu_project_template, and this PR is flagged as breaking change (not for patch release)
  - [ ] A description for the new xwalk has been added to EDU documentation site [here](https://github.com/edanalytics/edu_docs/blob/main/docs/docs/manage_extend/reference/configure_dbt_xwalks.md) 
- [ ] If a new configuration variable was added:
  - [ ] The code is written such that the variable is optional (preferred), and this behavior was tested, OR
  - [ ] The code is written such that the variable is required, and a default value was added to edu_project_template, and this PR is flagged as breaking change (not for patch release)
  - [ ] A description for the new variable has been added to EDU documentation site [here](https://github.com/edanalytics/edu_docs/blob/main/docs/docs/manage_extend/reference/configure_dbt_vars.md) 
- [x] Reviewer confirms the grain of all tables are unchanged, OR any changes are expected, communicated, and this PR is flagged as a breaking change (not for patch release)
