### PR TITLE
feature/tdoe student program assoc enhancements 0.6.2

### DIFF
--- a/macros/accordion_columns.sql
+++ b/macros/accordion_columns.sql
@@ -9,8 +9,11 @@ be included in a table.
   - coalesce_value: if this value is specified, a coalesce function will be added with
     this value as the second parameter (to be returned if the value in the column is null).
     If none (default), the coalesce function will not be added.
+  - add_trailing_comma: if this value is specified, a trailing comma will be added to the last
+    column. If not passed in, a trailing comma is added for backward compatibility
 -#}
-{% macro accordion_columns(source_table, exclude_columns, source_alias=none, coalesce_value=none) %}
+
+{% macro accordion_columns(source_table, exclude_columns, source_alias=none, coalesce_value=none, add_trailing_comma=true) %}
   {%- if source_alias is none -%}
    {%- set source_alias = source_table -%} 
   {%- endif -%}
@@ -20,11 +23,11 @@ be included in a table.
     ) %}
   {%- if coalesce_value is none %}
     {%- for col in keep_cols %}
-      {{ source_alias }}.{{ col }},
+      {{ source_alias }}.{{ col }}{% if not loop.last %},{% elif add_trailing_comma %},{% endif %}
     {%- endfor %}
   {%- else -%}
     {%- for col in keep_cols %}
-      coalesce({{ source_alias }}.{{ col }}, {{ coalesce_value }}) as {{ col }},
+      coalesce({{ source_alias }}.{{ col }}, {{ coalesce_value }}) as {{ col }}{% if not loop.last %},{% elif add_trailing_comma %},{% endif %}
     {%- endfor %}  
   {%- endif -%}
 {% endmacro %}

--- a/models/build/edfi_3/assessments/bld_ef3__student_assessment_cross_tenant.sql
+++ b/models/build/edfi_3/assessments/bld_ef3__student_assessment_cross_tenant.sql
@@ -155,18 +155,18 @@ from deduped_assessments
   -- if this feature is not turned on, force return a zero row table
   select *
   from (select
-          null::varchar as tenant_code,
+          null::{{ dbt.type_string() }} as tenant_code,
           null::int as school_year,
           null::int as api_year,
-          null::varchar as k_student,
-          null::varchar as k_student_xyear,
-          null::varchar as k_assessment,
-          null::varchar as k_student_assessment,
-          null::varchar as k_student_assessment__original,
-          null::varchar as k_assessment__original,
-          null::varchar as student_unique_id,
+          null::{{ dbt.type_string() }} as k_student,
+          null::{{ dbt.type_string() }} as k_student_xyear,
+          null::{{ dbt.type_string() }} as k_assessment,
+          null::{{ dbt.type_string() }} as k_student_assessment,
+          null::{{ dbt.type_string() }} as k_student_assessment__original,
+          null::{{ dbt.type_string() }} as k_assessment__original,
+          null::{{ dbt.type_string() }} as student_unique_id,
           null::boolean as is_original_record,
-          null::varchar as original_tenant_code
+          null::{{ dbt.type_string() }} as original_tenant_code
        ) blank_subquery
   limit 0
 {% endif %}

--- a/models/build/edfi_3/assessments/bld_ef3__student_objective_assessment_cross_tenant.sql
+++ b/models/build/edfi_3/assessments/bld_ef3__student_objective_assessment_cross_tenant.sql
@@ -62,21 +62,21 @@ select * from deduped
 
 select * from (
     select
-        null::varchar as k_student_objective_assessment,
-        null::varchar as k_objective_assessment,
-        null::varchar as k_student_objective_assessment__original,
-        null::varchar as k_objective_assessment__original,
-        null::varchar as k_student_assessment,
-        null::varchar as k_student_assessment__original,
-        null::varchar as k_student,
-        null::varchar as k_student_xyear,
-        null::varchar as k_assessment,
-        null::varchar as k_assessment__original,
-        null::varchar as tenant_code,
+        null::{{ dbt.type_string() }} as k_student_objective_assessment,
+        null::{{ dbt.type_string() }} as k_objective_assessment,
+        null::{{ dbt.type_string() }} as k_student_objective_assessment__original,
+        null::{{ dbt.type_string() }} as k_objective_assessment__original,
+        null::{{ dbt.type_string() }} as k_student_assessment,
+        null::{{ dbt.type_string() }} as k_student_assessment__original,
+        null::{{ dbt.type_string() }} as k_student,
+        null::{{ dbt.type_string() }} as k_student_xyear,
+        null::{{ dbt.type_string() }} as k_assessment,
+        null::{{ dbt.type_string() }} as k_assessment__original,
+        null::{{ dbt.type_string() }} as tenant_code,
         null::int as school_year,
         null::int as api_year,
         null::boolean as is_original_record,
-        null::varchar as original_tenant_code
+        null::{{ dbt.type_string() }} as original_tenant_code
 ) limit 0
 
 {% endif %}

--- a/models/build/edfi_3/students/bld_ef3__student__disabilities.sql
+++ b/models/build/edfi_3/students/bld_ef3__student__disabilities.sql
@@ -1,0 +1,36 @@
+-- Define all optional disability models here.
+{% set stage_disability_relations = [] %}
+
+--Ed Org Disabilities
+{% do stage_disability_relations.append(ref('stg_ef3__stu_ed_org__disabilities')) %}
+
+-- Special Education
+{% if var('src:program:special_ed:enabled', True) %}
+    {% do stage_disability_relations.append(ref('stg_ef3__stu_spec_ed__disabilities')) %}
+{% endif %}
+
+with stacked as (
+    {{ dbt_utils.union_relations(
+        relations=stage_disability_relations
+    ) }}
+),
+formatted as (
+    select 
+        tenant_code,
+        api_year,
+        school_year,
+        k_student,
+        ed_org_id,
+        k_lea,
+        k_school,
+        k_program,
+        program_enroll_begin_date,
+        program_enroll_end_date,
+        disability_type,
+        disability_source_type,
+        disability_diagnosis,
+        order_of_disability,
+        v_designations
+    from stacked
+)
+select * from formatted

