### PR TITLE
Fix/add assessment_family

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 ## New features
 ## Under the hood
 ## Fixes
+- Update join logic in `bld_ef3__student_assessments_long_results` and `cfg_assessment_scores` to  join on the `assessment_family` and/or `assessment_identifier` fields in `xwalk_assessment_scores`, if they have been provided.
+## Migration
+- Configure `xwalk_assessment_scores`. Add in `assessment_family` field and remove redundant records.
 
 # edu_wh v0.5.0
 ## New features

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,11 @@
 # Unreleased
 ## New features
 ## Under the hood
-- Update join logic in `bld_ef3__student_assessments_long_results` and `cfg_assessment_scores` to  join on the `assessment_family` and/or `assessment_identifier` fields in `xwalk_assessment_scores`, if they have been provided. This allows for score configuration by either assess ID or family
 ## Fixes
+
+# edu_wh v0.5.1
+## Under the hood
+- Update join logic in `bld_ef3__student_assessments_long_results` and `cfg_assessment_scores` to  join on the `assessment_family` and/or `assessment_identifier` fields in `xwalk_assessment_scores`, if they have been provided. This allows for score configuration by either assess ID or family
 ## Migration
 - (Optional) Configure `xwalk_assessment_scores`. Add in `assessment_family` field and remove redundant records.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,10 @@
 # Unreleased
 ## New features
 ## Under the hood
+- Update join logic in `bld_ef3__student_assessments_long_results` and `cfg_assessment_scores` to  join on the `assessment_family` and/or `assessment_identifier` fields in `xwalk_assessment_scores`, if they have been provided. This allows for score configuration by either assess ID or family
 ## Fixes
-- Update join logic in `bld_ef3__student_assessments_long_results` and `cfg_assessment_scores` to  join on the `assessment_family` and/or `assessment_identifier` fields in `xwalk_assessment_scores`, if they have been provided.
 ## Migration
-- Configure `xwalk_assessment_scores`. Add in `assessment_family` field and remove redundant records.
+- (Optional) Configure `xwalk_assessment_scores`. Add in `assessment_family` field and remove redundant records.
 
 # edu_wh v0.5.0
 ## New features

--- a/models/build/edfi_3/assessments/bld_ef3__student_assessments_long_results.sql
+++ b/models/build/edfi_3/assessments/bld_ef3__student_assessments_long_results.sql
@@ -9,7 +9,16 @@ with assessment_family_lookup as (
     from {{ ref('dim_assessment') }}
 ),
 score_results as (
-    select * from {{ ref('stg_ef3__student_assessments__score_results') }}
+    select
+        tenant_code,
+        api_year,
+        k_student_assessment,
+        k_assessment,
+        assessment_identifier,
+        namespace,
+        score_name,
+        score_result 
+    from {{ ref('stg_ef3__student_assessments__score_results') }}
 ),
 xwalk_scores as (
     select * from {{ ref('xwalk_assessment_scores') }}

--- a/tests/config_tests/cfg_assessment_scores.sql
+++ b/tests/config_tests/cfg_assessment_scores.sql
@@ -21,16 +21,19 @@ joined as (
     select distinct
         fct_student_assessment.tenant_code, 
         fct_student_assessment.school_year,
-        dim_assessment.assessment_identifier
+        dim_assessment.assessment_identifier,
+        dim_assessment.assessment_family
     from fct_student_assessment
     join dim_assessment 
         on fct_student_assessment.k_assessment = 
             dim_assessment.k_assessment
     left join xwalk_assessment_scores
-        on dim_assessment.assessment_identifier = 
-            xwalk_assessment_scores.assessment_identifier
+        -- Join on assessment_identifier and/or assessment_family if present in xwalk_assessment_scores
+        on ifnull(xwalk_assessment_scores.assessment_identifier, '1') = iff(xwalk_assessment_scores.assessment_identifier is null, '1', dim_assessment.assessment_identifier)
+        and ifnull(xwalk_assessment_scores.assessment_family, '1') = iff(xwalk_assessment_scores.assessment_family is null, '1', dim_assessment.assessment_family)
 
-    where xwalk_assessment_scores.assessment_identifier is null
+    where 
+        xwalk_assessment_scores.assessment_identifier is null and xwalk_assessment_scores.assessment_family is null
     order by assessment_identifier
 )
 


### PR DESCRIPTION
## Description & motivation
Configure `bld_ef3__student_assessments_long_results` model and `cfg_assessment_scores` test to support joining to `xwalk_assessment_scores` seed table using `assessment_family`, `assessment_identifier`, or both.

## PR Merge Priority:
- [x] Low
- [ ] Medium
- [ ] High

## Changes to existing files:
- `bld_ef3__student_assessments_long_results`: Updated join code to join on `assessment_family` and/or `assessment_identifier` to account for cases where it may be preferable to use one field instead of the other in the `xwalk_assessment_scores` seed (e.g., for IB records)
- `cfg_assessment_scores`: Updated to return records where both `assessment_family` and `assessment_identifier` are null in the `xwalk_assessment_scores` seed.
- `changelog`: Updated changelog to describe changes.

## Tests and QC done:
- Ran dbt model and test and ensured changes were successful.

## edu_wh PR Review Checklist:
Make sure the following have been completed before approving this PR:
- [ ] Description of changes has been added to Unreleased section of [CHANGELOG.md](/CHANGELOG.md). Add under `## New Features` for features, etc.
- [ ] Code has been tested/checked for Databricks and Snowflake compatibility - EA engineers see Databricks checklist [here](https://edanalytics.slite.com/app/docs/LRjXFxVRAWA5ST) 
- [ ] Reviewer confirms the grain of all tables are unchanged, OR any changes are expected, communicated, and this PR is flagged as a breaking change (not for patch release)
- [ ] If a new configuration xwalk was added:
  - [ ] The code is written such that the xwalk is optional (preferred), and this behavior was tested, OR
  - [ ] The code is written such that the xwalk is required, and the required xwalk is added to edu_project_template, and this PR is flagged as breaking change (not for patch release)
  - [ ] A description for the new xwalk has been added to EDU documentation site [here](https://github.com/edanalytics/edu_docs/blob/main/docs/docs/manage_extend/reference/configure_dbt_xwalks.md) 
- [ ] If a new configuration variable was added:
  - [ ] The code is written such that the variable is optional (preferred), and this behavior was tested, OR
  - [ ] The code is written such that the variable is required, and a default value was added to edu_project_template, and this PR is flagged as breaking change (not for patch release)
  - [ ] A description for the new variable has been added to EDU documentation site [here](https://github.com/edanalytics/edu_docs/blob/main/docs/docs/manage_extend/reference/configure_dbt_vars.md) 

<!---## Future ToDos & Questions:-->
<!---
[Optional] Include any future steps and questions related to this PR.
-->
