### PR TITLE
Fix/Support multiple subjects per course in DS 5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,14 @@
 ## Under the hood
 ## Fixes
 
+
+# edu_wh v0.4.3
+## Fixes
+- Fix model `dim_course` to handle multiple academic subjects per course (Ed-Fi Data Standard v5.0 breaking change)
+  - Add array column `subject_array` to `dim_course`, containing array of academic subjects if these exist
+  - Add logic to populate `academic_subject` column with single-valued subjects in both cases where data source is <5.0 or >5.0
+  - Add upstream `bld_ef3__course_subject` 
+
 # edu_wh v0.4.2
 ## New features
 - Add tests `cfg_assessment_scores` and `cfg_objective_assessment_scores` to find assess/obj assess with no scores configured

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,14 +2,11 @@
 ## New features
 ## Under the hood
 ## Fixes
-
-
-# edu_wh v0.4.3
-## Fixes
 - Fix model `dim_course` to handle multiple academic subjects per course (Ed-Fi Data Standard v5.0 breaking change)
   - Add array column `subject_array` to `dim_course`, containing array of academic subjects if these exist
   - Add logic to populate `academic_subject` column with single-valued subjects in both cases where data source is <5.0 or >5.0
   - Add upstream `bld_ef3__course_subject` 
+
 
 # edu_wh v0.4.2
 ## New features

--- a/models/build/edfi_3/courses/bld_ef3__course_subject.sql
+++ b/models/build/edfi_3/courses/bld_ef3__course_subject.sql
@@ -19,13 +19,12 @@ select
     stg_courses.api_year,
     stg_courses.k_course,
     build_array.subject_array,
-    -- Coalesce or base logic on stg_courses.data_model_version compared to 5.0?
     coalesce(
         case
             when array_size(build_array.subject_array) = 1
                 then subject_array[0]
             when array_size(build_array.subject_array) > 1
-                then 'Multiple' -- Make configurable, like edu:stu_demos_multiple_races_code?
+                then 'Multiple'
         end,
         stg_courses.academic_subject
     ) as academic_subject

--- a/models/build/edfi_3/courses/bld_ef3__course_subject.sql
+++ b/models/build/edfi_3/courses/bld_ef3__course_subject.sql
@@ -1,0 +1,35 @@
+with stg_course_subjects as (
+    select * from {{ ref('stg_ef3__courses__academic_subjects') }}
+),
+stg_courses as (
+    select * from {{ ref('stg_ef3__courses') }}
+),
+build_array as (
+    select
+        tenant_code,
+        api_year,
+        k_course,
+        array_agg(academic_subject) as subject_array
+    from stg_course_subjects
+    group by 1, 2, 3
+)
+
+select
+    stg_courses.tenant_code,
+    stg_courses.api_year,
+    stg_courses.k_course,
+    build_array.subject_array,
+    -- Coalesce or base logic on stg_courses.data_model_version compared to 5.0?
+    coalesce(
+        case
+            when array_size(build_array.subject_array) = 1
+                then subject_array[0]
+            when array_size(build_array.subject_array) > 1
+                then 'Multiple' -- Make configurable, like edu:stu_demos_multiple_races_code?
+        end,
+        stg_courses.academic_subject
+    ) as academic_subject
+from stg_courses 
+left join build_array 
+    on stg_courses.k_course = build_array.k_course
+