--- a/models/build/edfi_3/students/bld_ef3__student__wide_disability_designations.sql
+++ b/models/build/edfi_3/students/bld_ef3__student__wide_disability_designations.sql
@@ -1,0 +1,45 @@
+with student_disabilities as (
+    select * from {{ ref('bld_ef3__student__disabilities') }}
+),
+xwalk_disability_designations as (
+    select * from {{ ref('xwalk_disability_designations') }}
+),
+flattened as (
+    select 
+        tenant_code,
+        api_year,
+        school_year,
+        k_student,
+        ed_org_id,
+        k_lea,
+        k_school,
+        k_program,
+        disability_type,
+        {{ edu_edfi_source.extract_descriptor('designation.value:disabilityDesignationDescriptor::string') }} as disability_designation
+    from student_disabilities
+        {{ edu_edfi_source.json_flatten('v_designations', 'designation', outer=true) }}
+),
+pivoted as (
+    select 
+        tenant_code,
+        api_year,
+        school_year,
+        k_student,
+        ed_org_id,
+        k_lea,
+        k_school,
+        k_program,
+        disability_type
+        {%- if not is_empty_model('xwalk_disability_designations') -%},
+            {{ ea_pivot(
+                    column='indicator_name',
+                    values=dbt_utils.get_column_values(ref('xwalk_disability_designations'), 'indicator_name'),
+                    cast='boolean',
+            ) }}
+        {%- endif %}
+    from flattened
+    left outer join xwalk_disability_designations 
+        on flattened.disability_designation = xwalk_disability_designations.disability_designation_descriptor
+    group by all
+)
+select * from pivoted

--- a/models/core_warehouse/fct_student_assessment.sql
+++ b/models/core_warehouse/fct_student_assessment.sql
@@ -43,7 +43,8 @@ combined_with_cross_tenant as (
         {{ accordion_columns(
             source_table='stg_ef3__student_assessments',
             source_alias='student_assessments',
-            exclude_columns=['k_student_assessment', 'k_assessment', 'k_student', 'k_student_xyear', 'tenant_code', 'school_year']) }}
+            exclude_columns=['k_student_assessment', 'k_assessment', 'k_student', 'k_student_xyear', 'tenant_code', 'school_year'],
+            add_trailing_comma=false) }}
     from student_assessments
     -- left join because this model can return empty
         -- and to avoid enforcing a current school association

