### PR TITLE
Enhancements so that EDU release 0.6.2 works in Databricks.

### DIFF
--- a/macros/accordion_columns.sql
+++ b/macros/accordion_columns.sql
@@ -9,8 +9,11 @@ be included in a table.
   - coalesce_value: if this value is specified, a coalesce function will be added with
     this value as the second parameter (to be returned if the value in the column is null).
     If none (default), the coalesce function will not be added.
+  - add_trailing_comma: if this value is specified, a trailing comma will be added to the last
+    column. If not passed in, a trailing comma is added for backward compatibility
 -#}
-{% macro accordion_columns(source_table, exclude_columns, source_alias=none, coalesce_value=none) %}
+
+{% macro accordion_columns(source_table, exclude_columns, source_alias=none, coalesce_value=none, add_trailing_comma=true) %}
   {%- if source_alias is none -%}
    {%- set source_alias = source_table -%} 
   {%- endif -%}
@@ -20,11 +23,11 @@ be included in a table.
     ) %}
   {%- if coalesce_value is none %}
     {%- for col in keep_cols %}
-      {{ source_alias }}.{{ col }},
+      {{ source_alias }}.{{ col }}{% if not loop.last %},{% elif add_trailing_comma %},{% endif %}
     {%- endfor %}
   {%- else -%}
     {%- for col in keep_cols %}
-      coalesce({{ source_alias }}.{{ col }}, {{ coalesce_value }}) as {{ col }},
+      coalesce({{ source_alias }}.{{ col }}, {{ coalesce_value }}) as {{ col }}{% if not loop.last %},{% elif add_trailing_comma %},{% endif %}
     {%- endfor %}  
   {%- endif -%}
 {% endmacro %}

--- a/models/build/edfi_3/assessments/bld_ef3__student_assessment_cross_tenant.sql
+++ b/models/build/edfi_3/assessments/bld_ef3__student_assessment_cross_tenant.sql
@@ -155,18 +155,18 @@ from deduped_assessments
   -- if this feature is not turned on, force return a zero row table
   select *
   from (select
-          null::varchar as tenant_code,
+          null::{{ dbt.type_string() }} as tenant_code,
           null::int as school_year,
           null::int as api_year,
-          null::varchar as k_student,
-          null::varchar as k_student_xyear,
-          null::varchar as k_assessment,
-          null::varchar as k_student_assessment,
-          null::varchar as k_student_assessment__original,
-          null::varchar as k_assessment__original,
-          null::varchar as student_unique_id,
+          null::{{ dbt.type_string() }} as k_student,
+          null::{{ dbt.type_string() }} as k_student_xyear,
+          null::{{ dbt.type_string() }} as k_assessment,
+          null::{{ dbt.type_string() }} as k_student_assessment,
+          null::{{ dbt.type_string() }} as k_student_assessment__original,
+          null::{{ dbt.type_string() }} as k_assessment__original,
+          null::{{ dbt.type_string() }} as student_unique_id,
           null::boolean as is_original_record,
-          null::varchar as original_tenant_code
+          null::{{ dbt.type_string() }} as original_tenant_code
        ) blank_subquery
   limit 0
 {% endif %}

--- a/models/build/edfi_3/assessments/bld_ef3__student_objective_assessment_cross_tenant.sql
+++ b/models/build/edfi_3/assessments/bld_ef3__student_objective_assessment_cross_tenant.sql
@@ -62,21 +62,21 @@ select * from deduped
 
 select * from (
     select
-        null::varchar as k_student_objective_assessment,
-        null::varchar as k_objective_assessment,
-        null::varchar as k_student_objective_assessment__original,
-        null::varchar as k_objective_assessment__original,
-        null::varchar as k_student_assessment,
-        null::varchar as k_student_assessment__original,
-        null::varchar as k_student,
-        null::varchar as k_student_xyear,
-        null::varchar as k_assessment,
-        null::varchar as k_assessment__original,
-        null::varchar as tenant_code,
+        null::{{ dbt.type_string() }} as k_student_objective_assessment,
+        null::{{ dbt.type_string() }} as k_objective_assessment,
+        null::{{ dbt.type_string() }} as k_student_objective_assessment__original,
+        null::{{ dbt.type_string() }} as k_objective_assessment__original,
+        null::{{ dbt.type_string() }} as k_student_assessment,
+        null::{{ dbt.type_string() }} as k_student_assessment__original,
+        null::{{ dbt.type_string() }} as k_student,
+        null::{{ dbt.type_string() }} as k_student_xyear,
+        null::{{ dbt.type_string() }} as k_assessment,
+        null::{{ dbt.type_string() }} as k_assessment__original,
+        null::{{ dbt.type_string() }} as tenant_code,
         null::int as school_year,
         null::int as api_year,
         null::boolean as is_original_record,
-        null::varchar as original_tenant_code
+        null::{{ dbt.type_string() }} as original_tenant_code
 ) limit 0
 
 {% endif %}

