### PR TITLE
fix/dbt_test_failure_fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,6 @@
 # Unreleased
+- Updated tests `dbt_utils_unique_combination_of_columns_fct_student_language_instruction_program_association_k_student__k_program`, `dbt_utils_unique_combination_of_columns_fct_student_program_association_k_student__k_program`, and `dbt_utils_unique_combination_of_columns_fct_student_title_i_part_a_program_association_k_student__k_program` to include two additional columns. Previous test only listed partial primary key. 
+
 ## New features
 ## Under the hood
 - Add `begin_date` to primary key of `fct_staff_section_associations` to align with DS 5.0 and later

--- a/models/core_warehouse/fct_student_language_instruction_program_association.yml
+++ b/models/core_warehouse/fct_student_language_instruction_program_association.yml
@@ -18,6 +18,8 @@ models:
           combination_of_columns:
             - k_student
             - k_program
+            - k_student_xyear
+            - program_enroll_begin_date
 
     columns:
       - name: k_student

--- a/models/core_warehouse/fct_student_program_association.yml
+++ b/models/core_warehouse/fct_student_program_association.yml
@@ -14,6 +14,8 @@ models:
           combination_of_columns:
             - k_student
             - k_program
+            - k_student_xyear
+            - program_enroll_begin_date
     columns:
       - name: k_student
       - name: k_student_xyear

--- a/models/core_warehouse/fct_student_title_i_part_a_program_association.yml
+++ b/models/core_warehouse/fct_student_title_i_part_a_program_association.yml
@@ -18,6 +18,8 @@ models:
           combination_of_columns:
             - k_student
             - k_program
+            - k_student_xyear
+            - program_enroll_begin_date
 
     columns:
       - name: k_student


### PR DESCRIPTION
# fix/dbt_test_failure_unique_combinatoin

## Description & motivation
Fixed three DBT test failures all associated with the same issue. The Unique column combination test only listed partial primary keys for all three models. I added the remaining columns. 

## Breaking changes introduced by this PR:
No breaking changes. The updates were made only to .yml files for three serrate models. 

## PR Merge Priority:
- [x] Low
- [ ] Medium
- [ ] High


## Changes to existing files:
- `fct_student_language_instruction_program_association.yml` : Added two additional columns to the unique column combination test. 
- `fct_student_program_association.yml` : Added two additional columns to the unique column combination test. 
- `fct_student_title_i_part_a_program_association.yml`:  Added two additional columns to the unique column combination test. 

## Tests and QC done:

- Ran previously failing DBT tests locally to ensure they were no longer failing. 


## edu_wh PR Review Checklist:
Make sure the following have been completed before approving this PR:
- [x] Description of changes has been added to Unreleased section of [CHANGELOG.md](/CHANGELOG.md). Add under `## New Features` for features, etc.
- [x] Code has been tested/checked for Databricks and Snowflake compatibility - EA engineers see Databricks checklist [here](https://edanalytics.slite.com/app/docs/LRjXFxVRAWA5ST) 
- [x] Reviewer confirms the grain of all tables are unchanged, OR any changes are expected, communicated, and this PR is flagged as a breaking change (not for patch release)
- [ ] If a new configuration xwalk was added:
  - [ ] The code is written such that the xwalk is optional (preferred), and this behavior was tested, OR
  - [ ] The code is written such that the xwalk is required, and the required xwalk is added to edu_project_template, and this PR is flagged as breaking change (not for patch release)
  - [ ] A description for the new xwalk has been added to EDU documentation site [here](https://github.com/edanalytics/edu_docs/blob/main/docs/docs/manage_extend/reference/configure_dbt_xwalks.md) 
- [ ] If a new configuration variable was added:
  - [ ] The code is written such that the variable is optional (preferred), and this behavior was tested, OR
  - [ ] The code is written such that the variable is required, and a default value was added to edu_project_template, and this PR is flagged as breaking change (not for patch release)
  - [ ] A description for the new variable has been added to EDU documentation site [here](https://github.com/edanalytics/edu_docs/blob/main/docs/docs/manage_extend/reference/configure_dbt_vars.md) 

<!---## Future ToDos & Questions:-->
<!---
[Optional] Include any future steps and questions related to this PR.
-->