--- a/models/core_warehouse/fct_student_cte_program_associations.sql
+++ b/models/core_warehouse/fct_student_cte_program_associations.sql
@@ -2,11 +2,13 @@
 {{ 
   config(
     post_hook=[
+        "alter table {{ this }} alter column k_student_program set not null",
         "alter table {{ this }} alter column k_student set not null",
         "alter table {{ this }} alter column k_student_xyear set not null",
         "alter table {{ this }} alter column k_program set not null",
         "alter table {{ this }} alter column program_enroll_begin_date set not null",
-        "alter table {{ this }} add primary key (k_student, k_student_xyear, k_program, program_enroll_begin_date)",
+        "alter table {{ this }} alter column ed_org_id set not null",
+        "alter table {{ this }} add primary key (k_student_program)",
         "alter table {{ this }} add constraint fk_{{ this.name }}_student foreign key (k_student) references {{ ref('dim_student') }}",
         "alter table {{ this }} add constraint fk_{{ this.name }}_program foreign key (k_program) references {{ ref('dim_program') }}"
     ]
@@ -27,11 +29,14 @@ dim_program as (
 
 formatted as (
     select
+        stage.k_student_program,
         dim_student.k_student,
         dim_student.k_student_xyear,
         dim_program.k_program,
         dim_program.k_lea,
         dim_program.k_school,
+        stage.ed_org_id,
+
         stage.tenant_code,
         dim_program.school_year,
         stage.program_enroll_begin_date,

--- a/models/core_warehouse/fct_student_cte_program_associations.yml
+++ b/models/core_warehouse/fct_student_cte_program_associations.yml
@@ -7,8 +7,7 @@ models:
         This fact table contains student cte program enrollment information.
 
       ##### Primary Key:
-        `k_student, k_student_xyear, k_program, program_enroll_begin_date` -- There 
-        is one record per student, year, program enrol begin date, and cte program.
+        `k_student_program` -- There is one record per student, year, ed_org_id, program enroll begin date, and cte program.
 
     config:
       tags: ['cte']
@@ -20,13 +19,17 @@ models:
             combination_of_columns:
               - k_student
               - k_program
+              - ed_org_id
+              - program_enroll_begin_date
 
     columns:
+      - name: k_student_program
       - name: k_student
       - name: k_student_xyear
       - name: k_program
       - name: k_lea
       - name: k_school
+      - name: ed_org_id
       - name: tenant_code
       - name: school_year
       - name: program_enroll_begin_date

--- a/models/core_warehouse/fct_student_daily_attendance.sql
+++ b/models/core_warehouse/fct_student_daily_attendance.sql
@@ -233,7 +233,7 @@ cumulatives as (
         cumulative_days_enrolled >= {{ var('edu:attendance:chronic_absence_min_days') }} as meets_enrollment_threshold,
         {{ msr_chronic_absentee('cumulative_attendance_rate', 'cumulative_days_enrolled') }} as is_chronic_absentee,
         excusal_status_streaks.event_duration,
-        excusal_status_streaks.school_attendance_duration,
+        excusal_status_streaks.school_attendance_duration
     from excusal_status_streaks
 ),
 metric_labels as (

--- a/models/core_warehouse/fct_student_disability.sql
+++ b/models/core_warehouse/fct_student_disability.sql
@@ -1,0 +1,72 @@
+{{
+  config(
+    post_hook=[
+        "alter table {{ this }} alter column k_student_disability set not null",
+        "alter table {{ this }} alter column k_student set not null",
+        "alter table {{ this }} alter column disability_type set not null",
+        "alter table {{ this }} add primary key (k_student_disability)",
+        "alter table {{ this }} add constraint fk_{{ this.name }}_student foreign key (k_student) references {{ ref('dim_student') }}",
+        "alter table {{ this }} add constraint fk_{{ this.name }}_program foreign key (k_program) references {{ ref('dim_program') }}",
+        "alter table {{ this }} add constraint fk_{{ this.name }}_lea foreign key (k_lea) references {{ ref('dim_lea') }}",
+        "alter table {{ this }} add constraint fk_{{ this.name }}_school foreign key (k_school) references {{ ref('dim_school') }}",
+    ]
+  )
+}}
+
+with student_disabilities as (
+    select * from {{ ref('bld_ef3__student__disabilities') }}
+),
+dim_student as (
+    select * from {{ ref('dim_student') }}
+),
+student_disability_designations as (
+    select * from {{ ref('bld_ef3__student__wide_disability_designations') }}
+),
+formatted as (
+    select
+        {{ dbt_utils.generate_surrogate_key(
+            ['sd.tenant_code',
+            'sd.school_year',
+            'sd.k_student',
+            'sd.k_lea',
+            'sd.k_school',
+            'sd.k_program',
+            'sd.ed_org_id',
+            'sd.program_enroll_begin_date',]
+        ) }} as k_student_disability, 
+        sd.k_student,
+        stu.k_student_xyear,
+        sd.k_lea,
+        sd.k_school,
+        sd.k_program,
+        sd.ed_org_id,
+        sd.program_enroll_begin_date,
+        sd.program_enroll_end_date,
+        sd.tenant_code,
+        sd.api_year,
+        sd.school_year,
+        sd.disability_type,
+        sd.disability_source_type,
+        sd.disability_diagnosis,
+        sd.order_of_disability,
+        -- disability designations
+        {{ accordion_columns(
+            source_table='bld_ef3__student__wide_disability_designations',
+            exclude_columns=['tenant_code', 'api_year', 'school_year', 'k_student', 'ed_org_id', 'k_lea', 'k_school', 'k_program', 'disability_type'],
+            source_alias='disability_designations',
+            add_trailing_comma=false
+        ) }}
+    from student_disabilities sd
+    join dim_student stu
+        on stu.k_student = sd.k_student
+    left join student_disability_designations disability_designations
+        on sd.k_student = disability_designations.k_student
+        and (sd.k_lea = disability_designations.k_lea or (sd.k_lea is null and disability_designations.k_lea is null))
+        and (sd.k_school = disability_designations.k_school or (sd.k_school is null and disability_designations.k_school is null))
+        and (sd.k_program = disability_designations.k_program or (sd.k_program is null and disability_designations.k_program is null))
+        and sd.ed_org_id = disability_designations.ed_org_id
+        and sd.tenant_code = disability_designations.tenant_code
+        and sd.school_year = disability_designations.school_year
+        and sd.disability_type = disability_designations.disability_type
+)
+select * from formatted

--- a/models/core_warehouse/fct_student_disability.yml
+++ b/models/core_warehouse/fct_student_disability.yml
@@ -1,0 +1,86 @@
+version: 3
+
+models: 
+  - name: fct_student_disability
+    description: >
+     ##### Overview:
+       This fact table provides student disabilities, which could be assigned from multiple sources.
+       It references any or all of the following models:
+      - [stg_ef3__stu_ed_org__disabilities](#!/model/model.edu_edfi_source.stg_ef3__stu_ed_org__disabilities)
+      - [stg_ef3__stu_spec_ed__disabilities](#!/model/model.edu_edfi_source.stg_ef3__stu_spec_ed__disabilities)
+
+     ##### Primary Key:
+       `k_student_disability` --
+       There is one record per student, year, ed org / program
+
+     ##### Important business rules:
+        - This table is at two different grains since both Ed Orgs and Special Ed Programs can have disabilities listed. This is why this table has 
+           a surrogate key being made up of the two grains that fit in this table. If k_program is null then this is an ed org disability. 
+           If k_program is not null then it is a program disability. 
+        - `program_enroll_begin_date` is included in the unique key, because a student may be associated with the same program at multiple times,
+           and those associations may have different disabilities. When joining this table to `fct_student_{program_type}_program_association`,
+           always include `program_enroll_begin_date` in the join (see example query below).
+
+     ##### Example Use Cases:
+       1. Join Disabilities to Student Special Education data to find students' Special Ed disabilities
+       they received as part of that program:  
+         
+        ```
+          SELECT
+            assoc.k_student,
+            assoc.school_year,
+            assoc.k_program,
+            dim_program.program_type,
+            dim_program.program_id,
+            dim_program.program_name,
+            assoc.program_enroll_begin_date,
+            assoc.program_enroll_end_date,
+            dis.disability_type,
+            dis.disability_source_type,
+            dis.disability_diagnosis,
+            dis.order_of_disability
+          FROM analytics.prod_wh.fct_student_special_education_program_association assoc
+          JOIN analytics.prod_wh.dim_program
+            ON assoc.k_program = dim_program.k_program
+          -- left join because some programs may not have disabilities
+          LEFT join analytics.prod_wh.fct_student_disability dis
+            ON assoc.k_student = dis.k_student
+            AND assoc.k_program = dis.k_program
+            AND assoc.program_enroll_begin_date = dis.program_enroll_begin_date;
+        ```
+
+
+    config:
+      tags: ['special_ed']
+      enabled: >
+        {%- set var_values = [] -%}
+        {%- for variable in [
+             'src:program:special_ed:enabled',
+        ] -%}
+           {%- do var_values.append(var(variable, none)) -%}
+        {%- endfor -%}
+
+        {%- if True in var_values -%}
+           {{ True  | as_bool }}
+        {%- elif False in var_values -%}
+           {{ False | as_bool }}
+        {%- else -%}
+           {{ True  | as_bool }}
+        {%- endif -%}
+        
+    columns:
+      - name: k_student_disability, 
+      - name: k_student
+      - name: k_student_xyear
+      - name: k_lea
+      - name: k_school
+      - name: k_program
+      - name: program_enroll_begin_date
+      - name: program_enroll_end_date
+      - name: tenant_code
+      - name: api_year
+      - name: school_year
+      - name: disability_type
+      - name: disability_source_type
+      - name: disability_diagnosis
+      - name: order_of_disability

--- a/models/core_warehouse/fct_student_homeless_program_association.sql
+++ b/models/core_warehouse/fct_student_homeless_program_association.sql
@@ -1,11 +1,13 @@
 {{
   config(
     post_hook=[
+        "alter table {{ this }} alter column k_student_program set not null",
         "alter table {{ this }} alter column k_student set not null",
         "alter table {{ this }} alter column k_student_xyear set not null",
         "alter table {{ this }} alter column k_program set not null",
         "alter table {{ this }} alter column program_enroll_begin_date set not null",
-        "alter table {{ this }} add primary key (k_student, k_student_xyear, k_program, program_enroll_begin_date)",
+        "alter table {{ this }} alter column ed_org_id set not null",
+        "alter table {{ this }} add primary key (k_student_program)",
         "alter table {{ this }} add constraint fk_{{ this.name }}_student foreign key (k_student) references {{ ref('dim_student') }}",
         "alter table {{ this }} add constraint fk_{{ this.name }}_program foreign key (k_program) references {{ ref('dim_program') }}",
     ]
@@ -26,12 +28,14 @@ dim_program as (
 
 formatted as (
     select
+        stage.k_student_program,
         dim_student.k_student,
         dim_student.k_student_xyear,
         dim_program.k_program,
         dim_program.k_lea,
         dim_program.k_school,
-
+        stage.ed_org_id,
+        
         stage.tenant_code,
         dim_program.school_year,
         stage.program_enroll_begin_date,

--- a/models/core_warehouse/fct_student_homeless_program_association.yml
+++ b/models/core_warehouse/fct_student_homeless_program_association.yml
@@ -7,8 +7,7 @@ models:
         This fact table contains student homeless program enrollment information.
 
       ##### Primary Key:
-        `k_student, k_student_xyear, k_program, program_enroll_begin_date` -- There is one 
-        record per student, year, program enrol begin date, and homeless program.
+        `k_student_program` -- There is one record per student, year, ed_org_id, program enroll begin date, and homeless program.
 
     config:
       tags: ['homeless']
@@ -20,13 +19,17 @@ models:
             combination_of_columns:
               - k_student
               - k_program
+              - ed_org_id
+              - program_enroll_begin_date
 
     columns:
+      - name: k_student_program
       - name: k_student
       - name: k_student_xyear
       - name: k_program
       - name: k_lea
       - name: k_school
+      - name: ed_org_id
       - name: tenant_code
       - name: school_year
       - name: program_enroll_begin_date

--- a/models/core_warehouse/fct_student_language_instruction_program_association.sql
+++ b/models/core_warehouse/fct_student_language_instruction_program_association.sql
@@ -1,11 +1,13 @@
 {{
   config(
     post_hook=[
+        "alter table {{ this }} alter column k_student_program set not null",
         "alter table {{ this }} alter column k_student set not null",
         "alter table {{ this }} alter column k_student_xyear set not null",
         "alter table {{ this }} alter column k_program set not null",
         "alter table {{ this }} alter column program_enroll_begin_date set not null",
-        "alter table {{ this }} add primary key (k_student, k_student_xyear, k_program, program_enroll_begin_date)",
+        "alter table {{ this }} alter column ed_org_id set not null",
+        "alter table {{ this }} add primary key (k_student_program)",
         "alter table {{ this }} add constraint fk_{{ this.name }}_student foreign key (k_student) references {{ ref('dim_student') }}",
         "alter table {{ this }} add constraint fk_{{ this.name }}_program foreign key (k_program) references {{ ref('dim_program') }}",
     ]
@@ -26,11 +28,13 @@ dim_program as (
 
 formatted as (
     select
+        stage.k_student_program,
         dim_student.k_student,
         dim_student.k_student_xyear,
         dim_program.k_program,
         dim_program.k_lea,
         dim_program.k_school,
+        stage.ed_org_id, 
 
         stage.tenant_code,
         dim_program.school_year,

--- a/models/core_warehouse/fct_student_language_instruction_program_association.yml
+++ b/models/core_warehouse/fct_student_language_instruction_program_association.yml
@@ -7,8 +7,7 @@ models:
         This fact table contains student language instruction program enrollment information.
 
       ##### Primary Key:
-        `k_student, k_student_xyear, k_program, program_enroll_begin_date` -- There is one 
-        record per student, year, program enrol begin date, and language instruction program.
+        `k_student_program` -- There is one record per student, year, ed_org_id, program enroll begin date, and language instruction program.
 
     config:
       tags: ['language_instruction']
@@ -20,15 +19,17 @@ models:
             combination_of_columns:
               - k_student
               - k_program
-              - k_student_xyear
+              - ed_org_id
               - program_enroll_begin_date
 
     columns:
+      - name: k_student_program
       - name: k_student
       - name: k_student_xyear
       - name: k_program
       - name: k_lea
       - name: k_school
+      - name: ed_org_id
       - name: tenant_code
       - name: school_year
       - name: program_enroll_begin_date

--- a/models/core_warehouse/fct_student_migrant_education_program_associations.sql
+++ b/models/core_warehouse/fct_student_migrant_education_program_associations.sql
@@ -1,11 +1,13 @@
 {{
   config(
     post_hook=[
+        "alter table {{ this }} alter column k_student_program set not null",
         "alter table {{ this }} alter column k_student set not null",
         "alter table {{ this }} alter column k_student_xyear set not null",
         "alter table {{ this }} alter column k_program set not null",
         "alter table {{ this }} alter column program_enroll_begin_date set not null",
-        "alter table {{ this }} add primary key (k_student, k_student_xyear, k_program, program_enroll_begin_date)",
+        "alter table {{ this }} alter column ed_org_id set not null",
+        "alter table {{ this }} add primary key (k_student_program)",
         "alter table {{ this }} add constraint fk_{{ this.name }}_student foreign key (k_student) references {{ ref('dim_student') }}",
         "alter table {{ this }} add constraint fk_{{ this.name }}_program foreign key (k_program) references {{ ref('dim_program') }}",
     ]
@@ -27,11 +29,13 @@ dim_program as (
 
 formatted as (
     select
+        stage.k_student_program,
         dim_student.k_student,
         dim_student.k_student_xyear,
         dim_program.k_program,
         dim_program.k_lea,
         dim_program.k_school,
+        stage.ed_org_id, 
         stage.tenant_code,
         dim_program.school_year,
         stage.program_enroll_begin_date,

--- a/models/core_warehouse/fct_student_migrant_education_program_associations.yml
+++ b/models/core_warehouse/fct_student_migrant_education_program_associations.yml
@@ -7,8 +7,7 @@ models:
         This fact table contains student migrant education program enrollment information.
 
       ##### Primary Key:
-        `k_student, k_student_xyear, k_program, program_enroll_begin_date` -- There is one 
-        record per student, year, program enrol begin date, and migrant education program.
+        `k_student_program` -- There is one record per student, year, ed_org_id, program enroll begin date, and migrant education program.
 
     config:
       tags: ['migrant_education']
@@ -20,13 +19,17 @@ models:
             combination_of_columns:
               - k_student
               - k_program
+              - ed_org_id
+              - program_enroll_begin_date
 
     columns:
+      - name: k_student_program
       - name: k_student
       - name: k_student_xyear
       - name: k_program
       - name: k_lea
       - name: k_school
+      - name: ed_org_id
       - name: tenant_code
       - name: school_year
       - name: program_enroll_begin_date

--- a/models/core_warehouse/fct_student_objective_assessment.sql
+++ b/models/core_warehouse/fct_student_objective_assessment.sql
@@ -47,7 +47,8 @@ combined_with_cross_tenant as (
         {{ accordion_columns(
             source_table='stg_ef3__student_objective_assessments',
             source_alias='student_obj_assessments',
-            exclude_columns=['k_student_objective_assessment', 'k_objective_assessment', 'k_student_assessment', 'k_assessment', 'k_student', 'k_student_xyear', 'tenant_code', 'school_year']) }}
+            exclude_columns=['k_student_objective_assessment', 'k_objective_assessment', 'k_student_assessment', 'k_assessment', 'k_student', 'k_student_xyear', 'tenant_code', 'school_year'],
+            add_trailing_comma=false) }}
     from student_obj_assessments
     -- left join because this model can return empty
         -- and to avoid enforcing a current school association

--- a/models/core_warehouse/fct_student_program_association.sql
+++ b/models/core_warehouse/fct_student_program_association.sql
@@ -1,11 +1,13 @@
 {{
   config(
     post_hook=[
+        "alter table {{ this }} alter column k_student_program set not null",
         "alter table {{ this }} alter column k_student set not null",
         "alter table {{ this }} alter column k_student_xyear set not null",
         "alter table {{ this }} alter column k_program set not null",
         "alter table {{ this }} alter column program_enroll_begin_date set not null",
-        "alter table {{ this }} add primary key (k_student, k_student_xyear, k_program, program_enroll_begin_date)",
+        "alter table {{ this }} alter column ed_org_id set not null",
+        "alter table {{ this }} add primary key (k_student_program)",
         "alter table {{ this }} add constraint fk_{{ this.name }}_student foreign key (k_student) references {{ ref('dim_student') }}",
         "alter table {{ this }} add constraint fk_{{ this.name }}_program foreign key (k_program) references {{ ref('dim_program') }}",
     ]
@@ -26,11 +28,13 @@ dim_program as (
 
 formatted as (
     select
+        stage.k_student_program,
         dim_student.k_student,
         dim_student.k_student_xyear,
         dim_program.k_program,
         dim_program.k_lea,
         dim_program.k_school,
+        stage.ed_org_id,
 
         stage.tenant_code,
         dim_program.school_year,

--- a/models/core_warehouse/fct_student_program_association.yml
+++ b/models/core_warehouse/fct_student_program_association.yml
@@ -5,7 +5,7 @@ models:
     description: >
       Student program enrollment information.
 
-      *Primary Key:* `k_student, k_program`
+      *Primary Key:* `k_student_program, program_enroll_begin_date, participation_status`
 
     config:
       tags: ['core']
@@ -15,14 +15,16 @@ models:
             combination_of_columns:
               - k_student
               - k_program
-              - k_student_xyear
+              - ed_org_id
               - program_enroll_begin_date
     columns:
+      - name: k_student_program
       - name: k_student
       - name: k_student_xyear
       - name: k_program
       - name: k_lea
       - name: k_school
+      - name: ed_org_id
       - name: tenant_code
       - name: school_year
       - name: program_enroll_begin_date

--- a/models/core_warehouse/fct_student_program_participation_status.sql
+++ b/models/core_warehouse/fct_student_program_participation_status.sql
@@ -6,49 +6,49 @@
         "alter table {{ this }} alter column k_program set not null",
         "alter table {{ this }} alter column program_enroll_begin_date set not null",
         "alter table {{ this }} alter column ed_org_id set not null",
-        "alter table {{ this }} alter column program_service set not null",
-        "alter table {{ this }} add primary key (k_student_program, program_service)",
+        "alter table {{ this }} alter column participation_status set not null",
+        "alter table {{ this }} alter column status_begin_date set not null",
+        "alter table {{ this }} add primary key (k_student_program, participation_status, status_begin_date)",
         "alter table {{ this }} add constraint fk_{{ this.name }}_student foreign key (k_student) references {{ ref('dim_student') }}",
         "alter table {{ this }} add constraint fk_{{ this.name }}_program foreign key (k_program) references {{ ref('dim_program') }}",
     ]
   )
 }}
 
-
 -- Define all optional program service models here.
 {% set stage_program_relations = [] %}
 
 --Generic Program Assoc
-{% do stage_program_relations.append(ref('stg_ef3__stu_program__program_services')) %}
+{% do stage_program_relations.append(ref('stg_ef3__stu_program__program_participation_statuses')) %}
 
 -- Special Education
 {% if var('src:program:special_ed:enabled', True) %}
-    {% do stage_program_relations.append(ref('stg_ef3__stu_spec_ed__program_services')) %}
+    {% do stage_program_relations.append(ref('stg_ef3__stu_spec_ed__program_participation_statuses')) %}
 {% endif %}
 
 -- Language Instruction
 {% if var('src:program:language_instruction:enabled', True) %}
-    {% do stage_program_relations.append(ref('stg_ef3__stu_lang_instr__program_services')) %}
+    {% do stage_program_relations.append(ref('stg_ef3__stu_lang_instr__program_participation_statuses')) %}
 {% endif %}
 
 -- Homeless
 {% if var('src:program:homeless:enabled', True) %}
-    {% do stage_program_relations.append(ref('stg_ef3__stu_homeless__program_services')) %}
+    {% do stage_program_relations.append(ref('stg_ef3__stu_homeless__program_participation_statuses')) %}
 {% endif %}
 
 -- Title I Part A
 {% if var('src:program:title_i:enabled', True) %}
-    {% do stage_program_relations.append(ref('stg_ef3__stu_title_i_part_a__program_services')) %}
+    {% do stage_program_relations.append(ref('stg_ef3__stu_title_i_part_a__program_participation_statuses')) %}
 {% endif %}
 
 -- CTE
 {% if var('src:program:cte:enabled', True) %}
-    {% do stage_program_relations.append(ref('stg_ef3__stu_cte__program_services')) %}
+    {% do stage_program_relations.append(ref('stg_ef3__stu_cte__program_participation_statuses')) %}
 {% endif %}
 
 -- Migrant Education
 {% if var('src:program:migrant_education:enabled', True) %}
-    {% do stage_program_relations.append(ref('stg_ef3__stu_migrant_edu__program_services')) %}
+    {% do stage_program_relations.append(ref('stg_ef3__stu_migrant_edu__program_participation_statuses')) %}
 {% endif %}
 
 -- Food Service
@@ -87,16 +87,10 @@ subset as (
     stacked.tenant_code,
     stacked.ed_org_id,
     stacked.program_enroll_begin_date,
-    stacked.program_service,
-    stacked.primary_indicator,
-    {% if var('src:program:special_ed:enabled', True) %}
-        stacked.v_providers,
-    {% endif %}
-    {% if var('src:program:cte:enabled', True) %}
-        stacked.cip_code,
-    {% endif %}
-    stacked.service_begin_date,
-    stacked.service_end_date
+    stacked.participation_status,
+    stacked.status_begin_date,
+    stacked.status_end_date,
+    stacked.designated_by
     {# add any extension columns configured from all stage_program_relations #}
     {{ edu_edfi_source.extract_extension(model_name=relation_names, flatten=False) }}
 

--- a/models/core_warehouse/fct_student_program_participation_status.yml
+++ b/models/core_warehouse/fct_student_program_participation_status.yml
@@ -1,0 +1,61 @@
+version: 1
+
+models: 
+  - name: fct_student_program_participation_status
+    description: >
+     ##### Overview:
+       This fact table provides student program participation statuses, received as part of a program enrollment.
+       It references any or all of the following models:
+      - [stg_ef3__stu_spec_ed__program_participation_statuses](#!/model/model.edu_edfi_source.stg_ef3__stu_spec_ed__program_participation_statuses)
+      - [stg_ef3__stu_lang_instr__program_participation_statuses](#!/model/model.edu_edfi_source.stg_ef3__stu_lang_instr__program_participation_statuses)
+      - [stg_ef3__stu_homeless__program_participation_statuses](#!/model/model.edu_edfi_source.stg_ef3__stu_homeless__program_participation_statuses)
+      - [stg_ef3__stu_title_i__program_participation_statuses](#!/model/model.edu_edfi_source.stg_ef3__stu_title_i__program_participation_statuses)
+      - [stg_ef3__stu_cte__program_participation_statuses](#!/model/model.edu_edfi_source.stg_ef3__stu_cte__program_participation_statuses)
+      - [stg_ef3__stu_migrant_edu__program_participation_statusess](#!/model/model.edu_edfi_source.stg_ef3__stu_migrant_edu__program_participation_statuses)
+      - [stg_ef3__stu_school_food_service__program_participation_statuses](#!/model/model.edu_edfi_source.stg_ef3__stu_school_food_service__program_participation_statuses)
+      - [stg_ef3__stu_program__program_participation_statuses](#!/model/model.edu_edfi_source.stg_ef3__stu_program__program_participation_statuses)
+
+     ##### Primary Key:
+       `k_student_program, participation_status, status_begin_date` --
+       There is one record per student, year, program, ed org, program start date, program participation status, and status begin date.
+
+     ##### Important business rules:
+        - `program_enroll_begin_date` is included in the unique key, because a student may be associated with the same program at multiple times,
+           and those associations may have different program participation statuses. When joining this table to `fct_student_{program_type}_program_association`,
+           always include `program_enroll_begin_date` in the join.
+
+    config:
+      tags: ['special_ed', 'homeless', 'language_instruction', 'title_i', 'cte', 'migrant_education', 'food_service']
+      enabled: >
+        {%- set var_values = [] -%}
+        {%- for variable in [
+             'src:program:special_ed:enabled',
+             'src:program:homeless:enabled',
+             'src:program:language_instruction:enabled',
+             'src:program:title_i:enabled',
+             'src:program:cte:enabled',
+             'src:program:migrant_education:enabled',
+             'src:program:food_service:enabled'
+        ] -%}
+           {%- do var_values.append(var(variable, none)) -%}
+        {%- endfor -%}
+
+        {%- if True in var_values -%}
+           {{ True  | as_bool }}
+        {%- elif False in var_values -%}
+           {{ False | as_bool }}
+        {%- else -%}
+           {{ True  | as_bool }}
+        {%- endif -%}
+        
+    columns:
+      - name: k_student_program
+      - name: k_student
+      - name: k_program
+      - name: tenant_code
+      - name: ed_org_id
+      - name: program_enroll_begin_date
+      - name: participation_status
+      - name: status_begin_date
+      - name: status_end_date
+      - name: designated_by

--- a/models/core_warehouse/fct_student_program_service.yml
+++ b/models/core_warehouse/fct_student_program_service.yml
@@ -84,12 +84,15 @@ models:
             combination_of_columns:
               - k_student
               - k_program
+              - ed_org_id
               - program_enroll_begin_date
               - program_service
     columns:
+      - name: k_student_program
       - name: k_student
       - name: k_program
       - name: tenant_code
+      - name: ed_org_id
       - name: program_enroll_begin_date
       - name: program_service
       - name: primary_indicator

--- a/models/core_warehouse/fct_student_school_food_service_program_associations.sql
+++ b/models/core_warehouse/fct_student_school_food_service_program_associations.sql
@@ -1,11 +1,13 @@
 {{
   config(
     post_hook=[
+        "alter table {{ this }} alter column k_student_program set not null",
         "alter table {{ this }} alter column k_student set not null",
         "alter table {{ this }} alter column k_student_xyear set not null",
         "alter table {{ this }} alter column k_program set not null",
         "alter table {{ this }} alter column program_enroll_begin_date set not null",
-        "alter table {{ this }} add primary key (k_student, k_student_xyear, k_program, program_enroll_begin_date)",
+        "alter table {{ this }} alter column ed_org_id set not null",
+        "alter table {{ this }} add primary key (k_student_program)",
         "alter table {{ this }} add constraint fk_{{ this.name }}_student foreign key (k_student) references {{ ref('dim_student') }}",
         "alter table {{ this }} add constraint fk_{{ this.name }}_program foreign key (k_program) references {{ ref('dim_program') }}",
     ]
@@ -27,11 +29,14 @@ dim_program as (
 
 formatted as (
     select
+        stage.k_student_program,
         dim_student.k_student,
         dim_student.k_student_xyear,
         dim_program.k_program,
         dim_program.k_lea,
         dim_program.k_school,
+        stage.ed_org_id,
+        
         stage.tenant_code,
         dim_program.school_year,
         stage.program_enroll_begin_date,

--- a/models/core_warehouse/fct_student_school_food_service_program_associations.yml
+++ b/models/core_warehouse/fct_student_school_food_service_program_associations.yml
@@ -7,8 +7,7 @@ models:
         This fact table contains student food service program enrollment information.
 
       ##### Primary Key:
-        `k_student, k_student_xyear, k_program, program_enroll_begin_date` -- There 
-        is one record per student, year, program enrol begin date, and food service program.
+        `k_student_program` -- There is one record per student, year, ed_org_id, program enroll begin date, and food service program.
 
     config:
       tags: ['food_service']
@@ -20,13 +19,17 @@ models:
             combination_of_columns:
               - k_student
               - k_program
+              - ed_org_id
+              - program_enroll_begin_date
 
     columns:
+      - name: k_student_program
       - name: k_student
       - name: k_student_xyear
       - name: k_program
       - name: k_lea
       - name: k_school
+      - name: ed_org_id
       - name: tenant_code
       - name: school_year
       - name: program_enroll_begin_date

--- a/models/core_warehouse/fct_student_special_education_program_association.sql
+++ b/models/core_warehouse/fct_student_special_education_program_association.sql
@@ -1,11 +1,13 @@
 {{
   config(
     post_hook=[
+        "alter table {{ this }} alter column k_student_program set not null",
         "alter table {{ this }} alter column k_student set not null",
         "alter table {{ this }} alter column k_student_xyear set not null",
         "alter table {{ this }} alter column k_program set not null",
         "alter table {{ this }} alter column program_enroll_begin_date set not null",
-        "alter table {{ this }} add primary key (k_student, k_student_xyear, k_program, program_enroll_begin_date)",
+        "alter table {{ this }} alter column ed_org_id set not null",
+        "alter table {{ this }} add primary key (k_student_program)",
         "alter table {{ this }} add constraint fk_{{ this.name }}_student foreign key (k_student) references {{ ref('dim_student') }}",
         "alter table {{ this }} add constraint fk_{{ this.name }}_program foreign key (k_program) references {{ ref('dim_program') }}",
     ]
@@ -35,11 +37,13 @@ bld_primary_disability as (
 
 formatted as (
     select
+        stage.k_student_program,
         dim_student.k_student,
         dim_student.k_student_xyear,
         dim_program.k_program,
         dim_program.k_lea,
         dim_program.k_school,
+        stage.ed_org_id,
         stage.tenant_code,
         dim_program.school_year,
         stage.program_enroll_begin_date,

--- a/models/core_warehouse/fct_student_special_education_program_association.yml
+++ b/models/core_warehouse/fct_student_special_education_program_association.yml
@@ -7,8 +7,7 @@ models:
         This fact table contains student special education program enrollment information.
 
       ##### Primary Key:
-        `k_student, k_student_xyear, k_program, program_enroll_begin_date` -- There is one 
-        record per student, year, program enrol begin date, and special education program
+        `k_student_program` -- There is one record per student, year, ed_org_id, program enroll begin date, and special education program
 
     config:
       tags: ['special_ed']
@@ -19,13 +18,16 @@ models:
             combination_of_columns:
               - k_student
               - k_program
+              - ed_org_id
               - program_enroll_begin_date
     columns:
+      - name: k_student_program
       - name: k_student
       - name: k_student_xyear
       - name: k_program
       - name: k_lea
       - name: k_school
+      - name: ed_org_id
       - name: tenant_code
       - name: school_year
       - name: program_enroll_begin_date

--- a/models/core_warehouse/fct_student_title_i_part_a_program_association.sql
+++ b/models/core_warehouse/fct_student_title_i_part_a_program_association.sql
@@ -1,11 +1,13 @@
 {{
   config(
     post_hook=[
+        "alter table {{ this }} alter column k_student_program set not null",
         "alter table {{ this }} alter column k_student set not null",
         "alter table {{ this }} alter column k_student_xyear set not null",
         "alter table {{ this }} alter column k_program set not null",
         "alter table {{ this }} alter column program_enroll_begin_date set not null",
-        "alter table {{ this }} add primary key (k_student, k_student_xyear, k_program, program_enroll_begin_date)",
+        "alter table {{ this }} alter column ed_org_id set not null",
+        "alter table {{ this }} add primary key (k_student_program)",
         "alter table {{ this }} add constraint fk_{{ this.name }}_student foreign key (k_student) references {{ ref('dim_student') }}",
         "alter table {{ this }} add constraint fk_{{ this.name }}_program foreign key (k_program) references {{ ref('dim_program') }}",
     ]
@@ -26,11 +28,13 @@ dim_program as (
 
 formatted as (
     select
+        stage.k_student_program,
         dim_student.k_student,
         dim_student.k_student_xyear,
         dim_program.k_program,
         dim_program.k_lea,
         dim_program.k_school,
+        stage.ed_org_id,
         stage.tenant_code,
         dim_program.school_year,
         stage.program_enroll_begin_date,

--- a/models/core_warehouse/fct_student_title_i_part_a_program_association.yml
+++ b/models/core_warehouse/fct_student_title_i_part_a_program_association.yml
@@ -7,8 +7,7 @@ models:
         This fact table contains student Title I Part A program enrollment information.
 
       ##### Primary Key:
-        k_student, k_student_xyear, k_program, program_enroll_begin_date` -- There is one 
-        record per student, year, program enrol begin date, and Title I Part A program.
+        k_student_program` -- There is one record per student, year, ed_org_id, program enroll begin date, and Title I Part A program.
 
     config:
       tags: ['title_i']
@@ -20,15 +19,17 @@ models:
             combination_of_columns:
               - k_student
               - k_program
-              - k_student_xyear
+              - ed_org_id
               - program_enroll_begin_date
 
     columns:
+      - name: k_student_program
       - name: k_student
       - name: k_student_xyear
       - name: k_program
       - name: k_lea
       - name: k_school
+      - name: ed_org_id
       - name: tenant_code
       - name: school_year
       - name: program_enroll_begin_date


### PR DESCRIPTION
## Description & motivation
Tennessee needs additional data exposed for Student Program Associations. 

It should be noted that this PR _requires_ the enhancement to the `accordion_columns` macro found in [this PR](https://github.com/edanalytics/edu_wh/pull/228).

This PR contains many changes to support this, including:

1. The addition of a fct_student_disability model (plus supporting models) that will expose Student Disabilities that exist either on the Student EdOrg Association or the Student Special Education Program Association.
2. The addition of a fct_student_program_participation_status model that will expose Student X Program Association participation statuses.
3. All Student Program Association tables now contain a k_student_program surrogate key that includes the Association ed_org_id as a field. This will be the new PK across all the Student X Program Association tables. The previous implementation did not include the Association ed_org_id and this was a bug.
4. Ed_Org_Id is exposed in all the tables now.
5. I attempted to update all the documentation and make it correct.

## Breaking changes introduced by this PR:
This will POTENTIALLY contain breaking changes if other users expect the existing bug to produce results in the "bug way" instead of the intended way of how the endpoint was designed to work.

## PR Merge Priority:
- [X] Low
- [ ] Medium
- [ ] High

## Changes to existing files:
- `models/core_warehouse/fct_student_cte_program_associations.sql` : Added k_student_program surrogate key and ed_org_id.
- `models/core_warehouse/fct_student_cte_program_associations.yml` : Updated documentation.
- `models/core_warehouse/fct_student_homeless_program_association.sql` : Added k_student_program surrogate key and ed_org_id.
- `models/core_warehouse/fct_student_homeless_program_association.yml` : Updated documentation.
- `models/core_warehouse/fct_student_language_instruction_program_association.sql` : Added k_student_program surrogate key and ed_org_id.
- `models/core_warehouse/fct_student_language_instruction_program_association.yml` : Updated documentation.
- `models/core_warehouse/fct_student_migrant_education_program_associations.sql` : Added k_student_program surrogate key and ed_org_id.
- `models/core_warehouse/fct_student_migrant_education_program_associations.yml` : Updated documentation.
- `models/core_warehouse/fct_student_program_association.sql` : Added k_student_program surrogate key and ed_org_id.
- `models/core_warehouse/fct_student_program_association.yml` : Updated documentation.
- `models/core_warehouse/fct_student_program_service.sql` : Modified this to fix a couple of bugs where a couple columns MIGHT not exist, but also added the program services from the generic program endpoint.
- `models/core_warehouse/fct_student_program_service.yml` : Tweak to keep it up to date based on the changes I made.
- `models/core_warehouse/fct_student_school_food_service_program_associations.sql` : Added k_student_program surrogate key and ed_org_id.
- `models/core_warehouse/fct_student_school_food_service_program_associations.yml` : Updated documentation.
- `models/core_warehouse/fct_student_special_education_program_association.sql` : Added k_student_program surrogate key and ed_org_id.
- `models/core_warehouse/fct_student_special_education_program_association.yml` : Updated documentation.
- `models/core_warehouse/fct_student_title_i_part_a_program_association.sql` : Added k_student_program surrogate key and ed_org_id.
- `models/core_warehouse/fct_student_title_i_part_a_program_association.yml` : Updated documentation.

## New files created:
- `models/build/edfi_3/students/bld_ef3__student__disabilities.sql` : This is a new build file of student disabilities across the Edfi spectrum. At the time of this writing, student disabilities could come in on the Ed Org and Student Special Education endpoints. So this build table has disabilities from both those sources.
- `models/build/edfi_3/students/bld_ef3__student__wide_disability_designations.sql` : This is a new build file of student disability designations across the Edfi spectrum. This uses a new xwalk: xwalk_disability_designations. This flattens disability designations to be used later when building the fact table.
- `models/core_warehouse/fct_student_disability.sql` : This new fact table is what exposes student disabilities within the warehouse.
- `models/core_warehouse/fct_student_disability.yml` : I tried to follow your pattern here.
- `models/core_warehouse/fct_student_program_participation_status.sql` : New fact table that exposes student program association participation statuses.
- `models/core_warehouse/fct_student_program_participation_status.yml` : Documentation

## Tests and QC done:
Internal testing using stadium_tennessee project and this has been in our production system for sometime now.

## edu_wh PR Review Checklist:
Make sure the following have been completed before approving this PR:
- [ ] Description of changes has been added to Unreleased section of [CHANGELOG.md](/CHANGELOG.md). Add under `## New Features` for features, etc.
- [ ] Code has been tested/checked for Databricks and Snowflake compatibility - EA engineers see Databricks checklist [here](https://edanalytics.slite.com/app/docs/LRjXFxVRAWA5ST) 
- [ ] Reviewer confirms the grain of all tables are unchanged, OR any changes are expected, communicated, and this PR is flagged as a breaking change (not for patch release)
- [ ] If a new configuration xwalk was added:
  - [ ] The code is written such that the xwalk is optional (preferred), and this behavior was tested, OR
  - [ ] The code is written such that the xwalk is required, and the required xwalk is added to edu_project_template, and this PR is flagged as breaking change (not for patch release)
  - [ ] A description for the new xwalk has been added to EDU documentation site [here](https://github.com/edanalytics/edu_docs/blob/main/docs/docs/manage_extend/reference/configure_dbt_xwalks.md) 
- [ ] If a new configuration variable was added:
  - [ ] The code is written such that the variable is optional (preferred), and this behavior was tested, OR
  - [ ] The code is written such that the variable is required, and a default value was added to edu_project_template, and this PR is flagged as breaking change (not for patch release)
  - [ ] A description for the new variable has been added to EDU documentation site [here](https://github.com/edanalytics/edu_docs/blob/main/docs/docs/manage_extend/reference/configure_dbt_vars.md) 