--- a/models/core_warehouse/dim_course.sql
+++ b/models/core_warehouse/dim_course.sql
@@ -53,7 +53,7 @@ formatted as (
         {% if custom_data_sources is not none and custom_data_sources | length -%}
           {%- for source in custom_data_sources -%}
             {%- for indicator in custom_data_sources[source] -%}
-              , {{ custom_data_sources[source][indicator]['where'] }} as {{ indicator }}
+              {{ custom_data_sources[source][indicator]['where'] }} as {{ indicator }},
             {%- endfor -%}
           {%- endfor -%}
         {%- endif %}

--- a/models/core_warehouse/dim_course.sql
+++ b/models/core_warehouse/dim_course.sql
@@ -15,6 +15,9 @@ with stg_course as (
 bld_ef3__wide_ids_course as (
     select * from {{ ref('bld_ef3__wide_ids_course') }}
 ),
+bld_ef3__course_subject as (
+    select * from {{ ref('bld_ef3__course_subject') }}
+),
 formatted as (
     select 
         stg_course.k_course,
@@ -30,7 +33,7 @@ formatted as (
         stg_course.k_school,
         stg_course.ed_org_id,
         stg_course.ed_org_type,
-        stg_course.academic_subject,
+        bld_ef3__course_subject.academic_subject,
         stg_course.career_pathway,
         stg_course.course_defined_by,
         stg_course.gpa_applicability,
@@ -44,7 +47,7 @@ formatted as (
         stg_course.minimum_available_credit_type,
         stg_course.minimum_available_credit_conversion,
         stg_course.number_of_parts,
-        stg_course.time_required_for_completion
+        stg_course.time_required_for_completion,
 
         -- custom indicators
         {% if custom_data_sources is not none and custom_data_sources | length -%}
@@ -54,9 +57,15 @@ formatted as (
             {%- endfor -%}
           {%- endfor -%}
         {%- endif %}
+
+        bld_ef3__course_subject.subject_array,
+
+
     from stg_course
     left join bld_ef3__wide_ids_course 
         on stg_course.k_course = bld_ef3__wide_ids_course.k_course
+    left join bld_ef3__course_subject
+        on stg_course.k_course = bld_ef3__course_subject.k_course
     
     -- custom data sources
     {% if custom_data_sources is not none and custom_data_sources | length -%}

--- a/models/core_warehouse/dim_course.sql
+++ b/models/core_warehouse/dim_course.sql
@@ -58,7 +58,7 @@ formatted as (
           {%- endfor -%}
         {%- endif %}
 
-        bld_ef3__course_subject.subject_array,
+        bld_ef3__course_subject.subject_array
 
 
     from stg_course

--- a/models/core_warehouse/dim_course.yml
+++ b/models/core_warehouse/dim_course.yml
@@ -71,6 +71,8 @@ models:
       - name: time_required_for_completion
         description: "The actual or estimated number of clock minutes required for class completion. This number is especially important for career 
                       and technical education classes and may represent (in minutes) the clock hour requirement of the class."
+      - name: subject_array
+        description: A list of all the academic subjects associated with the course.
 
 
 


### PR DESCRIPTION
## Description & motivation
Handle DS 5.0+, where [academic subjects are now optional collections for Courses](https://edfidocs.blob.core.windows.net/$web/handbook/v5.0/index.html#/Course237aca05-9476-4646-9640-ecb9630bd8c7). `academicSubject` was previously [single-valued](https://edfidocs.blob.core.windows.net/$web/handbook/v4.0/index.html#/Course550). 

Depends on edanalytics/edu_edfi_source#139

## Breaking changes introduced by this PR:
- New array-valued column in `dim_course` may affect downstream queries
- `dim_course.academic_subject` will now be populated for DS 5.0 data; previously null

## PR Merge Priority:
- [x] Low
- [ ] Medium
- [ ] High

## Changes to existing files:

- `dim_course`: 
  - Update single-valued `academic_subject` as follows:
    - For courses in DS 5.0+, take the first value if the array has only one value. Otherwise, yield 'Multiple.`
    - For courses prior to DS 5.0, maintain old behavior and take the original value
  - Add new array-valued `subject_array` column, containing the full array of academic subjects for any DS 5.0+ rows.
  - Note that the above changes do not currently depend on `data_model_version` and merely depend on the presence or absence of the new array-valued field in the source data.


## New files created:
- `bld_ef3__course_subject`: Contains one row per course and wraps multiple subjects per course back into an array; also contains coalesce logic to produce a single value in `academic_subject` from whatever source data is present, single- or array-valued.

## Tests and QC done:
- Ran against dev data in Boston, which has sideloaded course data from DS 5.0. Confirmed row counts stay the same for `dim_course` and that new logic works properly for DS 5.0+ data. Unable to confirm if the multiple-valued logic works; no source data with more than one subject per course yet.

## edu_wh PR Review Checklist:
Make sure the following have been completed before approving this PR:
- [x] Description of changes has been added to Unreleased section of [CHANGELOG.md](/CHANGELOG.md). Add under `## New Features` for features, etc.
- [ ] If a new configuration xwalk was added:
  - [ ] The code is written such that the xwalk is optional (preferred), and this behavior was tested, OR
  - [ ] The code is written such that the xwalk is required, and the required xwalk is added to edu_project_template, and this PR is flagged as breaking change (not for patch release)
  - [ ] A description for the new xwalk has been added to EDU documentation site [here](https://github.com/edanalytics/edu_docs/blob/main/docs/docs/manage_extend/reference/configure_dbt_xwalks.md) 
- [ ] If a new configuration variable was added:
  - [ ] The code is written such that the variable is optional (preferred), and this behavior was tested, OR
  - [ ] The code is written such that the variable is required, and a default value was added to edu_project_template, and this PR is flagged as breaking change (not for patch release)
  - [ ] A description for the new variable has been added to EDU documentation site [here](https://github.com/edanalytics/edu_docs/blob/main/docs/docs/manage_extend/reference/configure_dbt_vars.md) 
- [x] Reviewer confirms the grain of all tables are unchanged, OR any changes are expected, communicated, and this PR is flagged as a breaking change (not for patch release)

