### PR TITLE
Fix/stad 67

### DIFF
--- a/models/core_warehouse/fct_student_daily_attendance.sql
+++ b/models/core_warehouse/fct_student_daily_attendance.sql
@@ -31,7 +31,7 @@ school_max_submitted as (
     -- find the most recently submitted attendance date by school
     select 
         fct_student_school_att.k_school,
-        fct_student_school_att.school_year,
+        dim_calendar_date.school_year,
         max(dim_calendar_date.calendar_date) as max_date_by_school
     from fct_student_school_att 
     join dim_calendar_date 
@@ -49,6 +49,7 @@ attendance_calendar as (
     from dim_calendar_date
     join school_max_submitted
         on dim_calendar_date.k_school = school_max_submitted.k_school
+        and dim_calendar_date.school_year = school_max_submitted.school_year
     -- only include instructional days in the attendance calendar
     where dim_calendar_date.is_school_day
     -- don't include dates in the future, as of run-time

--- a/models/core_warehouse/fct_student_daily_attendance.sql
+++ b/models/core_warehouse/fct_student_daily_attendance.sql
@@ -31,11 +31,12 @@ school_max_submitted as (
     -- find the most recently submitted attendance date by school
     select 
         fct_student_school_att.k_school,
+        fct_student_school_att.school_year,
         max(dim_calendar_date.calendar_date) as max_date_by_school
     from fct_student_school_att 
     join dim_calendar_date 
         on fct_student_school_att.k_calendar_date = dim_calendar_date.k_calendar_date
-    group by 1
+    group by 1, 2
 ),
 attendance_calendar as (
     -- a dataset of all possible days on which school attendance could be recorded


### PR DESCRIPTION
Fix/stad 67


## Description & motivation
This PR addresses [JIRA STAD-67](https://edanalytics.atlassian.net/browse/STAD-67?linkSource=email). If a tenant has multiple years of data flowing to Stadium, has attendance data correctly flowing in the latest year, but in some prior year has everything BUT attendance data flowing, then `fct_student_daily_attendance` is incorrectly reading this as 100% attendance for the prior year.  The model looks for a 'maximum submitted attendance date' to ensure that attendance is only counted through when attendance was actually submitted and currently only takes school into account, which for past years will give an incorrect 'school_max_submitted.max_date_by_school' (will always be the max submit date of the current school year).  This PR fixes this by grouping by both school and year to give an accurate max submit date.  An additional condition had to be added to use the last calendar date instead of the max submitted date if the attendance event is in an historical year. This is to ensure that dates in between the last attendance event and the last day of the calendar are included in attendance.

## Breaking changes introduced by this PR:
This PR will change attendance rates that were mistakenly counted as 100% due to missing attendance event data.

Make sure to include these breaking changes in the CHANGELOG.md

## PR Merge Priority:
<!---
This checklist helps the reviewers understand the level of priority for merging this PR.
A loose description of merging priority levels is:
Low: A week or more.
Medium: Within 3 days or less.
High: As soon as possible.
-->
- [ ] Low
- [x] Medium
- [ ] High

<!---
If High Priority, explain why as a comment below.
-->

## Changes to existing files:
<!---
Include this section if you are changing any existing files or creating breaking changes to existing files. Label the model name and describe the logic behind the changes made, try to be very descriptive here. For example:
- `stg_model` : Describe any changes made to `stg_model` and why the changes where made.
- `src_staging` : Describe any changes made to `src_staging` and why the changes where made.
-->
- `fct_student_daily_attendance` : `max_calendar` cte added. `or` condition added to `attendance_calendar` cte. `school_year` added to `group by` in `school_max_submitted` cte.

## New files created:
<!---
Include this section if you are creating any new files. Label the model name and describe the logic behind the changes made, try to be very descriptive here. For example:
- `stg_new_model` : Describe the purpose of `stg_new_model` and the logic behind creating the model.
- `src_new_staging` : Describe the purpose of `src_new_staging`.
-->
none

## Tests and QC done:
<!---
Describe any process that confirms that the files do what is expected, include screenshots if relevant. For example:
- Analyst replication confirmed that updates to `stg_model` new counts were correct.
- Executed a dbt project run and ensured it was successful.
-->
- Tested in both `stadium_txexchange` and `stadium_boston` warehouses.

## edu_wh PR Review Checklist:
Make sure the following have been completed before approving this PR:
- [ ] Description of changes has been added to Unreleased section of [CHANGELOG.md](/CHANGELOG.md). Add under `## New Features` for features, etc.
- [ ] Code has been tested/checked for Databricks and Snowflake compatibility - EA engineers see Databricks checklist [here](https://edanalytics.slite.com/app/docs/LRjXFxVRAWA5ST) 
- [ ] Reviewer confirms the grain of all tables are unchanged, OR any changes are expected, communicated, and this PR is flagged as a breaking change (not for patch release)
- [ ] If a new configuration xwalk was added:
  - [ ] The code is written such that the xwalk is optional (preferred), and this behavior was tested, OR
  - [ ] The code is written such that the xwalk is required, and the required xwalk is added to edu_project_template, and this PR is flagged as breaking change (not for patch release)
  - [ ] A description for the new xwalk has been added to EDU documentation site [here](https://github.com/edanalytics/edu_docs/blob/main/docs/docs/manage_extend/reference/configure_dbt_xwalks.md) 
- [ ] If a new configuration variable was added:
  - [ ] The code is written such that the variable is optional (preferred), and this behavior was tested, OR
  - [ ] The code is written such that the variable is required, and a default value was added to edu_project_template, and this PR is flagged as breaking change (not for patch release)
  - [ ] A description for the new variable has been added to EDU documentation site [here](https://github.com/edanalytics/edu_docs/blob/main/docs/docs/manage_extend/reference/configure_dbt_vars.md) 

<!---## Future ToDos & Questions:-->
<!---
[Optional] Include any future steps and questions related to this PR.
-->
