### PR TITLE
Feature/Staff Safe Display Name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Unreleased
 - Updated tests `dbt_utils_unique_combination_of_columns_fct_student_language_instruction_program_association_k_student__k_program`, `dbt_utils_unique_combination_of_columns_fct_student_program_association_k_student__k_program`, and `dbt_utils_unique_combination_of_columns_fct_student_title_i_part_a_program_association_k_student__k_program` to include two additional columns. Previous test only listed partial primary key. 
+- Add `safe_display_name` to `dim_staff`, the logic for this column replicates that of `bld_ef3__immutable_stu_demos`.
 
 ## New features
 ## Under the hood

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,8 @@
 # Unreleased
 - Updated tests `dbt_utils_unique_combination_of_columns_fct_student_language_instruction_program_association_k_student__k_program`, `dbt_utils_unique_combination_of_columns_fct_student_program_association_k_student__k_program`, and `dbt_utils_unique_combination_of_columns_fct_student_title_i_part_a_program_association_k_student__k_program` to include two additional columns. Previous test only listed partial primary key. 
-- Add `safe_display_name` to `dim_staff`, the logic for this column replicates that of `bld_ef3__immutable_stu_demos`.
-
 ## New features
 ## Under the hood
+- Add `safe_display_name` to `dim_staff`, the logic for this column replicates that of `bld_ef3__immutable_stu_demos`.
 ## Fixes
 
 # edu_wh v0.5.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,13 @@
 # Unreleased
-- Updated tests `dbt_utils_unique_combination_of_columns_fct_student_language_instruction_program_association_k_student__k_program`, `dbt_utils_unique_combination_of_columns_fct_student_program_association_k_student__k_program`, and `dbt_utils_unique_combination_of_columns_fct_student_title_i_part_a_program_association_k_student__k_program` to include two additional columns. Previous test only listed partial primary key. 
 ## New features
 ## Under the hood
+## Fixes
+
+# edu_wh v0.5.2
+## New features
 - Add `safe_display_name` to `dim_staff`, the logic for this column replicates that of `bld_ef3__immutable_stu_demos`.
 ## Fixes
+- Updated tests `dbt_utils_unique_combination_of_columns_fct_student_language_instruction_program_association_k_student__k_program`, `dbt_utils_unique_combination_of_columns_fct_student_program_association_k_student__k_program`, and `dbt_utils_unique_combination_of_columns_fct_student_title_i_part_a_program_association_k_student__k_program` to include two additional columns. Previous test only listed partial primary key. 
 
 # edu_wh v0.5.1
 ## New features

--- a/dbt_project.yml
+++ b/dbt_project.yml
@@ -1,7 +1,7 @@
 config-version: 2
 
 name: 'edu_wh'
-version: '0.5.1'
+version: '0.5.2'
 require-dbt-version: [">=1.0.0", "<2.0.0"]
 
 # This setting configures which "profile" dbt uses for this project.

--- a/models/core_warehouse/dim_staff.sql
+++ b/models/core_warehouse/dim_staff.sql
@@ -38,6 +38,7 @@ formatted as (
         choose_email.email_address,
         choose_email.email_type,
         stg_staff.last_name || ', ' || stg_staff.first_name as display_name,
+        concat(display_name, ' (', stg_staff.staff_unique_id, ')') as safe_display_name,
         stg_staff.first_name,
         stg_staff.last_name,
         stg_staff.middle_name,


### PR DESCRIPTION
## Description & motivation
Added `safe_display_name` to `dim_staff`. The logic for this column is replicated from `dim_student`.

## Breaking changes introduced by this PR:
None

## PR Merge Priority:
- [ ] Low
- [ ] Medium
- [x] High  --> The September release of `edu_ext_podium` will depend on this column.

## Tests and QC done:
- Executed a dbt project run and ensured it was successful.
- Ensured no duplicates were created through the creation of the column.
- Ensured the column concatenated the right columns and outputted the right formatting.

## edu_wh PR Review Checklist:
Make sure the following have been completed before approving this PR:
- [x] Description of changes has been added to Unreleased section of [CHANGELOG.md](/CHANGELOG.md). Add under `## New Features` for features, etc.
- [x] Code has been tested/checked for Databricks and Snowflake compatibility - EA engineers see Databricks checklist [here](https://edanalytics.slite.com/app/docs/LRjXFxVRAWA5ST) 
- [x] Reviewer confirms the grain of all tables are unchanged, OR any changes are expected, communicated, and this PR is flagged as a breaking change (not for patch release)
- [ ] If a new configuration xwalk was added:
  - [ ] The code is written such that the xwalk is optional (preferred), and this behavior was tested, OR
  - [ ] The code is written such that the xwalk is required, and the required xwalk is added to edu_project_template, and this PR is flagged as breaking change (not for patch release)
  - [ ] A description for the new xwalk has been added to EDU documentation site [here](https://github.com/edanalytics/edu_docs/blob/main/docs/docs/manage_extend/reference/configure_dbt_xwalks.md) 
- [ ] If a new configuration variable was added:
  - [ ] The code is written such that the variable is optional (preferred), and this behavior was tested, OR
  - [ ] The code is written such that the variable is required, and a default value was added to edu_project_template, and this PR is flagged as breaking change (not for patch release)
  - [ ] A description for the new variable has been added to EDU documentation site [here](https://github.com/edanalytics/edu_docs/blob/main/docs/docs/manage_extend/reference/configure_dbt_vars.md) 
