### PR TITLE
feature/Update to fct_student_discipline_actions.sql to support Custom Data Sources

### DIFF
--- a/models/core_warehouse/fct_student_discipline_actions.sql
+++ b/models/core_warehouse/fct_student_discipline_actions.sql
@@ -10,6 +10,8 @@
     ]
   )
 }}
+{# Load custom data sources from var #}
+{% set custom_data_sources = var("edu:discipline_actions:custom_data_sources", []) %}
 
 with stg_discipline_actions as (
     select * from {{ ref('stg_ef3__discipline_actions') }}
@@ -32,7 +34,7 @@ flatten_staff_keys as (
         k_student_xyear,
         discipline_action_id,
         discipline_date,
-        {{ edu_edfi_source.gen_skey('k_staff', alt_ref='value:staffReference') }}
+		{{ edu_edfi_source.gen_skey('k_staff', alt_ref='value:staffReference') }}
     from stg_discipline_actions
         {{ edu_edfi_source.json_flatten('v_staffs') }}
 ),
@@ -83,6 +85,15 @@ formatted as (
         bld_discipline_incident_associations.k_student_discipline_incident_behavior_array
         {# add any extension columns configured from stg_ef3__discipline_actions #}
         {{ edu_edfi_source.extract_extension(model_name='stg_ef3__discipline_actions', flatten=False) }}
+
+        -- custom data sources
+        {% if custom_data_sources is not none and custom_data_sources | length -%}
+          {%- for source in custom_data_sources -%}
+            {%- for indicator in custom_data_sources[source] -%}
+              , {{ custom_data_sources[source][indicator]['where'] }} as {{ indicator }}
+            {%- endfor -%}
+          {%- endfor -%}
+        {%- endif %}
     from stg_discipline_actions
     join dim_student 
         on stg_discipline_actions.k_student = dim_student.k_student
@@ -100,6 +111,15 @@ formatted as (
         on stg_discipline_actions.k_student = agg_staff_keys.k_student
         and stg_discipline_actions.discipline_action_id = agg_staff_keys.discipline_action_id
         and stg_discipline_actions.discipline_date = agg_staff_keys.discipline_date
+    -- custom data sources
+    {% if custom_data_sources is not none and custom_data_sources | length -%}
+      {%- for source in custom_data_sources -%}
+        left join {{ ref(source) }}
+          on stg_discipline_actions.k_student = {{ source }}.k_student
+          and stg_discipline_actions.discipline_date = {{ source }}.discipline_date
+          and stg_discipline_actions.discipline_action_id = {{ source }}.discipline_action_id
+      {% endfor %}
+    {%- endif %}
     {{ edu_edfi_source.json_flatten('v_disciplines') }}
     -- brule: one or the other school must be populated
     where (assignment_school_id is not null or responsibility_school_id is not null)
@@ -132,3 +152,4 @@ join_descriptor_interpretation as (
         on formatted.discipline_action = xwalk_discipline_actions.discipline_action
 )
 select * from join_descriptor_interpretation
+


### PR DESCRIPTION
Modified fct_student_discipline_actions to support Custom Data Sources.

## Description & motivation
We needed to add additional columns to fct_student_discipline_actions so I have implemented the custom data sources on it.

## Breaking changes introduced by this PR:
There should be NO breaking changes... HOWEVER HOWEVER HOWEVER, this new code base uses the changes EA has implemented for Databricks. **I have not tested that this works with your code because we haven't switched to this latest codebase yet.**

## PR Merge Priority:
- [X] Low
- [ ] Medium
- [ ] High

## Changes to existing files:
- `fct_student_discipline_actions.sql` : Added the standard custom data sources implementation

## New files created:
N/A

## Tests and QC done:
**I have not tested that this works with your code because we haven't switched to this latest codebase yet.**
This works with the snowflake codebase with our own databricks code.

## edu_wh PR Review Checklist:
Make sure the following have been completed before approving this PR:
- [ ] Description of changes has been added to Unreleased section of [CHANGELOG.md](/CHANGELOG.md). Add under `## New Features` for features, etc.
- [ ] Code has been tested/checked for Databricks and Snowflake compatibility - EA engineers see Databricks checklist [here](https://edanalytics.slite.com/app/docs/LRjXFxVRAWA5ST) 
- [ ] Reviewer confirms the grain of all tables are unchanged, OR any changes are expected, communicated, and this PR is flagged as a breaking change (not for patch release)
- [ ] If a new configuration xwalk was added:
  - [ ] The code is written such that the xwalk is optional (preferred), and this behavior was tested, OR
  - [ ] The code is written such that the xwalk is required, and the required xwalk is added to edu_project_template, and this PR is flagged as breaking change (not for patch release)
  - [ ] A description for the new xwalk has been added to EDU documentation site [here](https://github.com/edanalytics/edu_docs/blob/main/docs/docs/manage_extend/reference/configure_dbt_xwalks.md) 
- [ ] If a new configuration variable was added:
  - [ ] The code is written such that the variable is optional (preferred), and this behavior was tested, OR
  - [ ] The code is written such that the variable is required, and a default value was added to edu_project_template, and this PR is flagged as breaking change (not for patch release)
  - [ ] A description for the new variable has been added to EDU documentation site [here](https://github.com/edanalytics/edu_docs/blob/main/docs/docs/manage_extend/reference/configure_dbt_vars.md) 
