### PR TITLE
fix/: fct_student_diploma sort_index hard-coded NULL casted to int

### DIFF
--- a/models/core_warehouse/fct_student_diploma.sql
+++ b/models/core_warehouse/fct_student_diploma.sql
@@ -51,7 +51,7 @@ joined_with_xwalk as (
         {% if xwalk_academic_term_enabled %} 
         xwalk_academic_terms.sort_index
         {% else %}
-        NULL as sort_index
+        cast(NULL as int) as sort_index
         {% endif %}
     from joined_diploma
     {% if xwalk_academic_term_enabled %}


### PR DESCRIPTION
## Description & motivation
Databricks (or DBT?) assigns a data type of "void" to columns where every field is null. This breaks being able to do something simple like "select *" within databricks web ui (and other places). Casted this column to an int data type when it is hard coded to null.

## Breaking changes introduced by this PR:
Should be none. But I cannot test in Snowflake.

## PR Merge Priority:
- [X] Low
- [ ] Medium
- [ ] High

## Changes to existing files:
`fct_student_diploma.sql`: Casted NULL as sort_index to int so that databricks (or dbt?) doesn't flip out trying to show a void type

## New files created:
None

## Tests and QC done:
Tested locally in TN. select * on fct_student_diploma now doesn't throw crazy errors.

## edu_wh PR Review Checklist:
Make sure the following have been completed before approving this PR:
- [ ] Description of changes has been added to Unreleased section of [CHANGELOG.md](/CHANGELOG.md). Add under `## New Features` for features, etc.
- [ ] Code has been tested/checked for Databricks and Snowflake compatibility - EA engineers see Databricks checklist [here](https://edanalytics.slite.com/app/docs/LRjXFxVRAWA5ST) 
- [ ] Reviewer confirms the grain of all tables are unchanged, OR any changes are expected, communicated, and this PR is flagged as a breaking change (not for patch release)
- [ ] If a new configuration xwalk was added:
  - [ ] The code is written such that the xwalk is optional (preferred), and this behavior was tested, OR
  - [ ] The code is written such that the xwalk is required, and the required xwalk is added to edu_project_template, and this PR is flagged as breaking change (not for patch release)
  - [ ] A description for the new xwalk has been added to EDU documentation site [here](https://github.com/edanalytics/edu_docs/blob/main/docs/docs/manage_extend/reference/configure_dbt_xwalks.md) 
- [ ] If a new configuration variable was added:
  - [ ] The code is written such that the variable is optional (preferred), and this behavior was tested, OR
  - [ ] The code is written such that the variable is required, and a default value was added to edu_project_template, and this PR is flagged as breaking change (not for patch release)
  - [ ] A description for the new variable has been added to EDU documentation site [here](https://github.com/edanalytics/edu_docs/blob/main/docs/docs/manage_extend/reference/configure_dbt_vars.md) 

<!---## Future ToDos & Questions:-->
None