--- a/models/core_warehouse/fct_student_assessment.sql
+++ b/models/core_warehouse/fct_student_assessment.sql
@@ -43,7 +43,8 @@ combined_with_cross_tenant as (
         {{ accordion_columns(
             source_table='stg_ef3__student_assessments',
             source_alias='student_assessments',
-            exclude_columns=['k_student_assessment', 'k_assessment', 'k_student', 'k_student_xyear', 'tenant_code', 'school_year']) }}
+            exclude_columns=['k_student_assessment', 'k_assessment', 'k_student', 'k_student_xyear', 'tenant_code', 'school_year'],
+            add_trailing_comma=false) }}
     from student_assessments
     -- left join because this model can return empty
         -- and to avoid enforcing a current school association

--- a/models/core_warehouse/fct_student_daily_attendance.sql
+++ b/models/core_warehouse/fct_student_daily_attendance.sql
@@ -233,7 +233,7 @@ cumulatives as (
         cumulative_days_enrolled >= {{ var('edu:attendance:chronic_absence_min_days') }} as meets_enrollment_threshold,
         {{ msr_chronic_absentee('cumulative_attendance_rate', 'cumulative_days_enrolled') }} as is_chronic_absentee,
         excusal_status_streaks.event_duration,
-        excusal_status_streaks.school_attendance_duration,
+        excusal_status_streaks.school_attendance_duration
     from excusal_status_streaks
 ),
 metric_labels as (

--- a/models/core_warehouse/fct_student_objective_assessment.sql
+++ b/models/core_warehouse/fct_student_objective_assessment.sql
@@ -47,7 +47,8 @@ combined_with_cross_tenant as (
         {{ accordion_columns(
             source_table='stg_ef3__student_objective_assessments',
             source_alias='student_obj_assessments',
-            exclude_columns=['k_student_objective_assessment', 'k_objective_assessment', 'k_student_assessment', 'k_assessment', 'k_student', 'k_student_xyear', 'tenant_code', 'school_year']) }}
+            exclude_columns=['k_student_objective_assessment', 'k_objective_assessment', 'k_student_assessment', 'k_assessment', 'k_student', 'k_student_xyear', 'tenant_code', 'school_year'],
+            add_trailing_comma=false) }}
     from student_obj_assessments
     -- left join because this model can return empty
         -- and to avoid enforcing a current school association


### PR DESCRIPTION
## Description & motivation
In order to use 0.6.2 within Databricks I had to make these changes.

## Breaking changes introduced by this PR:
None.

## PR Merge Priority:
- [X] Low
- [ ] Medium
- [ ] High

## Changes to existing files:
accordion_columns.sql - needed to add an additional, backward compatible, flag for "add_trailing_comma" so that the trailing comma can be controlled since databricks hates trailing commas. this is backward compatible with the existing function.
bld_ef3__student_assessment_cross_tenant.sql‎ - had to change the null::varchar columns so that dbt will pick String for databricks instead of varchar since databricks wants varchars to have lengths defined.
bld_ef3__student_objective_assessment_cross_tenant.sql - same as above
fct_student_assessment.sql - uses the accordion columns change mentioned above to remove the trailing comma
fct_student_daily_attendance.sql - fixed a stray trailing comma
fct_student_objective_assessment.sql - uses the accordion columns change mentioned above to remove the trailing comma

## New files created:
None

## Tests and QC done:
Tested using stadium_tennessee code that uses the 0.6.2 release with these changes.

## edu_wh PR Review Checklist:
Make sure the following have been completed before approving this PR:
- [ ] Description of changes has been added to Unreleased section of [CHANGELOG.md](/CHANGELOG.md). Add under `## New Features` for features, etc.
- [ ] Code has been tested/checked for Databricks and Snowflake compatibility - EA engineers see Databricks checklist [here](https://edanalytics.slite.com/app/docs/LRjXFxVRAWA5ST) 
- [ ] Reviewer confirms the grain of all tables are unchanged, OR any changes are expected, communicated, and this PR is flagged as a breaking change (not for patch release)
- [ ] If a new configuration xwalk was added:
  - [ ] The code is written such that the xwalk is optional (preferred), and this behavior was tested, OR
  - [ ] The code is written such that the xwalk is required, and the required xwalk is added to edu_project_template, and this PR is flagged as breaking change (not for patch release)
  - [ ] A description for the new xwalk has been added to EDU documentation site [here](https://github.com/edanalytics/edu_docs/blob/main/docs/docs/manage_extend/reference/configure_dbt_xwalks.md) 
- [ ] If a new configuration variable was added:
  - [ ] The code is written such that the variable is optional (preferred), and this behavior was tested, OR
  - [ ] The code is written such that the variable is required, and a default value was added to edu_project_template, and this PR is flagged as breaking change (not for patch release)
  - [ ] A description for the new variable has been added to EDU documentation site [here](https://github.com/edanalytics/edu_docs/blob/main/docs/docs/manage_extend/reference/configure_dbt_vars.md) 
