### PR TITLE
dbt docs: clarify tenant part of student surrogate keys

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Unreleased
 ## New features
 ## Under the hood
+- Update dim_student.yaml (dbt documentation) to be more precise on surrogate key defs for commonly referenced k_student and k_student_xyear
 ## Fixes
 
 # edu_wh v0.4.3

--- a/models/core_warehouse/dim_student.yml
+++ b/models/core_warehouse/dim_student.yml
@@ -7,15 +7,15 @@ models:
         This dimension table defines students across years and some of their key characteristics.
 
       ##### Primary Key:
-        `k_student` -- There is one record per student and year (note that `k_student` is an annualized identifier)
+        `k_student` -- There is one record per tenant, student and year (note that `k_student` is an annualized identifier)
 
       ##### Important Business Rules:
-        `k_student` is annualized, meaning it is a surrogate key for [`student_unique_id` + `school_year`]. This reflects the 
+        `k_student` is annualized, meaning it is a surrogate key for [`tenant_code` + `student_unique_id` + `school_year`]. This reflects the 
         analytical reality of K-12 accountability measures (most measures are annualized), and the common
         demand to define student characteristics on a yearly basis (e.g. how many students were part of a Special Education Program *this year*).  
 
         At times it will be useful to run longitudinal analysis linking a student to events across years. For that, use `k_student_xyear`,
-        a surrogate key for [`student_unique_id`].
+        a surrogate key for [`tenant_code` + `student_unique_id`].
 
       {{ doc(var('edu:custom_docs:dim_student')) if var('edu:custom_docs:dim_student', '') }}  
 


### PR DESCRIPTION
<!---
Provide Title above, ensure it summarizes the work in the PR. Example PR titles templates:
* "feature/ (or build/): describe new functionality"
* "hotfix/: describe issue fix for immediate release"
* "bugfix/ (or fix/): describe issue fix, not necessary for immediate release"
* "docs/: adding or updating documentation"
-->
# hotfix/k_student_dbt_docs


## PR Merge Priority:
<!---
This checklist helps the reviewers understand the level of priority for merging this PR.
A loose description of merging priority levels is:
Low: A week or more.
Medium: Within 3 days or less.
High: As soon as possible.
-->
- [x] Low
- [ ] Medium
- [ ] High

<!---
If High Priority, explain why as a comment below.
-->

## Changes to existing files:
<!---
Include this section if you are changing any existing files or creating breaking changes to existing files. Label the model name and describe the logic behind the changes made, try to be very descriptive here. For example:
- `stg_model` : Describe any changes made to `stg_model` and why the changes where made.
- `src_staging` : Describe any changes made to `src_staging` and why the changes where made.
-->
- Update dim_student.yaml to be more precise on surrogate key defs for commonly referenced `k_student` and `k_student_xyear.`

## edu_wh PR Review Checklist:
Make sure the following have been completed before approving this PR:
- [x] Description of changes has been added to Unreleased section of [CHANGELOG.md](/CHANGELOG.md). Add under `## New Features` for features, etc.
- [ ] If a new configuration xwalk was added:
  - [ ] The code is written such that the xwalk is optional (preferred), and this behavior was tested, OR
  - [ ] The code is written such that the xwalk is required, and the required xwalk is added to edu_project_template, and this PR is flagged as breaking change (not for patch release)
  - [ ] A description for the new xwalk has been added to EDU documentation site [here](https://github.com/edanalytics/edu_docs/blob/main/docs/docs/manage_extend/reference/configure_dbt_xwalks.md) 
- [ ] If a new configuration variable was added:
  - [ ] The code is written such that the variable is optional (preferred), and this behavior was tested, OR
  - [ ] The code is written such that the variable is required, and a default value was added to edu_project_template, and this PR is flagged as breaking change (not for patch release)
  - [ ] A description for the new variable has been added to EDU documentation site [here](https://github.com/edanalytics/edu_docs/blob/main/docs/docs/manage_extend/reference/configure_dbt_vars.md) 
- [x] Reviewer confirms the grain of all tables are unchanged, OR any changes are expected, communicated, and this PR is flagged as a breaking change (not for patch release)

<!---## Future ToDos & Questions:-->
<!---
[Optional] Include any future steps and questions related to this PR.
-->
