### PR TITLE
Feature/epdm models: create fct and dim tables for performance-based assessment of educator candidates

### DIFF
--- a/models/tpdm_warehouse/dim_candidate.sql
+++ b/models/tpdm_warehouse/dim_candidate.sql
@@ -1,3 +1,11 @@
+{{
+  config(
+    post_hook=[
+        "alter table {{ this }} add primary key (k_candidate)"
+    ]
+  )
+}}
+
 with stg_candidates as (
     select * from {{ ref('stg_tpdm__candidates') }}
 ),

--- a/models/tpdm_warehouse/dim_candidate.sql
+++ b/models/tpdm_warehouse/dim_candidate.sql
@@ -1,0 +1,48 @@
+with stg_candidates as (
+    select * from {{ ref('stg_tpdm__candidates') }}
+),
+
+formatted as (
+    select
+        k_candidate,
+        k_person, 
+        tenant_code,
+        api_year,
+        candidate_id,
+        person_id, 
+        first_name, 
+        last_name, 
+        middle_name, 
+        maiden_name, 
+        generation_code_suffix, 
+        personal_title_prefix, 
+        preferred_first_name, 
+        preferred_last_name, 
+        birth_city, 
+        birth_date, 
+        birth_international_province, 
+        date_entered_us, 
+        displacement_status, 
+        is_economic_disadvantaged, 
+        is_first_generation_student, 
+        has_hispanic_latino_ethnicity, 
+        is_multiple_birth, 
+        gender, 
+        sex, 
+        birth_sex, 
+        birth_state, 
+        birth_country, 
+        english_language_exam, 
+        lep_code, 
+        v_addresses, 
+        v_disabilities, 
+        v_emails, 
+        v_languages, 
+        v_other_names, 
+        v_personal_identification_documents, 
+        v_races, 
+        v_telephones 
+    from stg_candidates
+)
+
+select * from formatted

--- a/models/tpdm_warehouse/dim_candidate.yml
+++ b/models/tpdm_warehouse/dim_candidate.yml
@@ -1,0 +1,69 @@
+version: 2
+
+models:
+  - name: dim_candidate
+    description: >
+        ##### Overview:
+          Defines an educator candidate.
+
+        ##### Primary Key:
+          `k_candidate` - There is one record per candidate
+    config:
+      tags: ['tpdm']
+    columns:
+      - name: k_candidate
+        description: generated primary key from `tenant_code`, `api_year`, and `candidate_id`
+        tests: 
+          - unique
+      - name: k_person
+        description: "Generated surrogate key from `tenant_code`, `api_year`, `person_id`, and `source_system`"
+      - name: tenant_code
+        description: "Code defining the Tenant (may be an LEA, SEA, etc.) of the Ed-Fi ODS from which this record was pulled"
+      - name: api_year
+      - name: candidate_id
+        description: A unique alphanumeric code assigned to a candidate
+      - name: person_id
+        description: A unique alphanumeric code assigned to a person
+      - name: first_name
+      - name: last_name
+      - name: middle_name
+      - name: maiden_name
+      - name: generation_code_suffix
+      - name: personal_title_prefix
+      - name: preferred_first_name
+      - name: preferred_last_name
+      - name: birth_city
+      - name: birth_date
+      - name: birth_international_province
+      - name: date_entered_us
+      - name: displacement_status
+      - name: is_economic_disadvantaged
+      - name: is_first_generation_student
+      - name: has_hispanic_latino_ethnicity
+      - name: is_multiple_birth
+      - name: gender
+      - name: sex
+      - name: birth_sex
+      - name: birth_state
+      - name: birth_country
+        description: xxxx
+      - name: english_language_exam
+        description: "Indicates that a person passed, failed, or did not take an English Language assessment (e.g., TOEFFL)."
+      - name: lep_code
+        description: "An indication that the student has been identified as limited English proficient by the Language Proficiency Assessment Committee (LPAC), or English proficient."
+      - name: v_addresses
+        description: The set of elements that describes an address, including the street address, city, state, and ZIP code.
+      - name: v_disabilities
+        description: "The disability condition(s) that best describes an individual's impairment."
+      - name: v_emails
+        description: The numbers, letters, and symbols used to identify an electronic mail (e-mail) user within the network to which the individual or organization belongs.
+      - name: v_languages
+        description: "The language(s) the individual uses to communicate"
+      - name: v_other_names
+        description: "Other names (e.g., alias, nickname, previous legal name) associated with a person."
+      - name: v_personal_identification_documents
+        description: Describes the documentation of citizenship.
+      - name: v_races
+        description: "The general racial category which most clearly reflects the individual's recognition of his or her community or with which the individual most identifies. The data model allows for multiple entries so that each individual can specify all appropriate races."
+      - name: v_telephones
+        description: "The 10-digit telephone number, including the area code, for the person."        

