### PR TITLE
update key to include begin_date, ds 5.0

### DIFF
--- a/models/core_warehouse/fct_staff_section_association.sql
+++ b/models/core_warehouse/fct_staff_section_association.sql
@@ -1,7 +1,7 @@
 {{
   config(
     post_hook=[
-        "alter table {{ this }} add primary key (k_staff, k_course_section)",
+        "alter table {{ this }} add primary key (k_staff, k_course_section, begin_date)",
         "alter table {{ this }} add constraint fk_{{ this.name }}_staff foreign key (k_staff) references {{ ref('dim_staff') }}",
         "alter table {{ this }} add constraint fk_{{ this.name }}_section foreign key (k_course_section) references {{ ref('dim_course_section') }}",
     ]
@@ -18,7 +18,7 @@ dim_course_section as (
     select * from {{ ref('dim_course_section') }}
 ),
 formatted as (
-    select 
+    select
         dim_staff.k_staff,
         dim_course_section.k_school,
         dim_course_section.k_course_section,
@@ -33,8 +33,8 @@ formatted as (
         -- create indicator for active assignment
         iff(
             -- is highest school year observed by tenant
-            stg_staff_section.school_year = max(stg_staff_section.school_year) 
-                over(partition by stg_staff_section.tenant_code)
+            stg_staff_section.school_year = max(stg_staff_section.school_year)
+                over (partition by stg_staff_section.tenant_code)
             -- not yet exited
             and (stg_staff_section.end_date is null
                 or stg_staff_section.end_date >= current_date())
@@ -45,7 +45,7 @@ formatted as (
         {# add any extension columns configured from stg_ef3__staff_section_associations #}
         {{ edu_edfi_source.extract_extension(model_name='stg_ef3__staff_section_associations', flatten=False) }}
     from stg_staff_section
-    join dim_staff 
+    join dim_staff
         on stg_staff_section.k_staff = dim_staff.k_staff
     join dim_course_section
         on stg_staff_section.k_course_section = dim_course_section.k_course_section

--- a/models/core_warehouse/fct_staff_section_association.yml
+++ b/models/core_warehouse/fct_staff_section_association.yml
@@ -7,7 +7,7 @@ models:
        This fact table provides information on the associations between Staff and Course Sections. It includes both active and historic associations.
 
      ##### Primary Key:
-       `k_staff, k_course_section` -- There is one record per staff and course section.
+       `k_staff, k_course_section, begin_date` -- There is one record per staff, course section, and begin_date
     
      ##### Important Business Rules:
        `is_active_assignment` is TRUE if:  


### PR DESCRIPTION
<!---
Provide Title above, ensure it summarizes the work in the PR. Example PR titles templates:
* "feature/ (or build/): describe new functionality"
* "hotfix/: describe issue fix for immediate release"
* "bugfix/ (or fix/): describe issue fix, not necessary for immediate release"
* "docs/: adding or updating documentation"
-->

## Description & motivation
Add `begin_date` to primary key to align with DS 5.0+. Only changing the primary key declaration and corresponding docs.
Note that `begin_date` should be guaranteed non-null, as even before it was required it had a default value, so there should be no impact on Databricks compatibility.
<!---
High level description your PR, and why you're making it. Is this linked to slack thread, Monday board, open
issue, a continuation to a previous PR? Link it here if relevant (use the "#" symbol for issues/PRs).
-->

## PR Merge Priority:
<!---
This checklist helps the reviewers understand the level of priority for merging this PR.
A loose description of merging priority levels is:
Low: A week or more.
Medium: Within 3 days or less.
High: As soon as possible.
-->
- [ ] Low
- [x] Medium
- [ ] High

<!---
If High Priority, explain why as a comment below.
-->

-->

## edu_wh PR Review Checklist:
Make sure the following have been completed before approving this PR:
- [ ] Description of changes has been added to Unreleased section of [CHANGELOG.md](/CHANGELOG.md). Add under `## New Features` for features, etc.
- [ ] If a new configuration xwalk was added:
  - [ ] The code is written such that the xwalk is optional (preferred), and this behavior was tested, OR
  - [ ] The code is written such that the xwalk is required, and the required xwalk is added to edu_project_template, and this PR is flagged as breaking change (not for patch release)
  - [ ] A description for the new xwalk has been added to EDU documentation site [here](https://github.com/edanalytics/edu_docs/blob/main/docs/docs/manage_extend/reference/configure_dbt_xwalks.md) 
- [ ] If a new configuration variable was added:
  - [ ] The code is written such that the variable is optional (preferred), and this behavior was tested, OR
  - [ ] The code is written such that the variable is required, and a default value was added to edu_project_template, and this PR is flagged as breaking change (not for patch release)
  - [ ] A description for the new variable has been added to EDU documentation site [here](https://github.com/edanalytics/edu_docs/blob/main/docs/docs/manage_extend/reference/configure_dbt_vars.md) 
- [ ] Reviewer confirms the grain of all tables are unchanged, OR any changes are expected, communicated, and this PR is flagged as a breaking change (not for patch release)

<!---## Future ToDos & Questions:-->
<!---
[Optional] Include any future steps and questions related to this PR.
-->
