### PR TITLE
Fix `fct_student_discipline_actions` column `name` typo in YAML docs

### DIFF
--- a/models/core_warehouse/fct_student_discipline_actions.yml
+++ b/models/core_warehouse/fct_student_discipline_actions.yml
@@ -138,7 +138,7 @@ models:
       - name: k_school__responsibility
         description: >
           The school responsible for the student's discipline
-      - name: k_discipline_actions_event >
+      - name: k_discipline_actions_event
         description: >
           A key containing discipline_action_id and discipline_date to represent a single discipline event.
       - name: k_staff


### PR DESCRIPTION
## Description & motivation
I found this typo in `fct_student_discipline_actions.yml`, the column name accidentally has a carat at the end (`k_discipline_actions_event >`) when it should not (`k_discipline_actions_event`).

## Breaking changes introduced by this PR:
(None)

## PR Merge Priority:
- [x] Low
- [ ] Medium
- [ ] High

## edu_wh PR Review Checklist:
Make sure the following have been completed before approving this PR:
- [ ] Description of changes has been added to Unreleased section of [CHANGELOG.md](/CHANGELOG.md). Add under `## New Features` for features, etc.
- [ ] Code has been tested/checked for Databricks and Snowflake compatibility - EA engineers see Databricks checklist [here](https://edanalytics.slite.com/app/docs/LRjXFxVRAWA5ST) 
- [ ] Reviewer confirms the grain of all tables are unchanged, OR any changes are expected, communicated, and this PR is flagged as a breaking change (not for patch release)
- [ ] If a new configuration xwalk was added:
  - [ ] The code is written such that the xwalk is optional (preferred), and this behavior was tested, OR
  - [ ] The code is written such that the xwalk is required, and the required xwalk is added to edu_project_template, and this PR is flagged as breaking change (not for patch release)
  - [ ] A description for the new xwalk has been added to EDU documentation site [here](https://github.com/edanalytics/edu_docs/blob/main/docs/docs/manage_extend/reference/configure_dbt_xwalks.md) 
- [ ] If a new configuration variable was added:
  - [ ] The code is written such that the variable is optional (preferred), and this behavior was tested, OR
  - [ ] The code is written such that the variable is required, and a default value was added to edu_project_template, and this PR is flagged as breaking change (not for patch release)
  - [ ] A description for the new variable has been added to EDU documentation site [here](https://github.com/edanalytics/edu_docs/blob/main/docs/docs/manage_extend/reference/configure_dbt_vars.md) 