--- a/models/tpdm_warehouse/dim_performance_evaluation.sql
+++ b/models/tpdm_warehouse/dim_performance_evaluation.sql
@@ -1,0 +1,25 @@
+with stg_performance_evaluations as (
+    select * from {{ ref('stg_tpdm__performance_evaluations') }}
+),
+
+stg_performance_evaluation_ratings as (
+    select * from {{ ref('stg_tpdm__performance_evaluation_ratings') }}
+),
+
+formatted as (
+    select
+        stg_performance_evaluation_ratings.k_performance_evaluation,
+        stg_performance_evaluations.ed_org_id,
+        stg_performance_evaluations.performance_evaluation_title,
+        stg_performance_evaluations.performance_evaluation_type,
+        stg_performance_evaluations.school_year,
+        stg_performance_evaluations.academic_term,
+        stg_performance_evaluations.performance_evaluation_description,
+        stg_performance_evaluations.academic_subject,
+        stg_performance_evaluations.v_grade_levels,
+        stg_performance_evaluations.v_rating_levels
+    from stg_performance_evaluation_ratings
+    join stg_performance_evaluations
+        on stg_performance_evaluation_ratings.k_performance_evaluation = stg_performance_evaluations.k_performance_evaluation
+)
+select * from formatted

--- a/models/tpdm_warehouse/dim_performance_evaluation.sql
+++ b/models/tpdm_warehouse/dim_performance_evaluation.sql
@@ -16,7 +16,7 @@ stg_performance_evaluation_ratings as (
 
 formatted as (
     select
-        stg_performance_evaluation_ratings.k_performance_evaluation,
+        stg_performance_evaluations.k_performance_evaluation,
         stg_performance_evaluations.ed_org_id,
         stg_performance_evaluations.performance_evaluation_title,
         stg_performance_evaluations.performance_evaluation_type,
@@ -26,8 +26,8 @@ formatted as (
         stg_performance_evaluations.academic_subject,
         stg_performance_evaluations.v_grade_levels,
         stg_performance_evaluations.v_rating_levels
-    from stg_performance_evaluation_ratings
-    join stg_performance_evaluations
-        on stg_performance_evaluation_ratings.k_performance_evaluation = stg_performance_evaluations.k_performance_evaluation
+    from stg_performance_evaluations
+    join stg_performance_evaluation_ratings 
+        on stg_performance_evaluations.k_performance_evaluation = stg_performance_evaluation_ratings.k_performance_evaluation
 )
 select * from formatted

--- a/models/tpdm_warehouse/dim_performance_evaluation.sql
+++ b/models/tpdm_warehouse/dim_performance_evaluation.sql
@@ -1,3 +1,11 @@
+{{
+  config(
+    post_hook=[
+        "alter table {{ this }} add primary key (k_performance_evaluation)"
+    ]
+  )
+}}
+
 with stg_performance_evaluations as (
     select * from {{ ref('stg_tpdm__performance_evaluations') }}
 ),

--- a/models/tpdm_warehouse/dim_performance_evaluation.yml
+++ b/models/tpdm_warehouse/dim_performance_evaluation.yml
@@ -1,0 +1,35 @@
+version: 2
+
+models:
+  - name: dim_performance_evaluation
+    description: >
+        ##### Overview:
+          Defines a performance evaluation of an educator.
+
+        ##### Primary Key:
+          `k_performance_evaluation` - There is one record per performance evaluation
+    config:
+      tags: ['tpdm']
+    columns:
+      - name: k_performance_evaluation
+        description: Generated surrogate key from [tenant_code, api_year, ed_org_id, evaluation_period, performance_evaluation_title, performance_evaluation_type, school_year, academic_term]
+        tests: 
+          - unique
+      - name: ed_org_id
+        description: The identifier assigned to an education organization.
+      - name: performance_evaluation_title
+        description: An assigned unique identifier for the performance evaluation.
+      - name: performance_evaluation_type
+        description: "The type (e.g., walkthrough, summative) of performance evaluation conducted."
+      - name: school_year
+        description: The identifier for the school year.
+      - name: academic_term
+        description: The term for the session during the school year.
+      - name: performance_evaluation_description
+        description: The long description of the Performance Evaluation.
+      - name: academic_subject
+        description: The description of the content or subject area of a performance evaluation.
+      - name: v_grade_levels
+        description: The grade levels involved with the performance evaluation.
+      - name: v_rating_levels
+        description: "The descriptive level(s) of ratings (cut scores) for the evaluation."

--- a/models/tpdm_warehouse/fct_candidate_assessment.sql
+++ b/models/tpdm_warehouse/fct_candidate_assessment.sql
@@ -1,0 +1,49 @@
+{{
+  config(
+    post_hook=[
+        "alter table {{ this }} add primary key (k_candidate, k_performance_evaluation, k_person)",
+        "alter table {{ this }} add constraint fk_{{ this.name }}_candidate foreign key (k_candidate) references {{ ref('dim_candidate') }}",
+        "alter table {{ this }} add constraint fk_{{ this.name }}_person foreign key (k_person) references {{ ref('dim_candidate') }}",
+        "alter table {{ this }} add constraint fk_{{ this.name }}_performance_evaluation foreign key (k_performance_evaluation) references {{ ref('dim_performance_evaluation') }}",
+    ]
+  )
+}}
+
+with stg_performance_evaluation_ratings as (
+    select * from {{ ref('stg_tpdm__performance_evaluation_ratings') }}
+),
+
+dim_candidate as (
+    select * from {{ ref('dim_candidate') }}
+),
+
+dim_performance_evaluation as (
+    select * from {{ ref('dim_performance_evaluation') }}
+),
+
+formatted as (
+    select
+        {{ dbt_utils.generate_surrogate_key(
+            ['dim_candidate.k_candidate',
+             'dim_performance_evaluation.k_performance_evaluation',
+             'dim_candidate.k_person']
+        ) }} as k_candidate_assessment,
+        dim_candidate.k_candidate,
+        dim_candidate.k_person,
+        dim_performance_evaluation.k_performance_evaluation,
+        stg_performance_evaluation_ratings.results as rating_results,
+        stg_performance_evaluation_ratings.performance_evaluation_rating_level as rating_level,
+        stg_performance_evaluation_ratings.reviewers,
+        stg_performance_evaluation_ratings.coteaching_style_observed,
+        stg_performance_evaluation_ratings.comments,
+        stg_performance_evaluation_ratings.is_announced,
+        stg_performance_evaluation_ratings.schedule_date,
+        stg_performance_evaluation_ratings.actual_date,
+        stg_performance_evaluation_ratings.actual_duration,
+    from dim_candidate
+    join stg_performance_evaluation_ratings
+        on dim_candidate.k_person = stg_performance_evaluation_ratings.k_person
+    join dim_performance_evaluation
+        on stg_performance_evaluation_ratings.k_performance_evaluation = dim_performance_evaluation.k_performance_evaluation
+)
+select * from formatted

--- a/models/tpdm_warehouse/fct_candidate_assessment.sql
+++ b/models/tpdm_warehouse/fct_candidate_assessment.sql
@@ -23,11 +23,6 @@ dim_performance_evaluation as (
 
 formatted as (
     select
-        {{ dbt_utils.generate_surrogate_key(
-            ['dim_candidate.k_candidate',
-             'dim_performance_evaluation.k_performance_evaluation',
-             'dim_candidate.k_person']
-        ) }} as k_candidate_assessment,
         dim_candidate.k_candidate,
         dim_candidate.k_person,
         dim_performance_evaluation.k_performance_evaluation,
@@ -40,9 +35,9 @@ formatted as (
         stg_performance_evaluation_ratings.schedule_date,
         stg_performance_evaluation_ratings.actual_date,
         stg_performance_evaluation_ratings.actual_duration,
-    from dim_candidate
-    join stg_performance_evaluation_ratings
-        on dim_candidate.k_person = stg_performance_evaluation_ratings.k_person
+    from stg_performance_evaluation_ratings
+    join dim_candidate
+        on stg_performance_evaluation_ratings.k_person = dim_candidate.k_person
     join dim_performance_evaluation
         on stg_performance_evaluation_ratings.k_performance_evaluation = dim_performance_evaluation.k_performance_evaluation
 )

--- a/models/tpdm_warehouse/fct_candidate_assessment.yml
+++ b/models/tpdm_warehouse/fct_candidate_assessment.yml
@@ -7,15 +7,10 @@ models:
           Defines a performance-based assessment of an educator candidate
 
         ##### Primary Key:
-          `k_candidate_assessment` - There is one record per performance evaluation for a given candidate. This is a generated surrogate key
-          from [k_candidate, k_performance_evaluation, k_person]
+          `k_candidate`, `k_performance_evaluation`, and `k_person` - There is one record per performance evaluation for a given candidate, who is a type of person
     config:
       tags: ['tpdm']
     columns:
-      - name: k_candidate_assessment
-        description: Generated surrogate key from `k_candidate`, `k_performance_evaluation`, and `k_person`
-        tests: 
-          - unique
       - name: k_candidate
         description: Foreign key to dim_candidate, generated from `tenant_code`, `api_year`, and `candidate_id`
       - name: k_person

--- a/models/tpdm_warehouse/fct_candidate_assessment.yml
+++ b/models/tpdm_warehouse/fct_candidate_assessment.yml
@@ -1,0 +1,43 @@
+version: 2
+
+models:
+  - name: fct_candidate assessment
+    description: >
+        ##### Overview:
+          Defines a performance-based assessment of an educator candidate
+
+        ##### Primary Key:
+          `k_candidate_assessment` - There is one record per performance evaluation for a given candidate. This is a generated surrogate key
+          from [k_candidate, k_performance_evaluation, k_person]
+    config:
+      tags: ['tpdm']
+    columns:
+      - name: k_candidate_assessment
+        description: Generated surrogate key from `k_candidate`, `k_performance_evaluation`, and `k_person`
+        tests: 
+          - unique
+      - name: k_candidate
+        description: Foreign key to dim_candidate, generated from `tenant_code`, `api_year`, and `candidate_id`
+      - name: k_person
+        description: "Generated surrogate key from `tenant_code`, `api_year`, `person_id`, and `source_system`"
+      - name: k_performance_evaluation
+        description: Foreign key to dim_performance_evaluation, generated from [tenant_code, api_year, ed_org_id, evaluation_period, performance_evaluation_title, performance_evaluation_type, school_year, academic_term]
+      - name: rating_results
+        description: The numerical summary rating or score for the performance evaluation.
+      - name: rating_level
+        description: The rating level achieved based upon the rating or score.
+      - name: reviewers
+        description: The person(s) that conducted the performance evaluation.
+      - name: coteaching_style_observed
+        description: A type of co-teaching observed as part of the performance evaluation.
+      - name: comments
+        description: Any comments about the performance evaluation to be captured.
+      - name: is_announced
+        description: An indicator of whether the performance evaluation was announced or not.
+      - name: schedule_date
+        description: The month, day, and year on which the performance evaluation was to be conducted.
+      - name: actual_date
+        description: The month, day, and year on which the performance evaluation was conducted.
+      - name: actual_duration
+        description: The actual or estimated number of clock minutes during which the performance evaluation was conducted.
+      


### PR DESCRIPTION
## Description & motivation
Three models for EPDM data. Done as part of summer intern final project, with the hope of answering analytics questions from the SCDE. It is part of [this Jira epic](https://edanalytics.atlassian.net/browse/STAD-104).

## PR Merge Priority:
- [ ] Low

## New files created:
- `dim_candidate.sql`: dimension table to describe an educator candidate
- `dim_candidate.yml`: YAML to describe table above
- `dim_performance_evaluation.sql`: dimension table to describe a performance evaluation 
- `dim_performance_evaluation.yml`: YAML to describe table above
- `fct_candidate_assessment.sql`: fact table to describe the event of a performance evaluation for a given educator candidate, including rating and results
- `fct_candidate_assessment.yml`: YAML to describe table above

## Tests and QC done:
- Executed successful dbt project run in TX stadium.

## edu_wh PR Review Checklist:
Make sure the following have been completed before approving this PR:
- [ ] Description of changes has been added to Unreleased section of [CHANGELOG.md](/CHANGELOG.md). Add under `## New Features` for features, etc.
- [ ] If a new configuration xwalk was added:
  - [ ] The code is written such that the xwalk is optional (preferred), and this behavior was tested, OR
  - [ ] The code is written such that the xwalk is required, and the required xwalk is added to edu_project_template, and this PR is flagged as breaking change (not for patch release)
  - [ ] A description for the new xwalk has been added to EDU documentation site [here](https://github.com/edanalytics/edu_docs/blob/main/docs/docs/manage_extend/reference/configure_dbt_xwalks.md) 
- [ ] If a new configuration variable was added:
  - [ ] The code is written such that the variable is optional (preferred), and this behavior was tested, OR
  - [ ] The code is written such that the variable is required, and a default value was added to edu_project_template, and this PR is flagged as breaking change (not for patch release)
  - [ ] A description for the new variable has been added to EDU documentation site [here](https://github.com/edanalytics/edu_docs/blob/main/docs/docs/manage_extend/reference/configure_dbt_vars.md) 
- [ ] Reviewer confirms the grain of all tables are unchanged, OR any changes are expected, communicated, and this PR is flagged as a breaking change (not for patch release)

<!---## Future ToDos & Questions:-->
- Build the other models related to this project.