### PR TITLE
Feature/tdoe cds enhanced and everwhere 0.6.2

### DIFF
--- a/macros/accordion_columns.sql
+++ b/macros/accordion_columns.sql
@@ -9,8 +9,11 @@ be included in a table.
   - coalesce_value: if this value is specified, a coalesce function will be added with
     this value as the second parameter (to be returned if the value in the column is null).
     If none (default), the coalesce function will not be added.
+  - add_trailing_comma: if this value is specified, a trailing comma will be added to the last
+    column. If not passed in, a trailing comma is added for backward compatibility
 -#}
-{% macro accordion_columns(source_table, exclude_columns, source_alias=none, coalesce_value=none) %}
+
+{% macro accordion_columns(source_table, exclude_columns, source_alias=none, coalesce_value=none, add_trailing_comma=true) %}
   {%- if source_alias is none -%}
    {%- set source_alias = source_table -%} 
   {%- endif -%}
@@ -20,11 +23,11 @@ be included in a table.
     ) %}
   {%- if coalesce_value is none %}
     {%- for col in keep_cols %}
-      {{ source_alias }}.{{ col }},
+      {{ source_alias }}.{{ col }}{% if not loop.last %},{% elif add_trailing_comma %},{% endif %}
     {%- endfor %}
   {%- else -%}
     {%- for col in keep_cols %}
-      coalesce({{ source_alias }}.{{ col }}, {{ coalesce_value }}) as {{ col }},
+      coalesce({{ source_alias }}.{{ col }}, {{ coalesce_value }}) as {{ col }}{% if not loop.last %},{% elif add_trailing_comma %},{% endif %}
     {%- endfor %}  
   {%- endif -%}
 {% endmacro %}

--- a/macros/custom_data_sources_macros.sql
+++ b/macros/custom_data_sources_macros.sql
@@ -1,0 +1,106 @@
+{%- macro cds_depends_on(cds_model_config) -%}
+    {%- set cds = var(cds_model_config, {}) -%}
+        {%- if cds is mapping and cds|length -%}
+            {%- for source_name, _ in cds.items() -%}
+-- depends_on: {{ ref(source_name) }}
+            {%- endfor -%}
+    {%- endif -%}
+{%- endmacro -%}
+
+{%- macro add_cds_joins_v1(custom_data_sources, driving_alias, join_cols) -%}
+    {#-
+      Expected "old" config shape per source:
+        <source_name>: {
+          <indicator_name>: { where: <col_or_expr> },
+          ...
+        }
+
+      Only sources WITHOUT 'joins' key are considered "old" and handled here.
+    -#}
+
+    {% if custom_data_sources is mapping and custom_data_sources|length %}
+        {% for source_name, source_config in custom_data_sources|dictsort %}
+            {% if 'joins' not in source_config %}
+                left join {{ ref(source_name) }} as {{ source_name }}
+                {% for col in join_cols %}
+                    {% if loop.first %}
+                        on {{ driving_alias }}.{{ col }} = {{ source_name }}.{{ col }}
+                    {% else %}
+                        and {{ driving_alias }}.{{ col }} = {{ source_name }}.{{ col }}
+                    {% endif %}
+                {% endfor %}
+            {% endif %}
+        {% endfor %}
+    {% endif %}
+{%- endmacro -%}
+
+{%- macro add_cds_joins_v2(custom_data_sources) -%}
+    {#-
+      Expected "new" config shape per source:
+        <source_name>: {
+          joins: [ "<expr1>", "<expr2>", ... ],
+          cds_additional_cols: {
+            <src_col_name>: { as: <alias>, default: <literal_or_expr> },
+            ...
+          }
+        }
+
+      Only sources WITH 'joins' key are handled here.
+    -#}
+
+    {% if custom_data_sources is mapping and custom_data_sources|length %}
+        {% for source_name, source_config in custom_data_sources|dictsort %}
+            {% if 'joins' in source_config and source_config.joins %}
+                left join {{ ref(source_name) }} as {{ source_name }}
+                {% for join in source_config.joins %}
+                    {% if loop.first %}
+                        on {{ join }}
+                    {% else %}
+                        and {{ join }}
+                    {% endif %}
+                {% endfor %}
+            {% endif %}
+        {% endfor %}
+    {% endif %}
+{%- endmacro -%}
+
+{%- macro add_cds_columns(custom_data_sources) -%}
+    {#-
+      Old format per source:
+        <source_name>: {
+          <indicator_name>: { where: <col_or_expr> },
+          ...
+        }
+      Emits:
+        , <source_name>.<where> as <indicator_name>
+
+      New format per source:
+        <source_name>: {
+          joins: [...],
+          cds_additional_cols: {
+            <src_col_name>: { as: <alias>, default: <literal_or_expr> },
+            ...
+          }
+        }
+      Emits:
+        , coalesce(<source_name>.<src_col_name>, <default>) as <alias>
+    -#}
+
+    {% if custom_data_sources is mapping and custom_data_sources|length %}
+        {% for source_name, source_config in custom_data_sources|dictsort %}
+            {% if 'joins' in source_config %}
+                {# New config pathway #}
+                {% if 'cds_additional_cols' in source_config and source_config.cds_additional_cols %}
+                    {% for src_col_name, src_col_config in source_config.cds_additional_cols.items() %}
+                        , coalesce({{ source_name }}.{{ src_col_name }}, {{ src_col_config.default }}) as {{ src_col_config.as }}
+                    {% endfor %}
+                {% endif %}
+            {% else %}
+                {# Old config pathway #}
+                {% for indicator_name, indicator_config in source_config.items() %}
+                    , {{ source_name }}.{{ indicator_config.where }} as {{ indicator_name }}
+                {% endfor %}
+            {% endif %}
+        {% endfor %}
+    {% endif %}
+{%- endmacro -%}

--- a/models/build/edfi_3/assessments/bld_ef3__student_assessment_cross_tenant.sql
+++ b/models/build/edfi_3/assessments/bld_ef3__student_assessment_cross_tenant.sql
@@ -155,18 +155,18 @@ from deduped_assessments
   -- if this feature is not turned on, force return a zero row table
   select *
   from (select
-          null::varchar as tenant_code,
+          null::{{ dbt.type_string() }} as tenant_code,
           null::int as school_year,
           null::int as api_year,
-          null::varchar as k_student,
-          null::varchar as k_student_xyear,
-          null::varchar as k_assessment,
-          null::varchar as k_student_assessment,
-          null::varchar as k_student_assessment__original,
-          null::varchar as k_assessment__original,
-          null::varchar as student_unique_id,
+          null::{{ dbt.type_string() }} as k_student,
+          null::{{ dbt.type_string() }} as k_student_xyear,
+          null::{{ dbt.type_string() }} as k_assessment,
+          null::{{ dbt.type_string() }} as k_student_assessment,
+          null::{{ dbt.type_string() }} as k_student_assessment__original,
+          null::{{ dbt.type_string() }} as k_assessment__original,
+          null::{{ dbt.type_string() }} as student_unique_id,
           null::boolean as is_original_record,
-          null::varchar as original_tenant_code
+          null::{{ dbt.type_string() }} as original_tenant_code
        ) blank_subquery
   limit 0
 {% endif %}

--- a/models/build/edfi_3/assessments/bld_ef3__student_objective_assessment_cross_tenant.sql
+++ b/models/build/edfi_3/assessments/bld_ef3__student_objective_assessment_cross_tenant.sql
@@ -62,21 +62,21 @@ select * from deduped
 
 select * from (
     select
-        null::varchar as k_student_objective_assessment,
-        null::varchar as k_objective_assessment,
-        null::varchar as k_student_objective_assessment__original,
-        null::varchar as k_objective_assessment__original,
-        null::varchar as k_student_assessment,
-        null::varchar as k_student_assessment__original,
-        null::varchar as k_student,
-        null::varchar as k_student_xyear,
-        null::varchar as k_assessment,
-        null::varchar as k_assessment__original,
-        null::varchar as tenant_code,
+        null::{{ dbt.type_string() }} as k_student_objective_assessment,
+        null::{{ dbt.type_string() }} as k_objective_assessment,
+        null::{{ dbt.type_string() }} as k_student_objective_assessment__original,
+        null::{{ dbt.type_string() }} as k_objective_assessment__original,
+        null::{{ dbt.type_string() }} as k_student_assessment,
+        null::{{ dbt.type_string() }} as k_student_assessment__original,
+        null::{{ dbt.type_string() }} as k_student,
+        null::{{ dbt.type_string() }} as k_student_xyear,
+        null::{{ dbt.type_string() }} as k_assessment,
+        null::{{ dbt.type_string() }} as k_assessment__original,
+        null::{{ dbt.type_string() }} as tenant_code,
         null::int as school_year,
         null::int as api_year,
         null::boolean as is_original_record,
-        null::varchar as original_tenant_code
+        null::{{ dbt.type_string() }} as original_tenant_code
 ) limit 0
 
 {% endif %}

--- a/models/build/edfi_3/students/bld_ef3__student__disabilities.sql
+++ b/models/build/edfi_3/students/bld_ef3__student__disabilities.sql
@@ -1,0 +1,36 @@
+-- Define all optional disability models here.
+{% set stage_disability_relations = [] %}
+
+--Ed Org Disabilities
+{% do stage_disability_relations.append(ref('stg_ef3__stu_ed_org__disabilities')) %}
+
+-- Special Education
+{% if var('src:program:special_ed:enabled', True) %}
+    {% do stage_disability_relations.append(ref('stg_ef3__stu_spec_ed__disabilities')) %}
+{% endif %}
+
+with stacked as (
+    {{ dbt_utils.union_relations(
+        relations=stage_disability_relations
+    ) }}
+),
+formatted as (
+    select 
+        tenant_code,
+        api_year,
+        school_year,
+        k_student,
+        ed_org_id,
+        k_lea,
+        k_school,
+        k_program,
+        program_enroll_begin_date,
+        program_enroll_end_date,
+        disability_type,
+        disability_source_type,
+        disability_diagnosis,
+        order_of_disability,
+        v_designations
+    from stacked
+)
+select * from formatted

--- a/models/build/edfi_3/students/bld_ef3__student__wide_disability_designations.sql
+++ b/models/build/edfi_3/students/bld_ef3__student__wide_disability_designations.sql
@@ -1,0 +1,45 @@
+with student_disabilities as (
+    select * from {{ ref('bld_ef3__student__disabilities') }}
+),
+xwalk_disability_designations as (
+    select * from {{ ref('xwalk_disability_designations') }}
+),
+flattened as (
+    select 
+        tenant_code,
+        api_year,
+        school_year,
+        k_student,
+        ed_org_id,
+        k_lea,
+        k_school,
+        k_program,
+        disability_type,
+        {{ edu_edfi_source.extract_descriptor('designation.value:disabilityDesignationDescriptor::string') }} as disability_designation
+    from student_disabilities
+        {{ edu_edfi_source.json_flatten('v_designations', 'designation', outer=true) }}
+),
+pivoted as (
+    select 
+        tenant_code,
+        api_year,
+        school_year,
+        k_student,
+        ed_org_id,
+        k_lea,
+        k_school,
+        k_program,
+        disability_type
+        {%- if not is_empty_model('xwalk_disability_designations') -%},
+            {{ ea_pivot(
+                    column='indicator_name',
+                    values=dbt_utils.get_column_values(ref('xwalk_disability_designations'), 'indicator_name'),
+                    cast='boolean',
+            ) }}
+        {%- endif %}
+    from flattened
+    left outer join xwalk_disability_designations 
+        on flattened.disability_designation = xwalk_disability_designations.disability_designation_descriptor
+    group by all
+)
+select * from pivoted

--- a/models/core_warehouse/dim_assessment.sql
+++ b/models/core_warehouse/dim_assessment.sql
@@ -7,6 +7,9 @@
   )
 }}
 
+{{ cds_depends_on('edu:assessment:custom_data_sources') }}
+{% set custom_data_sources = var('edu:assessment:custom_data_sources', []) %}
+
 with stg_assessments as (
     select * from {{ ref('stg_ef3__assessments') }}
 ),
@@ -77,6 +80,18 @@ dedupe_assessments as (
             order_by='tenant_code,school_year'
         )
     }}
+),
+add_cds_columns as (
+    select dedupe_assessments.*
+
+        -- custom data sources columns
+        {{ add_cds_columns(custom_data_sources=custom_data_sources) }}
+    from dedupe_assessments
+
+    -- custom data sources
+    {{ add_cds_joins_v1(custom_data_sources=custom_data_sources, driving_alias='dedupe_assessments', join_cols=['k_assessment']) }}
+    {{ add_cds_joins_v2(custom_data_sources=custom_data_sources) }}
+
 )
-select * from dedupe_assessments
+select * from add_cds_columns
 order by tenant_code, k_assessment

--- a/models/core_warehouse/dim_calendar_date.sql
+++ b/models/core_warehouse/dim_calendar_date.sql
@@ -8,8 +8,9 @@
     ]
   )
 }}
-{# Load custom data sources from var #}
-{% set custom_data_sources = var("edu:calendar_date:custom_data_sources", []) %}
+
+{{ cds_depends_on('edu:calendar_date:custom_data_sources') }}
+{% set custom_data_sources = var('edu:calendar_date:custom_data_sources', []) %}
 
 with stg_calendar_date as (
     select * from {{ ref('stg_ef3__calendar_dates') }}
@@ -105,24 +106,15 @@ week_calculation as (
             else week_of_calendar_year + 52 - start_week_offset
         end as week_of_school_year
 
-        -- custom indicators
-        {% if custom_data_sources is not none and custom_data_sources | length -%}
-          {%- for source in custom_data_sources -%}
-            {%- for indicator in custom_data_sources[source] -%}
-              , {{ custom_data_sources[source][indicator]['where'] }} as {{ indicator }}
-            {%- endfor -%}
-          {%- endfor -%}
-        {%- endif %}
+        -- custom data sources columns
+        {{ add_cds_columns(custom_data_sources=custom_data_sources) }}
     from augmented
     join week_offset
         on augmented.k_school_calendar = week_offset.k_school_calendar
+    
     -- custom data sources
-    {% if custom_data_sources is not none and custom_data_sources | length -%}
-      {%- for source in custom_data_sources -%}
-        left join {{ ref(source) }}
-          on augmented.k_calendar_date = {{ source }}.k_calendar_date
-      {% endfor %}
-    {%- endif %}
+    {{ add_cds_joins_v1(custom_data_sources=custom_data_sources, driving_alias='augmented', join_cols=['k_calendar_date']) }}
+    {{ add_cds_joins_v2(custom_data_sources=custom_data_sources) }}
 )
 select * from week_calculation
 order by tenant_code, k_school, calendar_date desc

--- a/models/core_warehouse/dim_class_period.sql
+++ b/models/core_warehouse/dim_class_period.sql
@@ -6,8 +6,8 @@
     ]
   )
 }}
-{# Load custom data sources from var #}
-{% set custom_data_sources = var("edu:class_period:custom_data_sources", []) %}
+{{ cds_depends_on('edu:class_period:custom_data_sources') }}
+{% set custom_data_sources = var('edu:class_period:custom_data_sources', []) %}
 
 with class_periods as (
     select * from {{ ref('stg_ef3__class_periods') }}
@@ -48,24 +48,15 @@ formatted as (
           else timediff(MINUTE, concat('2020-01-01 ', start_time)::timestamp, dateadd(hour, 12 , concat('2020-01-01 ', end_time)::timestamp))   
         end as period_duration
 
-        -- custom indicators
-        {% if custom_data_sources is not none and custom_data_sources | length -%}
-          {%- for source in custom_data_sources -%}
-            {%- for indicator in custom_data_sources[source] -%}
-              , {{ custom_data_sources[source][indicator]['where'] }} as {{ indicator }}
-            {%- endfor -%}
-          {%- endfor -%}
-        {%- endif %}
+        -- custom data sources columns
+        {{ add_cds_columns(custom_data_sources=custom_data_sources) }}
     from class_periods
     join dim_school
         on class_periods.k_school = dim_school.k_school
+
     -- custom data sources
-    {% if custom_data_sources is not none and custom_data_sources | length -%}
-      {%- for source in custom_data_sources -%}
-        left join {{ ref(source) }}
-          on class_periods.k_class_period = {{ source }}.k_class_period
-      {% endfor %}
-    {%- endif %}
+    {{ add_cds_joins_v1(custom_data_sources=custom_data_sources, driving_alias='class_periods', join_cols=['k_class_period']) }}
+    {{ add_cds_joins_v2(custom_data_sources=custom_data_sources) }}
 )
 select {{ edu_edfi_source.star('formatted', except=['meeting_time']) }}
 from formatted

--- a/models/core_warehouse/dim_classroom.sql
+++ b/models/core_warehouse/dim_classroom.sql
@@ -8,6 +8,9 @@
   )
 }}
 
+{{ cds_depends_on('edu:classroom:custom_data_sources') }}
+{% set custom_data_sources = var('edu:classroom:custom_data_sources', []) %}
+
 with locations as (
     select * from {{ ref('stg_ef3__locations') }}
 ),
@@ -22,9 +25,16 @@ formatted as (
         locations.classroom_id_code,
         locations.maximum_seating,
         locations.optimum_seating
+        
+        -- custom data sources columns
+        {{ add_cds_columns(custom_data_sources=custom_data_sources) }}
     from locations
     join dim_school
         on locations.k_school = dim_school.k_school
+
+    -- custom data sources
+    {{ add_cds_joins_v1(custom_data_sources=custom_data_sources, driving_alias='locations', join_cols=['k_location']) }}
+    {{ add_cds_joins_v2(custom_data_sources=custom_data_sources) }}
 )
 select * from formatted
 order by tenant_code, k_school, k_classroom

--- a/models/core_warehouse/dim_cohort.sql
+++ b/models/core_warehouse/dim_cohort.sql
@@ -7,6 +7,9 @@
   )
 }}
 
+{{ cds_depends_on('edu:cohort:custom_data_sources') }}
+{% set custom_data_sources = var('edu:cohort:custom_data_sources', []) %}
+
 with stg_cohorts as (
     select * from {{ ref('stg_ef3__cohorts') }}
 ),
@@ -23,7 +26,14 @@ formatted as (
         stg_cohorts.cohort_description,
         stg_cohorts.cohort_scope,
         stg_cohorts.cohort_type
+        
+        -- custom data sources_columns
+        {{ add_cds_columns(custom_data_sources=custom_data_sources) }}
     from stg_cohorts
+
+    -- custom data sources
+    {{ add_cds_joins_v1(custom_data_sources=custom_data_sources, driving_alias='stg_cohorts', join_cols=['k_cohort']) }}
+    {{ add_cds_joins_v2(custom_data_sources=custom_data_sources) }}
 )
 select * from formatted
 order by tenant_code, school_year desc, k_cohort

--- a/models/core_warehouse/dim_course_section.sql
+++ b/models/core_warehouse/dim_course_section.sql
@@ -10,8 +10,8 @@
   )
 }}
 
-{# Load custom data sources from var #}
-{% set custom_data_sources = var("edu:course_section:custom_data_sources", []) %}
+{{ cds_depends_on('edu:course_section:custom_data_sources') }}
+{% set custom_data_sources = var('edu:course_section:custom_data_sources', []) %}
   
 with offering as (
     select * from {{ ref('stg_ef3__course_offerings') }}
@@ -64,16 +64,10 @@ joined as (
         stg_ef3__sections.available_credits,
         stg_ef3__sections.available_credit_type,
         stg_ef3__sections.available_credit_conversion
-
+        
         -- todo: add characteristic indicators
-        -- custom indicators
-        {% if custom_data_sources is not none and custom_data_sources | length -%}
-          {%- for source in custom_data_sources -%}
-            {%- for indicator in custom_data_sources[source] -%}
-              , {{ custom_data_sources[source][indicator]['where'] }} as {{ indicator }}
-            {%- endfor -%}
-          {%- endfor -%}
-        {%- endif %}
+        -- custom data sources_columns
+        {{ add_cds_columns(custom_data_sources=custom_data_sources) }}
     from stg_ef3__sections
     join offering
         on stg_ef3__sections.k_course_offering = offering.k_course_offering
@@ -81,15 +75,10 @@ joined as (
         on offering.k_course = dim_course.k_course
     left join section_chars 
         on stg_ef3__sections.k_course_section = section_chars.k_course_section
+
     -- custom data sources
-    {% if custom_data_sources is not none and custom_data_sources | length -%}
-      {%- for source in custom_data_sources -%}
-      {%- if source != 'stg_ef3__sections' -%}
-        left join {{ ref(source) }}
-          on stg_ef3__sections.k_course_section = {{ source }}.k_course_section
-      {%- endif -%}
-      {% endfor %}
-    {%- endif %}
+    {{ add_cds_joins_v1(custom_data_sources=custom_data_sources, driving_alias='stg_ef3__sections', join_cols=['k_course_section']) }}
+    {{ add_cds_joins_v2(custom_data_sources=custom_data_sources) }}
 )
 select * from joined
 order by tenant_code, k_school, k_course_section

--- a/models/core_warehouse/dim_discipline_incident.sql
+++ b/models/core_warehouse/dim_discipline_incident.sql
@@ -8,6 +8,9 @@
   )
 }}
 
+{{ cds_depends_on('edu:discipline_incident:custom_data_sources') }}
+{% set custom_data_sources = var('edu:discipline_incident:custom_data_sources', []) %}
+
 with stg_discipline_incidents as (
     select * from {{ ref('stg_ef3__discipline_incidents') }}
 ),
@@ -51,11 +54,18 @@ formatted as (
         stg_discipline_incidents.reporter_description,
         stg_discipline_incidents.incident_location,
         behaviors.behavior_array
+        
+        -- custom data sources columns
+        {{ add_cds_columns(custom_data_sources=custom_data_sources) }}
     from stg_discipline_incidents
     -- behaviors are not required
     left join behaviors
         on stg_discipline_incidents.k_discipline_incident = behaviors.k_discipline_incident
     join dim_school
         on stg_discipline_incidents.k_school = dim_school.k_school
+
+    -- custom data sources
+    {{ add_cds_joins_v1(custom_data_sources=custom_data_sources, driving_alias='stg_discipline_incidents', join_cols=['k_discipline_incident']) }}
+    {{ add_cds_joins_v2(custom_data_sources=custom_data_sources) }}
 )
 select * from formatted

--- a/models/core_warehouse/dim_esc.sql
+++ b/models/core_warehouse/dim_esc.sql
@@ -7,6 +7,9 @@
   )
 }}
 
+{{ cds_depends_on('edu:esc:custom_data_sources') }}
+{% set custom_data_sources = var('edu:esc:custom_data_sources', []) %}
+
 with stg_esc as (
     select * from {{ ref('stg_ef3__education_service_centers') }}
 ),
@@ -40,9 +43,16 @@ formatted as (
         choose_address.county_fips_code,
         choose_address.latitude,
         choose_address.longitude
+        
+        -- custom data sources columns
+        {{ add_cds_columns(custom_data_sources=custom_data_sources) }}
     from stg_esc
     left join choose_address 
         on stg_esc.k_esc = choose_address.k_esc
+
+    -- custom data sources
+    {{ add_cds_joins_v1(custom_data_sources=custom_data_sources, driving_alias='stg_esc', join_cols=['k_esc']) }}
+    {{ add_cds_joins_v2(custom_data_sources=custom_data_sources) }}
 )
 select * from formatted
 order by tenant_code, k_esc

--- a/models/core_warehouse/dim_grading_period.sql
+++ b/models/core_warehouse/dim_grading_period.sql
@@ -8,6 +8,8 @@
   )
 }}
 
+{{ cds_depends_on('edu:grading_period:custom_data_sources') }}
+{% set custom_data_sources = var('edu:grading_period:custom_data_sources', []) %}
 
 with stg_grading_periods as (
     select * from {{ ref('stg_ef3__grading_periods') }}
@@ -26,9 +28,16 @@ formatted as (
         stg_grading_periods.begin_date,
         stg_grading_periods.end_date,
         stg_grading_periods.total_instructional_days
+
+        -- custom data sources columns
+        {{ add_cds_columns(custom_data_sources=custom_data_sources) }}
     from stg_grading_periods
     join dim_school
         on stg_grading_periods.k_school = dim_school.k_school
+
+    -- custom data sources
+    {{ add_cds_joins_v1(custom_data_sources=custom_data_sources, driving_alias='stg_grading_periods', join_cols=['k_grading_period']) }}
+    {{ add_cds_joins_v2(custom_data_sources=custom_data_sources) }}
 )
 select * from formatted
 order by tenant_code, k_school, k_grading_period

--- a/models/core_warehouse/dim_graduation_plan.sql
+++ b/models/core_warehouse/dim_graduation_plan.sql
@@ -7,6 +7,8 @@
   )
 }}
 
+{{ cds_depends_on('edu:graduation_plan:custom_data_sources') }}
+{% set custom_data_sources = var('edu:graduation_plan:custom_data_sources', []) %}
 
 with stg_graduation_plans as (
     select * from {{ ref('stg_ef3__graduation_plans') }}
@@ -33,8 +35,13 @@ formatted as (
 
         {{ edu_edfi_source.extract_extension(model_name='stg_ef3__graduation_plans', flatten=False) }}
 
-
+        -- custom data sources columns
+        {{ add_cds_columns(custom_data_sources=custom_data_sources) }}
     from stg_graduation_plans
+
+    -- custom data sources
+    {{ add_cds_joins_v1(custom_data_sources=custom_data_sources, driving_alias='stg_graduation_plans', join_cols=['k_graduation_plan']) }}
+    {{ add_cds_joins_v2(custom_data_sources=custom_data_sources) }}
 )
 select * from formatted
 order by tenant_code, k_graduation_plan

--- a/models/core_warehouse/dim_lea.sql
+++ b/models/core_warehouse/dim_lea.sql
@@ -7,6 +7,9 @@
   )
 }}
 
+{{ cds_depends_on('edu:lea:custom_data_sources') }}
+{% set custom_data_sources = var('edu:lea:custom_data_sources', []) %}
+
 with stg_lea as (
     select * from {{ ref('stg_ef3__local_education_agencies') }}
 ),
@@ -50,12 +53,19 @@ formatted as (
         choose_address.county_fips_code,
         choose_address.latitude,
         choose_address.longitude
+
+        -- custom data sources columns
+        {{ add_cds_columns(custom_data_sources=custom_data_sources) }}
     from stg_lea
     left join choose_address 
         on stg_lea.k_lea = choose_address.k_lea
     join tenant_lea_ownership
         on stg_lea.tenant_code = tenant_lea_ownership.tenant_code
-        and stg_lea.lea_id = tenant_lea_ownership.lea_id
+        and stg_lea.lea_id = cast(tenant_lea_ownership.lea_id as int)
+
+    -- custom data sources
+    {{ add_cds_joins_v1(custom_data_sources=custom_data_sources, driving_alias='stg_lea', join_cols=['k_lea']) }}
+    {{ add_cds_joins_v2(custom_data_sources=custom_data_sources) }}
 )
 select * from formatted
 order by tenant_code, k_lea

--- a/models/core_warehouse/dim_learning_standard.sql
+++ b/models/core_warehouse/dim_learning_standard.sql
@@ -7,6 +7,8 @@
   )
 }}
 
+{{ cds_depends_on('edu:learning_standard:custom_data_sources') }}
+{% set custom_data_sources = var('edu:learning_standard:custom_data_sources', []) %}
 
 with stg_learning_standards as (
     select * from {{ ref('stg_ef3__learning_standards') }}
@@ -30,7 +32,14 @@ formatted as (
         stg_learning_standards.v_grade_levels,
         stg_learning_standards.v_learning_standard_identification_codes,
         stg_learning_standards.v_content_standard
+
+        -- custom data sources columns
+        {{ add_cds_columns(custom_data_sources=custom_data_sources) }}
     from stg_learning_standards
+
+    -- custom data sources
+    {{ add_cds_joins_v1(custom_data_sources=custom_data_sources, driving_alias='stg_learning_standards', join_cols=['k_learning_standard']) }}
+    {{ add_cds_joins_v2(custom_data_sources=custom_data_sources) }}
 )
 select * from formatted
 order by tenant_code, k_learning_standard

--- a/models/core_warehouse/dim_network.sql
+++ b/models/core_warehouse/dim_network.sql
@@ -7,6 +7,8 @@
   )
 }}
 
+{{ cds_depends_on('edu:network:custom_data_sources') }}
+{% set custom_data_sources = var('edu:network:custom_data_sources', []) %}
 
 with stg_networks as (
     select * from {{ ref('stg_ef3__education_organization_networks') }}
@@ -21,7 +23,14 @@ formatted as (
         stg_networks.operational_status,
         stg_networks.network_short_name,
         stg_networks.website
+
+        -- custom data sources columns
+        {{ add_cds_columns(custom_data_sources=custom_data_sources) }}
     from stg_networks
+
+    -- custom data sources
+    {{ add_cds_joins_v1(custom_data_sources=custom_data_sources, driving_alias='stg_networks', join_cols=['k_network']) }}
+    {{ add_cds_joins_v2(custom_data_sources=custom_data_sources) }}
 )
 select * from formatted
 order by tenant_code, k_network

--- a/models/core_warehouse/dim_objective_assessment.sql
+++ b/models/core_warehouse/dim_objective_assessment.sql
@@ -8,6 +8,9 @@
   )
 }}
 
+{{ cds_depends_on('edu:objective_assessment:custom_data_sources') }}
+{% set custom_data_sources = var('edu:objective_assessment:custom_data_sources', []) %}
+
 with stg_obj_assessments as (
     select * from {{ ref('stg_ef3__objective_assessments') }}
 ),
@@ -52,6 +55,7 @@ formatted as (
         on stg_obj_assessments.k_objective_assessment = obj_assessment_scores.k_objective_assessment
     left join obj_assessment_pls
         on stg_obj_assessments.k_objective_assessment = obj_assessment_pls.k_objective_assessment
+
     -- left join fans out to one original row + one row per cross-tenant mapping
     left join dedupe_cross_tenant
         on stg_obj_assessments.k_objective_assessment = dedupe_cross_tenant.k_objective_assessment__original
@@ -64,6 +68,18 @@ dedupe_objective_assessments as (
             order_by='tenant_code,school_year'
         )
     }}
+),
+add_cds_columns as (
+    select dedupe_objective_assessments.*
+
+        -- custom data sources columns
+        {{ add_cds_columns(custom_data_sources=custom_data_sources) }}
+    from dedupe_objective_assessments
+
+    -- custom data sources
+    {{ add_cds_joins_v1(custom_data_sources=custom_data_sources, driving_alias='dedupe_objective_assessments', join_cols=['k_objective_assessment']) }}
+    {{ add_cds_joins_v2(custom_data_sources=custom_data_sources) }}
+
 )
-select * from dedupe_objective_assessments
+select * from add_cds_columns
 order by tenant_code, k_objective_assessment

--- a/models/core_warehouse/dim_program.sql
+++ b/models/core_warehouse/dim_program.sql
@@ -7,6 +7,9 @@
   )
 }}
 
+{{ cds_depends_on('edu:program:custom_data_sources') }}
+{% set custom_data_sources = var('edu:program:custom_data_sources', []) %}
+
 with stg_programs as (
     select * from {{ ref('stg_ef3__programs') }}
 ),
@@ -23,7 +26,14 @@ formatted as (
         stg_programs.program_id,
         stg_programs.program_name,
         stg_programs.program_type
+
+        -- custom data sources columns
+        {{ add_cds_columns(custom_data_sources=custom_data_sources) }}
     from stg_programs
+
+    -- custom data sources
+    {{ add_cds_joins_v1(custom_data_sources=custom_data_sources, driving_alias='stg_programs', join_cols=['k_program']) }}
+    {{ add_cds_joins_v2(custom_data_sources=custom_data_sources) }}
 )
 
 select * from formatted

--- a/models/core_warehouse/dim_school.sql
+++ b/models/core_warehouse/dim_school.sql
@@ -20,8 +20,9 @@
     ]
   )
 }}
-{# Load custom data sources from var #}
-{% set custom_data_sources = var("edu:schools:custom_data_sources", []) %}
+
+{{ cds_depends_on('edu:schools:custom_data_sources') }}
+{% set custom_data_sources = var('edu:schools:custom_data_sources', []) %}
 
 with stg_school as (
     select * from {{ ref('stg_ef3__schools') }}
@@ -98,14 +99,8 @@ formatted as (
         choose_address.latitude,
         choose_address.longitude
 
-        -- custom data sources
-        {% if custom_data_sources is not none and custom_data_sources | length -%}
-          {%- for source in custom_data_sources -%}
-            {%- for indicator in custom_data_sources[source] -%}
-              , {{ custom_data_sources[source][indicator]['where'] }} as {{ indicator }}
-            {%- endfor -%}
-          {%- endfor -%}
-        {%- endif %}
+        -- custom data sources columns
+        {{ add_cds_columns(custom_data_sources=custom_data_sources) }}
     from stg_school
     join dim_lea 
         on stg_school.k_lea = dim_lea.k_lea
@@ -115,13 +110,10 @@ formatted as (
         on stg_school.k_school = choose_address.k_school
     left join bld_network_associations
         on stg_school.k_school = bld_network_associations.k_school
+
     -- custom data sources
-    {% if custom_data_sources is not none and custom_data_sources | length -%}
-      {%- for source in custom_data_sources -%}
-        left join {{ ref(source) }}
-          on stg_school.k_school = {{ source }}.k_school
-      {% endfor %}
-    {%- endif %}
+    {{ add_cds_joins_v1(custom_data_sources=custom_data_sources, driving_alias='stg_school', join_cols=['k_school']) }}
+    {{ add_cds_joins_v2(custom_data_sources=custom_data_sources) }}
 )
 select * from formatted
 order by tenant_code, k_school

--- a/models/core_warehouse/dim_school_calendar.sql
+++ b/models/core_warehouse/dim_school_calendar.sql
@@ -8,6 +8,9 @@
   )
 }}
 
+{{ cds_depends_on('edu:school_calendar:custom_data_sources') }}
+{% set custom_data_sources = var('edu:school_calendar:custom_data_sources', []) %}
+
 with stg_calendar as (
     select * from {{ ref('stg_ef3__calendars') }}
 ),
@@ -33,11 +36,18 @@ formatted as (
         stg_calendar.calendar_code,
         stg_calendar.calendar_type,
         aggregated_grades.applicable_grade_levels_array
+
+        -- custom data sources columns
+        {{ add_cds_columns(custom_data_sources=custom_data_sources) }}
     from stg_calendar
     join dim_school
         on stg_calendar.k_school = dim_school.k_school
     left join aggregated_grades
         on stg_calendar.k_school_calendar = aggregated_grades.k_school_calendar
+
+    -- custom data sources
+    {{ add_cds_joins_v1(custom_data_sources=custom_data_sources, driving_alias='stg_calendar', join_cols=['k_school_calendar']) }}
+    {{ add_cds_joins_v2(custom_data_sources=custom_data_sources) }}
 )
 select * from formatted
 order by tenant_code, k_school, k_school_calendar

--- a/models/core_warehouse/dim_session.sql
+++ b/models/core_warehouse/dim_session.sql
@@ -8,6 +8,9 @@
   )
 }}
 
+{{ cds_depends_on('edu:session:custom_data_sources') }}
+{% set custom_data_sources = var('edu:session:custom_data_sources', []) %}
+
 with stg_sessions as (
     select * from {{ ref('stg_ef3__sessions') }}
 ),
@@ -25,9 +28,16 @@ formatted as (
         stg_sessions.session_end_date,
         stg_sessions.total_instructional_days,
         stg_sessions.academic_term
+
+        -- custom data sources columns
+        {{ add_cds_columns(custom_data_sources=custom_data_sources) }}
     from stg_sessions
     join dim_school
         on stg_sessions.k_school = dim_school.k_school
+
+    -- custom data sources
+    {{ add_cds_joins_v1(custom_data_sources=custom_data_sources, driving_alias='stg_sessions', join_cols=['k_session']) }}
+    {{ add_cds_joins_v2(custom_data_sources=custom_data_sources) }}
 )
 select * from formatted
 order by tenant_code, k_school, session_begin_date desc

--- a/models/core_warehouse/dim_staff.sql
+++ b/models/core_warehouse/dim_staff.sql
@@ -6,8 +6,9 @@
     ]
   )
 }}
-{# Load custom data sources from var #}
-{% set custom_data_sources = var("edu:staff:custom_data_sources", []) %}
+
+{{ cds_depends_on('edu:staff:custom_data_sources') }}
+{% set custom_data_sources = var('edu:staff:custom_data_sources', []) %}
 
 with stg_staff as (
     select * from {{ ref('stg_ef3__staffs') }}
@@ -56,14 +57,8 @@ formatted as (
         stg_staff.years_of_prior_professional_experience,
         stg_staff.years_of_prior_teaching_experience
 
-        -- custom indicators
-        {% if custom_data_sources is not none and custom_data_sources | length -%}
-          {%- for source in custom_data_sources -%}
-            {%- for indicator in custom_data_sources[source] -%}
-              , {{ custom_data_sources[source][indicator]['where'] }} as {{ indicator }}
-            {%- endfor -%}
-          {%- endfor -%}
-        {%- endif %}
+        -- custom data sources columns
+        {{ add_cds_columns(custom_data_sources=custom_data_sources) }}
     from stg_staff
     left join bld_ef3__wide_ids_staff 
         on stg_staff.k_staff = bld_ef3__wide_ids_staff.k_staff
@@ -71,13 +66,10 @@ formatted as (
         on stg_staff.k_staff = choose_email.k_staff
     left join staff_race_ethnicity
         on stg_staff.k_staff = staff_race_ethnicity.k_staff
+
     -- custom data sources
-    {% if custom_data_sources is not none and custom_data_sources | length -%}
-      {%- for source in custom_data_sources -%}
-        left join {{ ref(source) }}
-          on stg_staff.k_staff = {{ source }}.k_staff
-      {% endfor %}
-    {%- endif %}
+    {{ add_cds_joins_v1(custom_data_sources=custom_data_sources, driving_alias='stg_staff', join_cols=['k_staff']) }}
+    {{ add_cds_joins_v2(custom_data_sources=custom_data_sources) }}
 )
 select * from formatted
 order by tenant_code, k_staff

--- a/models/core_warehouse/dim_subgroup.sql
+++ b/models/core_warehouse/dim_subgroup.sql
@@ -8,6 +8,9 @@
     )
 }}
 
+{{ cds_depends_on('edu:subgroup:custom_data_sources') }}
+{% set custom_data_sources = var('edu:subgroup:custom_data_sources', []) %}
+
 with dim_student as (
     select * from {{ ref('dim_student') }}
 ),
@@ -90,7 +93,14 @@ keyed as (
     joined_with_display_names.subgroup_category_display_name,
     joined_with_display_names.subgroup_value,
     joined_with_display_names.subgroup_value_display_name
+
+    -- custom data sources columns
+    {{ add_cds_columns(custom_data_sources=custom_data_sources) }}
   from joined_with_display_names
+
+  -- custom data sources
+  {{ add_cds_joins_v1(custom_data_sources=custom_data_sources, driving_alias='joined_with_display_names', join_cols=['subgroup_category', 'subgroup_value']) }}
+  {{ add_cds_joins_v2(custom_data_sources=custom_data_sources) }}
 )
 
 select * from keyed

--- a/models/core_warehouse/fct_staff_school_association.sql
+++ b/models/core_warehouse/fct_staff_school_association.sql
@@ -9,6 +9,9 @@
   )
 }}
 
+{{ cds_depends_on('edu:staff_school_association:custom_data_sources') }}
+{% set custom_data_sources = var('edu:staff_school_association:custom_data_sources', []) %}
+
 with stg_staff_school as (
     select * from {{ ref('stg_ef3__staff_school_associations') }}
 ),
@@ -104,5 +107,17 @@ check_active as (
             true, false
         ) as is_active_assignment
     from formatted
+),
+cds_cols as (
+    select 
+        ca.*
+
+        -- custom data sources columns
+        {{ add_cds_columns(custom_data_sources=custom_data_sources) }}
+    from check_active ca
+
+    -- custom data sources
+    {{ add_cds_joins_v1(custom_data_sources=custom_data_sources, driving_alias='ca', join_cols=['k_staff_school_association']) }}
+    {{ add_cds_joins_v2(custom_data_sources=custom_data_sources) }}
 )
-select * from check_active
+select * from cds_cols

--- a/models/core_warehouse/fct_student_academic_record.sql
+++ b/models/core_warehouse/fct_student_academic_record.sql
@@ -8,6 +8,9 @@
   )
 }}
 
+{{ cds_depends_on('edu:student_academic_record:custom_data_sources') }}
+{% set custom_data_sources = var('edu:student_academic_record:custom_data_sources', []) %}
+
 with stg_academic_record as (
     select * from {{ ref('stg_ef3__student_academic_records') }}
 ),
@@ -46,11 +49,18 @@ formatted as (
         stg_academic_record.session_attempted_credit_conversion
         {# add any extension columns configured from stg_ef3__student_academic_records #}
         {{ edu_edfi_source.extract_extension(model_name='stg_ef3__student_academic_records', flatten=False) }}
+        
+        -- custom data sources columns
+        {{ add_cds_columns(custom_data_sources=custom_data_sources) }}
     from stg_academic_record
     left join dim_school
         on stg_academic_record.k_school = dim_school.k_school
     left join dim_student
         on stg_academic_record.k_student_xyear = dim_student.k_student_xyear
         and stg_academic_record.school_year = dim_student.school_year
+        
+    -- custom data sources
+    {{ add_cds_joins_v1(custom_data_sources=custom_data_sources, driving_alias='stg_academic_record', join_cols=['k_student_academic_record']) }}
+    {{ add_cds_joins_v2(custom_data_sources=custom_data_sources) }}
 )
 select * from formatted

--- a/models/core_warehouse/fct_student_assessment.sql
+++ b/models/core_warehouse/fct_student_assessment.sql
@@ -43,7 +43,8 @@ combined_with_cross_tenant as (
         {{ accordion_columns(
             source_table='stg_ef3__student_assessments',
             source_alias='student_assessments',
-            exclude_columns=['k_student_assessment', 'k_assessment', 'k_student', 'k_student_xyear', 'tenant_code', 'school_year']) }}
+            exclude_columns=['k_student_assessment', 'k_assessment', 'k_student', 'k_student_xyear', 'tenant_code', 'school_year'],
+            add_trailing_comma=false) }}
     from student_assessments
     -- left join because this model can return empty
         -- and to avoid enforcing a current school association

--- a/models/core_warehouse/fct_student_assessment.sql
+++ b/models/core_warehouse/fct_student_assessment.sql
@@ -9,6 +9,9 @@
   )
 }}
 
+{{ cds_depends_on('edu:student_assessment:custom_data_sources') }}
+{% set custom_data_sources = var('edu:student_assessment:custom_data_sources', []) %}
+
 with student_assessments_long_results as (
     select * from {{ ref('bld_ef3__student_assessments_long_results') }}
 ),
@@ -121,6 +124,13 @@ student_assessments_wide as (
 select
     {{ edu_edfi_source.star('student_assessments_wide', except=([] if var('edu:assessment:cross_tenant_enabled', False) else ['k_student_assessment__original', 'is_original_record', 'original_tenant_code'])) }},
     v_other_results
+    
+    -- custom data sources columns
+    {{ add_cds_columns(custom_data_sources=custom_data_sources) }}
+
 from student_assessments_wide
 left join object_agg_other_results
     on student_assessments_wide.k_student_assessment__original = object_agg_other_results.k_student_assessment
+-- custom data sources
+{{ add_cds_joins_v1(custom_data_sources=custom_data_sources, driving_alias='student_assessments_wide', join_cols=['k_student_assessment']) }}
+{{ add_cds_joins_v2(custom_data_sources=custom_data_sources) }}

--- a/models/core_warehouse/fct_student_cohort_association.sql
+++ b/models/core_warehouse/fct_student_cohort_association.sql
@@ -11,6 +11,9 @@
   )
 }}
 
+{{ cds_depends_on('edu:student_cohort_association:custom_data_sources') }}
+{% set custom_data_sources = var('edu:student_cohort_association:custom_data_sources', []) %}
+
 with stage as (
     select * from {{ ref('stg_ef3__student_cohort_associations') }}
 ),
@@ -48,13 +51,18 @@ formatted as (
         ) as is_active_cohort_association
         {# add any extension columns configured from stg_ef3__student_cohort_associations #}
         {{ edu_edfi_source.extract_extension(model_name='stg_ef3__student_cohort_associations', flatten=False) }}
+        
+        -- custom data sources columns
+        {{ add_cds_columns(custom_data_sources=custom_data_sources) }}
     from stage
-
         inner join dim_student
             on stage.k_student = dim_student.k_student
-
         inner join dim_cohort
             on stage.k_cohort = dim_cohort.k_cohort
+        
+        -- custom data sources
+        {{ add_cds_joins_v1(custom_data_sources=custom_data_sources, driving_alias='stage', join_cols=['k_student', 'k_cohort', 'cohort_begin_date']) }}
+        {{ add_cds_joins_v2(custom_data_sources=custom_data_sources) }}
 )
 
 select * from formatted

--- a/models/core_warehouse/fct_student_cte_program_associations.sql
+++ b/models/core_warehouse/fct_student_cte_program_associations.sql
@@ -2,11 +2,13 @@
 {{ 
   config(
     post_hook=[
+        "alter table {{ this }} alter column k_student_program set not null",
         "alter table {{ this }} alter column k_student set not null",
         "alter table {{ this }} alter column k_student_xyear set not null",
         "alter table {{ this }} alter column k_program set not null",
         "alter table {{ this }} alter column program_enroll_begin_date set not null",
-        "alter table {{ this }} add primary key (k_student, k_student_xyear, k_program, program_enroll_begin_date)",
+        "alter table {{ this }} alter column ed_org_id set not null",
+        "alter table {{ this }} add primary key (k_student_program)",
         "alter table {{ this }} add constraint fk_{{ this.name }}_student foreign key (k_student) references {{ ref('dim_student') }}",
         "alter table {{ this }} add constraint fk_{{ this.name }}_program foreign key (k_program) references {{ ref('dim_program') }}"
     ]
@@ -27,11 +29,14 @@ dim_program as (
 
 formatted as (
     select
+        stage.k_student_program,
         dim_student.k_student,
         dim_student.k_student_xyear,
         dim_program.k_program,
         dim_program.k_lea,
         dim_program.k_school,
+        stage.ed_org_id,
+
         stage.tenant_code,
         dim_program.school_year,
         stage.program_enroll_begin_date,

--- a/models/core_warehouse/fct_student_cte_program_associations.yml
+++ b/models/core_warehouse/fct_student_cte_program_associations.yml
@@ -7,8 +7,7 @@ models:
         This fact table contains student cte program enrollment information.
 
       ##### Primary Key:
-        `k_student, k_student_xyear, k_program, program_enroll_begin_date` -- There 
-        is one record per student, year, program enrol begin date, and cte program.
+        `k_student_program` -- There is one record per student, year, ed_org_id, program enroll begin date, and cte program.
 
     config:
       tags: ['cte']
@@ -20,13 +19,17 @@ models:
             combination_of_columns:
               - k_student
               - k_program
+              - ed_org_id
+              - program_enroll_begin_date
 
     columns:
+      - name: k_student_program
       - name: k_student
       - name: k_student_xyear
       - name: k_program
       - name: k_lea
       - name: k_school
+      - name: ed_org_id
       - name: tenant_code
       - name: school_year
       - name: program_enroll_begin_date

--- a/models/core_warehouse/fct_student_daily_attendance.sql
+++ b/models/core_warehouse/fct_student_daily_attendance.sql
@@ -233,7 +233,7 @@ cumulatives as (
         cumulative_days_enrolled >= {{ var('edu:attendance:chronic_absence_min_days') }} as meets_enrollment_threshold,
         {{ msr_chronic_absentee('cumulative_attendance_rate', 'cumulative_days_enrolled') }} as is_chronic_absentee,
         excusal_status_streaks.event_duration,
-        excusal_status_streaks.school_attendance_duration,
+        excusal_status_streaks.school_attendance_duration
     from excusal_status_streaks
 ),
 metric_labels as (

--- a/models/core_warehouse/fct_student_daily_attendance.sql
+++ b/models/core_warehouse/fct_student_daily_attendance.sql
@@ -12,6 +12,9 @@
   )
 }}
 
+{{ cds_depends_on('edu:student_daily_attendance:custom_data_sources') }}
+{% set custom_data_sources = var('edu:student_daily_attendance:custom_data_sources', []) %}
+
 with fct_student_school_att as (
     select * from {{ ref(var("edu:attendance:daily_attendance_source", 'fct_student_school_attendance_event')) }}
 ),
@@ -247,10 +250,17 @@ metric_labels as (
             when meets_enrollment_threshold then metric_absentee_categories.level_label 
             else null
         end as absentee_category_label
+        
+        -- custom data sources columns
+        {{ add_cds_columns(custom_data_sources=custom_data_sources) }}
     from cumulatives
     left join metric_absentee_categories
         on cumulative_attendance_rate > metric_absentee_categories.threshold_lower
         and cumulative_attendance_rate <= metric_absentee_categories.threshold_upper
+        
+    -- custom data sources
+    {{ add_cds_joins_v1(custom_data_sources=custom_data_sources, driving_alias='cumulatives', join_cols=['k_student', 'k_school', 'calendar_date']) }}
+    {{ add_cds_joins_v2(custom_data_sources=custom_data_sources) }}
 )
 
 select * from metric_labels 

--- a/models/core_warehouse/fct_student_diploma.sql
+++ b/models/core_warehouse/fct_student_diploma.sql
@@ -1,5 +1,8 @@
 {% set xwalk_academic_term_enabled = var('edu:xwalk_academic_terms:enabled', False) %}
 
+{{ cds_depends_on('edu:student_diploma:custom_data_sources') }}
+{% set custom_data_sources = var('edu:student_diploma:custom_data_sources', []) %}
+
 with stg_diplomas as (
     select * from {{ ref('stg_ef3__student_academic_records__diplomas') }}
 ),
@@ -53,11 +56,18 @@ joined_with_xwalk as (
         {% else %}
         1 as sort_index
         {% endif %}
+
+        -- custom data sources columns
+        {{ add_cds_columns(custom_data_sources=custom_data_sources) }}
     from joined_diploma
     {% if xwalk_academic_term_enabled %}
     left join xwalk_academic_terms
         on joined_diploma.academic_term = xwalk_academic_terms.academic_term
     {% endif %}
+        
+    -- custom data sources
+    {{ add_cds_joins_v1(custom_data_sources=custom_data_sources, driving_alias='joined_diploma', join_cols=['k_student', 'school_year', 'k_lea', 'k_school', 'diploma_type', 'diploma_award_date']) }}
+    {{ add_cds_joins_v2(custom_data_sources=custom_data_sources) }}
 ),
 dedupe_diplomas as (
      {{

--- a/models/core_warehouse/fct_student_disability.sql
+++ b/models/core_warehouse/fct_student_disability.sql
@@ -1,0 +1,72 @@
+{{
+  config(
+    post_hook=[
+        "alter table {{ this }} alter column k_student_disability set not null",
+        "alter table {{ this }} alter column k_student set not null",
+        "alter table {{ this }} alter column disability_type set not null",
+        "alter table {{ this }} add primary key (k_student_disability)",
+        "alter table {{ this }} add constraint fk_{{ this.name }}_student foreign key (k_student) references {{ ref('dim_student') }}",
+        "alter table {{ this }} add constraint fk_{{ this.name }}_program foreign key (k_program) references {{ ref('dim_program') }}",
+        "alter table {{ this }} add constraint fk_{{ this.name }}_lea foreign key (k_lea) references {{ ref('dim_lea') }}",
+        "alter table {{ this }} add constraint fk_{{ this.name }}_school foreign key (k_school) references {{ ref('dim_school') }}",
+    ]
+  )
+}}
+
+with student_disabilities as (
+    select * from {{ ref('bld_ef3__student__disabilities') }}
+),
+dim_student as (
+    select * from {{ ref('dim_student') }}
+),
+student_disability_designations as (
+    select * from {{ ref('bld_ef3__student__wide_disability_designations') }}
+),
+formatted as (
+    select
+        {{ dbt_utils.generate_surrogate_key(
+            ['sd.tenant_code',
+            'sd.school_year',
+            'sd.k_student',
+            'sd.k_lea',
+            'sd.k_school',
+            'sd.k_program',
+            'sd.ed_org_id',
+            'sd.program_enroll_begin_date',]
+        ) }} as k_student_disability, 
+        sd.k_student,
+        stu.k_student_xyear,
+        sd.k_lea,
+        sd.k_school,
+        sd.k_program,
+        sd.ed_org_id,
+        sd.program_enroll_begin_date,
+        sd.program_enroll_end_date,
+        sd.tenant_code,
+        sd.api_year,
+        sd.school_year,
+        sd.disability_type,
+        sd.disability_source_type,
+        sd.disability_diagnosis,
+        sd.order_of_disability,
+        -- disability designations
+        {{ accordion_columns(
+            source_table='bld_ef3__student__wide_disability_designations',
+            exclude_columns=['tenant_code', 'api_year', 'school_year', 'k_student', 'ed_org_id', 'k_lea', 'k_school', 'k_program', 'disability_type'],
+            source_alias='disability_designations',
+            add_trailing_comma=false
+        ) }}
+    from student_disabilities sd
+    join dim_student stu
+        on stu.k_student = sd.k_student
+    left join student_disability_designations disability_designations
+        on sd.k_student = disability_designations.k_student
+        and (sd.k_lea = disability_designations.k_lea or (sd.k_lea is null and disability_designations.k_lea is null))
+        and (sd.k_school = disability_designations.k_school or (sd.k_school is null and disability_designations.k_school is null))
+        and (sd.k_program = disability_designations.k_program or (sd.k_program is null and disability_designations.k_program is null))
+        and sd.ed_org_id = disability_designations.ed_org_id
+        and sd.tenant_code = disability_designations.tenant_code
+        and sd.school_year = disability_designations.school_year
+        and sd.disability_type = disability_designations.disability_type
+)
+select * from formatted

--- a/models/core_warehouse/fct_student_disability.sql
+++ b/models/core_warehouse/fct_student_disability.sql
@@ -13,6 +13,9 @@
   )
 }}
 
+{{ cds_depends_on('edu:student_disability:custom_data_sources') }}
+{% set custom_data_sources = var('edu:student_disability:custom_data_sources', []) %}
+
 with student_disabilities as (
     select * from {{ ref('bld_ef3__student__disabilities') }}
 ),
@@ -68,5 +71,17 @@ formatted as (
         and sd.tenant_code = disability_designations.tenant_code
         and sd.school_year = disability_designations.school_year
         and sd.disability_type = disability_designations.disability_type
+),
+cds_cols as (
+    select
+        f.*
+
+        -- custom data sources columns
+        {{ add_cds_columns(custom_data_sources=custom_data_sources) }}
+    from formatted f
+
+    -- custom data sources
+    {{ add_cds_joins_v1(custom_data_sources=custom_data_sources, driving_alias='f', join_cols=['k_student_disability']) }}
+    {{ add_cds_joins_v2(custom_data_sources=custom_data_sources) }}
 )
-select * from formatted
+select * from cds_cols

--- a/models/core_warehouse/fct_student_disability.yml
+++ b/models/core_warehouse/fct_student_disability.yml
@@ -1,0 +1,86 @@
+version: 3
+
+models: 
+  - name: fct_student_disability
+    description: >
+     ##### Overview:
+       This fact table provides student disabilities, which could be assigned from multiple sources.
+       It references any or all of the following models:
+      - [stg_ef3__stu_ed_org__disabilities](#!/model/model.edu_edfi_source.stg_ef3__stu_ed_org__disabilities)
+      - [stg_ef3__stu_spec_ed__disabilities](#!/model/model.edu_edfi_source.stg_ef3__stu_spec_ed__disabilities)
+
+     ##### Primary Key:
+       `k_student_disability` --
+       There is one record per student, year, ed org / program
+
+     ##### Important business rules:
+        - This table is at two different grains since both Ed Orgs and Special Ed Programs can have disabilities listed. This is why this table has 
+           a surrogate key being made up of the two grains that fit in this table. If k_program is null then this is an ed org disability. 
+           If k_program is not null then it is a program disability. 
+        - `program_enroll_begin_date` is included in the unique key, because a student may be associated with the same program at multiple times,
+           and those associations may have different disabilities. When joining this table to `fct_student_{program_type}_program_association`,
+           always include `program_enroll_begin_date` in the join (see example query below).
+
+     ##### Example Use Cases:
+       1. Join Disabilities to Student Special Education data to find students' Special Ed disabilities
+       they received as part of that program:  
+         
+        ```
+          SELECT
+            assoc.k_student,
+            assoc.school_year,
+            assoc.k_program,
+            dim_program.program_type,
+            dim_program.program_id,
+            dim_program.program_name,
+            assoc.program_enroll_begin_date,
+            assoc.program_enroll_end_date,
+            dis.disability_type,
+            dis.disability_source_type,
+            dis.disability_diagnosis,
+            dis.order_of_disability
+          FROM analytics.prod_wh.fct_student_special_education_program_association assoc
+          JOIN analytics.prod_wh.dim_program
+            ON assoc.k_program = dim_program.k_program
+          -- left join because some programs may not have disabilities
+          LEFT join analytics.prod_wh.fct_student_disability dis
+            ON assoc.k_student = dis.k_student
+            AND assoc.k_program = dis.k_program
+            AND assoc.program_enroll_begin_date = dis.program_enroll_begin_date;
+        ```
+
+
+    config:
+      tags: ['special_ed']
+      enabled: >
+        {%- set var_values = [] -%}
+        {%- for variable in [
+             'src:program:special_ed:enabled',
+        ] -%}
+           {%- do var_values.append(var(variable, none)) -%}
+        {%- endfor -%}
+
+        {%- if True in var_values -%}
+           {{ True  | as_bool }}
+        {%- elif False in var_values -%}
+           {{ False | as_bool }}
+        {%- else -%}
+           {{ True  | as_bool }}
+        {%- endif -%}
+        
+    columns:
+      - name: k_student_disability, 
+      - name: k_student
+      - name: k_student_xyear
+      - name: k_lea
+      - name: k_school
+      - name: k_program
+      - name: program_enroll_begin_date
+      - name: program_enroll_end_date
+      - name: tenant_code
+      - name: api_year
+      - name: school_year
+      - name: disability_type
+      - name: disability_source_type
+      - name: disability_diagnosis
+      - name: order_of_disability

--- a/models/core_warehouse/fct_student_discipline_actions_summary.sql
+++ b/models/core_warehouse/fct_student_discipline_actions_summary.sql
@@ -9,6 +9,9 @@
   )
 }}
 
+{{ cds_depends_on('edu:student_discipline_actions_summary:custom_data_sources') }}
+{% set custom_data_sources = var('edu:student_discipline_actions_summary:custom_data_sources', []) %}
+
 with stu_discipline_incident_behaviors_actions as (
     select * from {{ ref('stg_ef3__discipline_actions__student_discipline_incident_behaviors') }}
 ),
@@ -73,6 +76,9 @@ formatted as (
         {{ edu_edfi_source.extract_extension(model_name='stg_ef3__discipline_actions__student_discipline_incident_behaviors', flatten=False) }}
         {# add any extension columns configured from stg_ef3__discipline_actions__disciplines #}
         {{ edu_edfi_source.extract_extension(model_name='stg_ef3__discipline_actions__disciplines', flatten=False) }}
+
+        -- custom data sources columns
+        {{ add_cds_columns(custom_data_sources=custom_data_sources) }}
     from fct_student_discipline_actions
     left join stu_discipline_incident_behaviors_actions
         on fct_student_discipline_actions.k_student = stu_discipline_incident_behaviors_actions.k_student
@@ -96,6 +102,11 @@ formatted as (
         and fct_student_discipline_actions.k_student_xyear = behaviors_array.k_student_xyear
         and fct_student_discipline_actions.discipline_action_id = behaviors_array.discipline_action_id
         and fct_student_discipline_actions.discipline_date = behaviors_array.discipline_date
+        
+    -- custom data sources
+    {{ add_cds_joins_v1(custom_data_sources=custom_data_sources, driving_alias='fct_student_discipline_actions', join_cols=['k_student', 'k_discipline_actions_event']) }}
+    {{ add_cds_joins_v2(custom_data_sources=custom_data_sources) }}
+    
     -- in order to keep the grain of k_student and k_discipline_actions_event, we want to keep this subset 
     -- even if we do not have the severity orders defined
     qualify 1 = row_number() over (partition by fct_student_discipline_actions.k_student, fct_student_discipline_actions.k_discipline_actions_event order by fct_student_discipline_actions.severity_order desc nulls last, fct_student_discipline_incident_behaviors.severity_order desc nulls last)

--- a/models/core_warehouse/fct_student_discipline_incident_behaviors.sql
+++ b/models/core_warehouse/fct_student_discipline_incident_behaviors.sql
@@ -13,6 +13,9 @@
   )
 }}
 
+{{ cds_depends_on('edu:student_discipline_incident_behaviors:custom_data_sources') }}
+{% set custom_data_sources = var('edu:student_discipline_incident_behaviors:custom_data_sources', []) %}
+
 with stg_stu_discipline_incident_behaviors as (
     select * from {{ ref('stg_ef3__student_discipline_incident_behavior_associations') }}
 ),
@@ -76,6 +79,9 @@ formatted as (
         participation_codes.participation_codes_array
         {# add any extension columns configured from stg_ef3__student_discipline_incident_behavior_associations #}
         {{ edu_edfi_source.extract_extension(model_name='stg_ef3__student_discipline_incident_behavior_associations', flatten=False) }}
+
+        -- custom data sources columns
+        {{ add_cds_columns(custom_data_sources=custom_data_sources) }}
     from stg_stu_discipline_incident_behaviors
     left join participation_codes 
         on stg_stu_discipline_incident_behaviors.k_student = participation_codes.k_student
@@ -86,6 +92,10 @@ formatted as (
     join dim_discipline_incident on stg_stu_discipline_incident_behaviors.k_discipline_incident = dim_discipline_incident.k_discipline_incident
     left join xwalk_discipline_behaviors
         on stg_stu_discipline_incident_behaviors.behavior_type = xwalk_discipline_behaviors.behavior_type
+        
+    -- custom data sources
+    {{ add_cds_joins_v1(custom_data_sources=custom_data_sources, driving_alias='stg_stu_discipline_incident_behaviors', join_cols=['k_student', 'k_discipline_incident', 'behavior_type']) }}
+    {{ add_cds_joins_v2(custom_data_sources=custom_data_sources) }}
 )
 select *
 from formatted

--- a/models/core_warehouse/fct_student_discipline_incident_non_offenders.sql
+++ b/models/core_warehouse/fct_student_discipline_incident_non_offenders.sql
@@ -11,6 +11,9 @@
   )
 }}
 
+{{ cds_depends_on('edu:student_discipline_incident_non_offenders:custom_data_sources') }}
+{% set custom_data_sources = var('edu:student_discipline_incident_non_offenders:custom_data_sources', []) %}
+
 with stg_stu_discipline_incident_non_offenders as (
     select * from {{ ref('stg_ef3__student_discipline_incident_non_offender_associations') }}
 ),
@@ -47,6 +50,9 @@ formatted as (
         participation_codes.participation_codes_array
         {# add any extension columns configured from stg_ef3__student_discipline_incident_non_offender_associations #}
         {{ edu_edfi_source.extract_extension(model_name='stg_ef3__student_discipline_incident_non_offender_associations', flatten=False) }}
+
+        -- custom data sources columns
+        {{ add_cds_columns(custom_data_sources=custom_data_sources) }}
     from stg_stu_discipline_incident_non_offenders
     join participation_codes 
         on stg_stu_discipline_incident_non_offenders.k_student = participation_codes.k_student
@@ -55,6 +61,10 @@ formatted as (
     join dim_student on stg_stu_discipline_incident_non_offenders.k_student = dim_student.k_student
     join dim_school on stg_stu_discipline_incident_non_offenders.k_school = dim_school.k_school
     join dim_discipline_incident on stg_stu_discipline_incident_non_offenders.k_discipline_incident = dim_discipline_incident.k_discipline_incident
+        
+    -- custom data sources
+    {{ add_cds_joins_v1(custom_data_sources=custom_data_sources, driving_alias='stg_stu_discipline_incident_non_offenders', join_cols=['k_student', 'k_discipline_incident']) }}
+    {{ add_cds_joins_v2(custom_data_sources=custom_data_sources) }}
 )
 select *
 from formatted

--- a/models/core_warehouse/fct_student_discipline_incident_summary.sql
+++ b/models/core_warehouse/fct_student_discipline_incident_summary.sql
@@ -11,6 +11,9 @@
   )
 }}
 
+{{ cds_depends_on('edu:student_discipline_incident_summary:custom_data_sources') }}
+{% set custom_data_sources = var('edu:student_discipline_incident_summary:custom_data_sources', []) %}
+
 with stu_discipline_incident_behaviors_actions as (
     select * from {{ ref('stg_ef3__discipline_actions__student_discipline_incident_behaviors') }}
 ),
@@ -68,6 +71,9 @@ formatted as (
         {{ edu_edfi_source.extract_extension(model_name='stg_ef3__discipline_actions__student_discipline_incident_behaviors', flatten=False) }}
         {# add any extension columns configured from stg_ef3__discipline_actions__disciplines #}
         {{ edu_edfi_source.extract_extension(model_name='stg_ef3__discipline_actions__disciplines', flatten=False) }}
+
+        -- custom data sources columns
+        {{ add_cds_columns(custom_data_sources=custom_data_sources) }}
     from fct_student_discipline_incident_behaviors
     left join stu_discipline_incident_behaviors_actions
         on fct_student_discipline_incident_behaviors.k_student = stu_discipline_incident_behaviors_actions.k_student
@@ -90,6 +96,11 @@ formatted as (
         on fct_student_discipline_incident_behaviors.k_student = actions_array.k_student
         and fct_student_discipline_incident_behaviors.k_student_xyear = actions_array.k_student_xyear
         and fct_student_discipline_incident_behaviors.incident_id = actions_array.incident_id
+        
+    -- custom data sources
+    {{ add_cds_joins_v1(custom_data_sources=custom_data_sources, driving_alias='fct_student_discipline_incident_behaviors', join_cols=['k_student', 'k_discipline_incident']) }}
+    {{ add_cds_joins_v2(custom_data_sources=custom_data_sources) }}
+    
     -- in order to keep the grain of k_student and k_discipline_incident, we want to keep this subset 
     -- even if we do not have the severity orders defined
     qualify 1 = row_number() over (partition by fct_student_discipline_incident_behaviors.k_student, fct_student_discipline_incident_behaviors.k_discipline_incident order by fct_student_discipline_actions.severity_order desc nulls last, fct_student_discipline_incident_behaviors.severity_order desc nulls last)

--- a/models/core_warehouse/fct_student_gpa.sql
+++ b/models/core_warehouse/fct_student_gpa.sql
@@ -10,6 +10,9 @@
   )
 }}
 
+{{ cds_depends_on('edu:student_gpa:custom_data_sources') }}
+{% set custom_data_sources = var('edu:student_gpa:custom_data_sources', []) %}
+
 with combined_gpas as (
     select * from {{ ref('bld_ef3__combine_gpas') }}
 ),
@@ -30,9 +33,16 @@ formatted as (
         combined_gpas.gpa_value,
         combined_gpas.is_cumulative,
         combined_gpas.max_gpa_value
+
+        -- custom data sources columns
+        {{ add_cds_columns(custom_data_sources=custom_data_sources) }}
     from combined_gpas 
     join academic_record
         on combined_gpas.k_student_academic_record = academic_record.k_student_academic_record
+        
+    -- custom data sources
+    {{ add_cds_joins_v1(custom_data_sources=custom_data_sources, driving_alias='combined_gpas', join_cols=['k_student_academic_record', 'gpa_type']) }}
+    {{ add_cds_joins_v2(custom_data_sources=custom_data_sources) }}
 )
 select * from formatted
 order by tenant_code, k_student

--- a/models/core_warehouse/fct_student_grades.sql
+++ b/models/core_warehouse/fct_student_grades.sql
@@ -15,6 +15,9 @@
   )
 }}
 
+{{ cds_depends_on('edu:student_grades:custom_data_sources') }}
+{% set custom_data_sources = var('edu:student_grades:custom_data_sources', []) %}
+
 with stg_grades as (
     select * from {{ ref('stg_ef3__grades') }}
 ),
@@ -52,6 +55,9 @@ formatted as (
         letter_grade_xwalk.grade_sort_index
         {# add any extension columns configured from stg_ef3__grades #}
         {{ edu_edfi_source.extract_extension(model_name='stg_ef3__grades', flatten=False) }}
+
+        -- custom data sources columns
+        {{ add_cds_columns(custom_data_sources=custom_data_sources) }}
     from stg_grades
     join dim_student
         on stg_grades.k_student = dim_student.k_student
@@ -63,5 +69,9 @@ formatted as (
         on stg_grades.k_course_section = dim_course_section.k_course_section
     left join letter_grade_xwalk
         on lower(stg_grades.letter_grade_earned) = letter_grade_xwalk.letter_grade
+        
+    -- custom data sources
+    {{ add_cds_joins_v1(custom_data_sources=custom_data_sources, driving_alias='stg_grades', join_cols=['k_grading_period', 'k_student', 'k_school', 'k_course_section', 'grade_type']) }}
+    {{ add_cds_joins_v2(custom_data_sources=custom_data_sources) }}
 )
 select * from formatted

--- a/models/core_warehouse/fct_student_homeless_program_association.sql
+++ b/models/core_warehouse/fct_student_homeless_program_association.sql
@@ -1,11 +1,13 @@
 {{
   config(
     post_hook=[
+        "alter table {{ this }} alter column k_student_program set not null",
         "alter table {{ this }} alter column k_student set not null",
         "alter table {{ this }} alter column k_student_xyear set not null",
         "alter table {{ this }} alter column k_program set not null",
         "alter table {{ this }} alter column program_enroll_begin_date set not null",
-        "alter table {{ this }} add primary key (k_student, k_student_xyear, k_program, program_enroll_begin_date)",
+        "alter table {{ this }} alter column ed_org_id set not null",
+        "alter table {{ this }} add primary key (k_student_program)",
         "alter table {{ this }} add constraint fk_{{ this.name }}_student foreign key (k_student) references {{ ref('dim_student') }}",
         "alter table {{ this }} add constraint fk_{{ this.name }}_program foreign key (k_program) references {{ ref('dim_program') }}",
     ]
@@ -26,12 +28,14 @@ dim_program as (
 
 formatted as (
     select
+        stage.k_student_program,
         dim_student.k_student,
         dim_student.k_student_xyear,
         dim_program.k_program,
         dim_program.k_lea,
         dim_program.k_school,
-
+        stage.ed_org_id,
+        
         stage.tenant_code,
         dim_program.school_year,
         stage.program_enroll_begin_date,

--- a/models/core_warehouse/fct_student_homeless_program_association.sql
+++ b/models/core_warehouse/fct_student_homeless_program_association.sql
@@ -14,6 +14,9 @@
   )
 }}
 
+{{ cds_depends_on('edu:student_homeless_program_association:custom_data_sources') }}
+{% set custom_data_sources = var('edu:student_homeless_program_association:custom_data_sources', []) %}
+
 with stage as (
     select * from {{ ref('stg_ef3__student_homeless_program_associations') }}
 ),
@@ -53,6 +56,9 @@ formatted as (
         stage.reason_exited
         {# add any extension columns configured from stg_ef3__student_homeless_program_associations #}
         {{ edu_edfi_source.extract_extension(model_name='stg_ef3__student_homeless_program_associations', flatten=False) }}
+
+        -- custom data sources columns
+        {{ add_cds_columns(custom_data_sources=custom_data_sources) }}
     from stage
 
         inner join dim_student
@@ -60,6 +66,10 @@ formatted as (
 
         inner join dim_program
             on stage.k_program = dim_program.k_program
+
+    -- custom data sources
+    {{ add_cds_joins_v1(custom_data_sources=custom_data_sources, driving_alias='stage', join_cols=['k_student_program']) }}
+    {{ add_cds_joins_v2(custom_data_sources=custom_data_sources) }}
 )
 
 select * from formatted

--- a/models/core_warehouse/fct_student_homeless_program_association.yml
+++ b/models/core_warehouse/fct_student_homeless_program_association.yml
@@ -7,8 +7,7 @@ models:
         This fact table contains student homeless program enrollment information.
 
       ##### Primary Key:
-        `k_student, k_student_xyear, k_program, program_enroll_begin_date` -- There is one 
-        record per student, year, program enrol begin date, and homeless program.
+        `k_student_program` -- There is one record per student, year, ed_org_id, program enroll begin date, and homeless program.
 
     config:
       tags: ['homeless']
@@ -20,13 +19,17 @@ models:
             combination_of_columns:
               - k_student
               - k_program
+              - ed_org_id
+              - program_enroll_begin_date
 
     columns:
+      - name: k_student_program
       - name: k_student
       - name: k_student_xyear
       - name: k_program
       - name: k_lea
       - name: k_school
+      - name: ed_org_id
       - name: tenant_code
       - name: school_year
       - name: program_enroll_begin_date

--- a/models/core_warehouse/fct_student_language_instruction_program_association.sql
+++ b/models/core_warehouse/fct_student_language_instruction_program_association.sql
@@ -1,11 +1,13 @@
 {{
   config(
     post_hook=[
+        "alter table {{ this }} alter column k_student_program set not null",
         "alter table {{ this }} alter column k_student set not null",
         "alter table {{ this }} alter column k_student_xyear set not null",
         "alter table {{ this }} alter column k_program set not null",
         "alter table {{ this }} alter column program_enroll_begin_date set not null",
-        "alter table {{ this }} add primary key (k_student, k_student_xyear, k_program, program_enroll_begin_date)",
+        "alter table {{ this }} alter column ed_org_id set not null",
+        "alter table {{ this }} add primary key (k_student_program)",
         "alter table {{ this }} add constraint fk_{{ this.name }}_student foreign key (k_student) references {{ ref('dim_student') }}",
         "alter table {{ this }} add constraint fk_{{ this.name }}_program foreign key (k_program) references {{ ref('dim_program') }}",
     ]
@@ -26,11 +28,13 @@ dim_program as (
 
 formatted as (
     select
+        stage.k_student_program,
         dim_student.k_student,
         dim_student.k_student_xyear,
         dim_program.k_program,
         dim_program.k_lea,
         dim_program.k_school,
+        stage.ed_org_id, 
 
         stage.tenant_code,
         dim_program.school_year,

--- a/models/core_warehouse/fct_student_language_instruction_program_association.sql
+++ b/models/core_warehouse/fct_student_language_instruction_program_association.sql
@@ -14,6 +14,9 @@
   )
 }}
 
+{{ cds_depends_on('edu:student_language_instruction_program_association:custom_data_sources') }}
+{% set custom_data_sources = var('edu:student_language_instruction_program_association:custom_data_sources', []) %}
+
 with stage as (
     select * from {{ ref('stg_ef3__student_language_instruction_program_associations') }}
 ),
@@ -52,6 +55,9 @@ formatted as (
         stage.reason_exited
         {# add any extension columns configured from stg_ef3__student_language_instruction_program_associations #}
         {{ edu_edfi_source.extract_extension(model_name='stg_ef3__student_language_instruction_program_associations', flatten=False) }}
+
+        -- custom data sources columns
+        {{ add_cds_columns(custom_data_sources=custom_data_sources) }}
     from stage
 
         inner join dim_student
@@ -59,6 +65,10 @@ formatted as (
 
         inner join dim_program
             on stage.k_program = dim_program.k_program
+
+    -- custom data sources
+    {{ add_cds_joins_v1(custom_data_sources=custom_data_sources, driving_alias='stage', join_cols=['k_student_program']) }}
+    {{ add_cds_joins_v2(custom_data_sources=custom_data_sources) }}
 )
 
 select * from formatted

--- a/models/core_warehouse/fct_student_language_instruction_program_association.yml
+++ b/models/core_warehouse/fct_student_language_instruction_program_association.yml
@@ -7,8 +7,7 @@ models:
         This fact table contains student language instruction program enrollment information.
 
       ##### Primary Key:
-        `k_student, k_student_xyear, k_program, program_enroll_begin_date` -- There is one 
-        record per student, year, program enrol begin date, and language instruction program.
+        `k_student_program` -- There is one record per student, year, ed_org_id, program enroll begin date, and language instruction program.
 
     config:
       tags: ['language_instruction']
@@ -20,15 +19,17 @@ models:
             combination_of_columns:
               - k_student
               - k_program
-              - k_student_xyear
+              - ed_org_id
               - program_enroll_begin_date
 
     columns:
+      - name: k_student_program
       - name: k_student
       - name: k_student_xyear
       - name: k_program
       - name: k_lea
       - name: k_school
+      - name: ed_org_id
       - name: tenant_code
       - name: school_year
       - name: program_enroll_begin_date

--- a/models/core_warehouse/fct_student_learning_standard_grades.sql
+++ b/models/core_warehouse/fct_student_learning_standard_grades.sql
@@ -17,6 +17,9 @@
   )
 }}
 
+{{ cds_depends_on('edu:student_learning_standard_grades:custom_data_sources') }}
+{% set custom_data_sources = var('edu:student_learning_standard_grades:custom_data_sources', []) %}
+
 with stg_grades_learning_standards as (
     select * from {{ ref('stg_ef3__grades__learning_standards') }}
 ),
@@ -50,6 +53,9 @@ formatted as (
         stg_grades_learning_standards.learning_standard_numeric_grade_earned
         {# add any extension columns configured from stg_ef3__grades__learning_standards #}
         {{ edu_edfi_source.extract_extension(model_name='stg_ef3__grades__learning_standards', flatten=False) }}
+
+        -- custom data sources columns
+        {{ add_cds_columns(custom_data_sources=custom_data_sources) }}
     from stg_grades_learning_standards
     join dim_learning_standard
         on stg_grades_learning_standards.k_learning_standard = dim_learning_standard.k_learning_standard
@@ -61,5 +67,9 @@ formatted as (
         on stg_grades_learning_standards.k_grading_period = dim_grading_period.k_grading_period
     join dim_course_section
         on stg_grades_learning_standards.k_course_section = dim_course_section.k_course_section
+        
+    -- custom data sources
+    {{ add_cds_joins_v1(custom_data_sources=custom_data_sources, driving_alias='stg_grades_learning_standards', join_cols=['k_grading_period', 'k_student', 'k_school', 'k_course_section', 'grade_type', 'k_learning_standard']) }}
+    {{ add_cds_joins_v2(custom_data_sources=custom_data_sources) }}
 )
 select * from formatted

--- a/models/core_warehouse/fct_student_migrant_education_program_associations.sql
+++ b/models/core_warehouse/fct_student_migrant_education_program_associations.sql
@@ -1,11 +1,13 @@
 {{
   config(
     post_hook=[
+        "alter table {{ this }} alter column k_student_program set not null",
         "alter table {{ this }} alter column k_student set not null",
         "alter table {{ this }} alter column k_student_xyear set not null",
         "alter table {{ this }} alter column k_program set not null",
         "alter table {{ this }} alter column program_enroll_begin_date set not null",
-        "alter table {{ this }} add primary key (k_student, k_student_xyear, k_program, program_enroll_begin_date)",
+        "alter table {{ this }} alter column ed_org_id set not null",
+        "alter table {{ this }} add primary key (k_student_program)",
         "alter table {{ this }} add constraint fk_{{ this.name }}_student foreign key (k_student) references {{ ref('dim_student') }}",
         "alter table {{ this }} add constraint fk_{{ this.name }}_program foreign key (k_program) references {{ ref('dim_program') }}",
     ]
@@ -27,11 +29,13 @@ dim_program as (
 
 formatted as (
     select
+        stage.k_student_program,
         dim_student.k_student,
         dim_student.k_student_xyear,
         dim_program.k_program,
         dim_program.k_lea,
         dim_program.k_school,
+        stage.ed_org_id, 
         stage.tenant_code,
         dim_program.school_year,
         stage.program_enroll_begin_date,

--- a/models/core_warehouse/fct_student_migrant_education_program_associations.sql
+++ b/models/core_warehouse/fct_student_migrant_education_program_associations.sql
@@ -14,6 +14,8 @@
   )
 }}
 
+{{ cds_depends_on('edu:student_migrant_education_program_association:custom_data_sources') }}
+{% set custom_data_sources = var('edu:student_migrant_education_program_association:custom_data_sources', []) %}
 
 with stage as (
     select * from {{ ref('stg_ef3__student_migrant_education_program_associations') }}
@@ -53,6 +55,8 @@ formatted as (
         {# add any extension columns configured from stg_ef3__student_migrant_education_program_associations #}
         {{ edu_edfi_source.extract_extension(model_name='stg_ef3__student_migrant_education_program_associations', flatten=False) }}
 
+        -- custom data sources columns
+        {{ add_cds_columns(custom_data_sources=custom_data_sources) }}
     from stage
 
     inner join dim_student
@@ -60,6 +64,10 @@ formatted as (
 
     inner join dim_program
         on stage.k_program = dim_program.k_program
+
+    -- custom data sources
+    {{ add_cds_joins_v1(custom_data_sources=custom_data_sources, driving_alias='stage', join_cols=['k_student_program']) }}
+    {{ add_cds_joins_v2(custom_data_sources=custom_data_sources) }}
 )
 
 select * from formatted

--- a/models/core_warehouse/fct_student_migrant_education_program_associations.yml
+++ b/models/core_warehouse/fct_student_migrant_education_program_associations.yml
@@ -7,8 +7,7 @@ models:
         This fact table contains student migrant education program enrollment information.
 
       ##### Primary Key:
-        `k_student, k_student_xyear, k_program, program_enroll_begin_date` -- There is one 
-        record per student, year, program enrol begin date, and migrant education program.
+        `k_student_program` -- There is one record per student, year, ed_org_id, program enroll begin date, and migrant education program.
 
     config:
       tags: ['migrant_education']
@@ -20,13 +19,17 @@ models:
             combination_of_columns:
               - k_student
               - k_program
+              - ed_org_id
+              - program_enroll_begin_date
 
     columns:
+      - name: k_student_program
       - name: k_student
       - name: k_student_xyear
       - name: k_program
       - name: k_lea
       - name: k_school
+      - name: ed_org_id
       - name: tenant_code
       - name: school_year
       - name: program_enroll_begin_date

--- a/models/core_warehouse/fct_student_objective_assessment.sql
+++ b/models/core_warehouse/fct_student_objective_assessment.sql
@@ -47,7 +47,8 @@ combined_with_cross_tenant as (
         {{ accordion_columns(
             source_table='stg_ef3__student_objective_assessments',
             source_alias='student_obj_assessments',
-            exclude_columns=['k_student_objective_assessment', 'k_objective_assessment', 'k_student_assessment', 'k_assessment', 'k_student', 'k_student_xyear', 'tenant_code', 'school_year']) }}
+            exclude_columns=['k_student_objective_assessment', 'k_objective_assessment', 'k_student_assessment', 'k_assessment', 'k_student', 'k_student_xyear', 'tenant_code', 'school_year'],
+            add_trailing_comma=false) }}
     from student_obj_assessments
     -- left join because this model can return empty
         -- and to avoid enforcing a current school association

--- a/models/core_warehouse/fct_student_objective_assessment.sql
+++ b/models/core_warehouse/fct_student_objective_assessment.sql
@@ -10,6 +10,9 @@
   )
 }}
 
+{{ cds_depends_on('edu:student_objective_assessment:custom_data_sources') }}
+{% set custom_data_sources = var('edu:student_objective_assessment:custom_data_sources', []) %}
+
 with student_obj_assessments_long_results as (
     select * from {{ ref('bld_ef3__student_objective_assessments_long_results') }}
 ),
@@ -135,6 +138,13 @@ student_obj_assessments_wide_deduped as (
 select
     {{ edu_edfi_source.star('student_obj_assessments_wide_deduped', except=([] if var('edu:assessment:cross_tenant_enabled', False) else ['k_student_objective_assessment__original', 'is_original_record', 'original_tenant_code'])) }},
     v_other_results
+    
+    -- custom data sources columns
+    {{ add_cds_columns(custom_data_sources=custom_data_sources) }}
 from student_obj_assessments_wide_deduped
 left join object_agg_other_results
     on student_obj_assessments_wide_deduped.k_student_objective_assessment__original = object_agg_other_results.k_student_objective_assessment
+
+-- custom data sources
+{{ add_cds_joins_v1(custom_data_sources=custom_data_sources, driving_alias='student_obj_assessments_wide_deduped', join_cols=['k_student_objective_assessment']) }}
+{{ add_cds_joins_v2(custom_data_sources=custom_data_sources) }}

--- a/models/core_warehouse/fct_student_parent_association.sql
+++ b/models/core_warehouse/fct_student_parent_association.sql
@@ -10,6 +10,9 @@
   )
 }}
 
+{{ cds_depends_on('edu:student_parent_association:custom_data_sources') }}
+{% set custom_data_sources = var('edu:student_parent_association:custom_data_sources', []) %}
+
 with stg_stu_parent as (
     -- parents were renamed to contacts in Data Standard v5.0
     -- the contacts staging tables contain both parent and contact records
@@ -43,6 +46,9 @@ formatted as (
         stg_stu_parent.is_legal_guardian
         {# add any extension columns configured from stg_ef3__student_contact_associations #}
         {{ edu_edfi_source.extract_extension(model_name='stg_ef3__student_contact_associations', flatten=False) }}
+
+        -- custom data sources columns
+        {{ add_cds_columns(custom_data_sources=custom_data_sources) }}
     from stg_stu_parent
     -- subset to only the stu/parent records associated with the most recent student records
     join most_recent_k_student
@@ -52,5 +58,9 @@ formatted as (
         on stg_stu_parent.k_student_xyear = dim_student.k_student_xyear
     join dim_parent
         on stg_stu_parent.k_contact = dim_parent.k_parent
+        
+    -- custom data sources
+    {{ add_cds_joins_v1(custom_data_sources=custom_data_sources, driving_alias='stg_stu_parent', join_cols=['k_student', 'k_contact']) }}
+    {{ add_cds_joins_v2(custom_data_sources=custom_data_sources) }}
 )
 select * from formatted

--- a/models/core_warehouse/fct_student_program_association.sql
+++ b/models/core_warehouse/fct_student_program_association.sql
@@ -1,11 +1,13 @@
 {{
   config(
     post_hook=[
+        "alter table {{ this }} alter column k_student_program set not null",
         "alter table {{ this }} alter column k_student set not null",
         "alter table {{ this }} alter column k_student_xyear set not null",
         "alter table {{ this }} alter column k_program set not null",
         "alter table {{ this }} alter column program_enroll_begin_date set not null",
-        "alter table {{ this }} add primary key (k_student, k_student_xyear, k_program, program_enroll_begin_date)",
+        "alter table {{ this }} alter column ed_org_id set not null",
+        "alter table {{ this }} add primary key (k_student_program)",
         "alter table {{ this }} add constraint fk_{{ this.name }}_student foreign key (k_student) references {{ ref('dim_student') }}",
         "alter table {{ this }} add constraint fk_{{ this.name }}_program foreign key (k_program) references {{ ref('dim_program') }}",
     ]
@@ -26,11 +28,13 @@ dim_program as (
 
 formatted as (
     select
+        stage.k_student_program,
         dim_student.k_student,
         dim_student.k_student_xyear,
         dim_program.k_program,
         dim_program.k_lea,
         dim_program.k_school,
+        stage.ed_org_id,
 
         stage.tenant_code,
         dim_program.school_year,

--- a/models/core_warehouse/fct_student_program_association.sql
+++ b/models/core_warehouse/fct_student_program_association.sql
@@ -14,6 +14,9 @@
   )
 }}
 
+{{ cds_depends_on('edu:student_program_association:custom_data_sources') }}
+{% set custom_data_sources = var('edu:student_program_association:custom_data_sources', []) %}
+
 with stage as (
     select * from {{ ref('stg_ef3__student_program_associations') }}
 ),
@@ -49,6 +52,9 @@ formatted as (
         stage.reason_exited
         {# add any extension columns configured from stg_ef3__student_program_associations #}
         {{ edu_edfi_source.extract_extension(model_name='stg_ef3__student_program_associations', flatten=False) }}
+
+        -- custom data sources columns
+        {{ add_cds_columns(custom_data_sources=custom_data_sources) }}
     from stage
 
         inner join dim_student
@@ -56,6 +62,10 @@ formatted as (
 
         inner join dim_program
             on stage.k_program = dim_program.k_program
+
+    -- custom data sources
+    {{ add_cds_joins_v1(custom_data_sources=custom_data_sources, driving_alias='stage', join_cols=['k_student_program']) }}
+    {{ add_cds_joins_v2(custom_data_sources=custom_data_sources) }}
 )
 
 select * from formatted

--- a/models/core_warehouse/fct_student_program_association.yml
+++ b/models/core_warehouse/fct_student_program_association.yml
@@ -5,7 +5,7 @@ models:
     description: >
       Student program enrollment information.
 
-      *Primary Key:* `k_student, k_program`
+      *Primary Key:* `k_student_program, program_enroll_begin_date, participation_status`
 
     config:
       tags: ['core']
@@ -15,14 +15,16 @@ models:
             combination_of_columns:
               - k_student
               - k_program
-              - k_student_xyear
+              - ed_org_id
               - program_enroll_begin_date
     columns:
+      - name: k_student_program
       - name: k_student
       - name: k_student_xyear
       - name: k_program
       - name: k_lea
       - name: k_school
+      - name: ed_org_id
       - name: tenant_code
       - name: school_year
       - name: program_enroll_begin_date

--- a/models/core_warehouse/fct_student_program_participation_status.sql
+++ b/models/core_warehouse/fct_student_program_participation_status.sql
@@ -6,49 +6,49 @@
         "alter table {{ this }} alter column k_program set not null",
         "alter table {{ this }} alter column program_enroll_begin_date set not null",
         "alter table {{ this }} alter column ed_org_id set not null",
-        "alter table {{ this }} alter column program_service set not null",
-        "alter table {{ this }} add primary key (k_student_program, program_service)",
+        "alter table {{ this }} alter column participation_status set not null",
+        "alter table {{ this }} alter column status_begin_date set not null",
+        "alter table {{ this }} add primary key (k_student_program, participation_status, status_begin_date)",
         "alter table {{ this }} add constraint fk_{{ this.name }}_student foreign key (k_student) references {{ ref('dim_student') }}",
         "alter table {{ this }} add constraint fk_{{ this.name }}_program foreign key (k_program) references {{ ref('dim_program') }}",
     ]
   )
 }}
 
-
 -- Define all optional program service models here.
 {% set stage_program_relations = [] %}
 
 --Generic Program Assoc
-{% do stage_program_relations.append(ref('stg_ef3__stu_program__program_services')) %}
+{% do stage_program_relations.append(ref('stg_ef3__stu_program__program_participation_statuses')) %}
 
 -- Special Education
 {% if var('src:program:special_ed:enabled', True) %}
-    {% do stage_program_relations.append(ref('stg_ef3__stu_spec_ed__program_services')) %}
+    {% do stage_program_relations.append(ref('stg_ef3__stu_spec_ed__program_participation_statuses')) %}
 {% endif %}
 
 -- Language Instruction
 {% if var('src:program:language_instruction:enabled', True) %}
-    {% do stage_program_relations.append(ref('stg_ef3__stu_lang_instr__program_services')) %}
+    {% do stage_program_relations.append(ref('stg_ef3__stu_lang_instr__program_participation_statuses')) %}
 {% endif %}
 
 -- Homeless
 {% if var('src:program:homeless:enabled', True) %}
-    {% do stage_program_relations.append(ref('stg_ef3__stu_homeless__program_services')) %}
+    {% do stage_program_relations.append(ref('stg_ef3__stu_homeless__program_participation_statuses')) %}
 {% endif %}
 
 -- Title I Part A
 {% if var('src:program:title_i:enabled', True) %}
-    {% do stage_program_relations.append(ref('stg_ef3__stu_title_i_part_a__program_services')) %}
+    {% do stage_program_relations.append(ref('stg_ef3__stu_title_i_part_a__program_participation_statuses')) %}
 {% endif %}
 
 -- CTE
 {% if var('src:program:cte:enabled', True) %}
-    {% do stage_program_relations.append(ref('stg_ef3__stu_cte__program_services')) %}
+    {% do stage_program_relations.append(ref('stg_ef3__stu_cte__program_participation_statuses')) %}
 {% endif %}
 
 -- Migrant Education
 {% if var('src:program:migrant_education:enabled', True) %}
-    {% do stage_program_relations.append(ref('stg_ef3__stu_migrant_edu__program_services')) %}
+    {% do stage_program_relations.append(ref('stg_ef3__stu_migrant_edu__program_participation_statuses')) %}
 {% endif %}
 
 -- Food Service
@@ -87,16 +87,10 @@ subset as (
     stacked.tenant_code,
     stacked.ed_org_id,
     stacked.program_enroll_begin_date,
-    stacked.program_service,
-    stacked.primary_indicator,
-    {% if var('src:program:special_ed:enabled', True) %}
-        stacked.v_providers,
-    {% endif %}
-    {% if var('src:program:cte:enabled', True) %}
-        stacked.cip_code,
-    {% endif %}
-    stacked.service_begin_date,
-    stacked.service_end_date
+    stacked.participation_status,
+    stacked.status_begin_date,
+    stacked.status_end_date,
+    stacked.designated_by
     {# add any extension columns configured from all stage_program_relations #}
     {{ edu_edfi_source.extract_extension(model_name=relation_names, flatten=False) }}
 

--- a/models/core_warehouse/fct_student_program_participation_status.yml
+++ b/models/core_warehouse/fct_student_program_participation_status.yml
@@ -1,0 +1,61 @@
+version: 1
+
+models: 
+  - name: fct_student_program_participation_status
+    description: >
+     ##### Overview:
+       This fact table provides student program participation statuses, received as part of a program enrollment.
+       It references any or all of the following models:
+      - [stg_ef3__stu_spec_ed__program_participation_statuses](#!/model/model.edu_edfi_source.stg_ef3__stu_spec_ed__program_participation_statuses)
+      - [stg_ef3__stu_lang_instr__program_participation_statuses](#!/model/model.edu_edfi_source.stg_ef3__stu_lang_instr__program_participation_statuses)
+      - [stg_ef3__stu_homeless__program_participation_statuses](#!/model/model.edu_edfi_source.stg_ef3__stu_homeless__program_participation_statuses)
+      - [stg_ef3__stu_title_i__program_participation_statuses](#!/model/model.edu_edfi_source.stg_ef3__stu_title_i__program_participation_statuses)
+      - [stg_ef3__stu_cte__program_participation_statuses](#!/model/model.edu_edfi_source.stg_ef3__stu_cte__program_participation_statuses)
+      - [stg_ef3__stu_migrant_edu__program_participation_statusess](#!/model/model.edu_edfi_source.stg_ef3__stu_migrant_edu__program_participation_statuses)
+      - [stg_ef3__stu_school_food_service__program_participation_statuses](#!/model/model.edu_edfi_source.stg_ef3__stu_school_food_service__program_participation_statuses)
+      - [stg_ef3__stu_program__program_participation_statuses](#!/model/model.edu_edfi_source.stg_ef3__stu_program__program_participation_statuses)
+
+     ##### Primary Key:
+       `k_student_program, participation_status, status_begin_date` --
+       There is one record per student, year, program, ed org, program start date, program participation status, and status begin date.
+
+     ##### Important business rules:
+        - `program_enroll_begin_date` is included in the unique key, because a student may be associated with the same program at multiple times,
+           and those associations may have different program participation statuses. When joining this table to `fct_student_{program_type}_program_association`,
+           always include `program_enroll_begin_date` in the join.
+
+    config:
+      tags: ['special_ed', 'homeless', 'language_instruction', 'title_i', 'cte', 'migrant_education', 'food_service']
+      enabled: >
+        {%- set var_values = [] -%}
+        {%- for variable in [
+             'src:program:special_ed:enabled',
+             'src:program:homeless:enabled',
+             'src:program:language_instruction:enabled',
+             'src:program:title_i:enabled',
+             'src:program:cte:enabled',
+             'src:program:migrant_education:enabled',
+             'src:program:food_service:enabled'
+        ] -%}
+           {%- do var_values.append(var(variable, none)) -%}
+        {%- endfor -%}
+
+        {%- if True in var_values -%}
+           {{ True  | as_bool }}
+        {%- elif False in var_values -%}
+           {{ False | as_bool }}
+        {%- else -%}
+           {{ True  | as_bool }}
+        {%- endif -%}
+        
+    columns:
+      - name: k_student_program
+      - name: k_student
+      - name: k_program
+      - name: tenant_code
+      - name: ed_org_id
+      - name: program_enroll_begin_date
+      - name: participation_status
+      - name: status_begin_date
+      - name: status_end_date
+      - name: designated_by

--- a/models/core_warehouse/fct_student_program_service.sql
+++ b/models/core_warehouse/fct_student_program_service.sql
@@ -14,6 +14,8 @@
   )
 }}
 
+{{ cds_depends_on('edu:student_program_service:custom_data_sources') }}
+{% set custom_data_sources = var('edu:student_program_service:custom_data_sources', []) %}
 
 -- Define all optional program service models here.
 {% set stage_program_relations = [] %}
@@ -79,30 +81,36 @@ stacked as (
 {%- endfor -%}
 
 subset as (
-  select
-    stacked.k_student_program,
-    stacked.k_student,
-    stacked.k_student_xyear,
-    stacked.k_program,
-    stacked.tenant_code,
-    stacked.ed_org_id,
-    stacked.program_enroll_begin_date,
-    stacked.program_service,
-    stacked.primary_indicator,
-    {% if var('src:program:special_ed:enabled', True) %}
-        stacked.v_providers,
-    {% endif %}
-    {% if var('src:program:cte:enabled', True) %}
-        stacked.cip_code,
-    {% endif %}
-    stacked.service_begin_date,
-    stacked.service_end_date
-    {# add any extension columns configured from all stage_program_relations #}
-    {{ edu_edfi_source.extract_extension(model_name=relation_names, flatten=False) }}
+    select
+        stacked.k_student_program,
+        stacked.k_student,
+        stacked.k_student_xyear,
+        stacked.k_program,
+        stacked.tenant_code,
+        stacked.ed_org_id,
+        stacked.program_enroll_begin_date,
+        stacked.program_service,
+        stacked.primary_indicator,
+        {% if var('src:program:special_ed:enabled', True) %}
+            stacked.v_providers,
+        {% endif %}
+        {% if var('src:program:cte:enabled', True) %}
+            stacked.cip_code,
+        {% endif %}
+        stacked.service_begin_date,
+        stacked.service_end_date
+        {# add any extension columns configured from all stage_program_relations #}
+        {{ edu_edfi_source.extract_extension(model_name=relation_names, flatten=False) }}
 
-  from stacked
-  join dim_program
-    on stacked.k_program = dim_program.k_program
+        -- custom data sources columns
+        {{ add_cds_columns(custom_data_sources=custom_data_sources) }}
+    from stacked
+    join dim_program
+        on stacked.k_program = dim_program.k_program
+
+    -- custom data sources
+    {{ add_cds_joins_v1(custom_data_sources=custom_data_sources, driving_alias='stacked', join_cols=['k_student_program', 'program_service']) }}
+    {{ add_cds_joins_v2(custom_data_sources=custom_data_sources) }}
 )
 
 select * from subset

--- a/models/core_warehouse/fct_student_program_service.yml
+++ b/models/core_warehouse/fct_student_program_service.yml
@@ -84,12 +84,15 @@ models:
             combination_of_columns:
               - k_student
               - k_program
+              - ed_org_id
               - program_enroll_begin_date
               - program_service
     columns:
+      - name: k_student_program
       - name: k_student
       - name: k_program
       - name: tenant_code
+      - name: ed_org_id
       - name: program_enroll_begin_date
       - name: program_service
       - name: primary_indicator

--- a/models/core_warehouse/fct_student_school_association.sql
+++ b/models/core_warehouse/fct_student_school_association.sql
@@ -11,6 +11,9 @@
   )
 }}
 
+{{ cds_depends_on('edu:student_school_association:custom_data_sources') }}
+{% set custom_data_sources = var('edu:student_school_association:custom_data_sources', []) %}
+
 with stg_stu_school as (
     select * from {{ ref('stg_ef3__student_school_associations') }}
 ),
@@ -93,6 +96,9 @@ formatted as (
         ) as is_latest_annual_entry
         {# add any extension columns configured from stg_ef3__student_school_associations #}
         {{ edu_edfi_source.extract_extension(model_name='stg_ef3__student_school_associations', flatten=False) }}
+
+        -- custom data sources columns
+        {{ add_cds_columns(custom_data_sources=custom_data_sources) }}
     from stg_stu_school
     join dim_student
         on stg_stu_school.k_student = dim_student.k_student
@@ -109,6 +115,10 @@ formatted as (
         and equal_null(dim_school_calendar.k_school_calendar, bld_school_calendar_windows.k_school_calendar)
     left join xwalk_grade_levels
         on stg_stu_school.entry_grade_level = xwalk_grade_levels.grade_level
+    
+    -- custom data sources
+    {{ add_cds_joins_v1(custom_data_sources=custom_data_sources, driving_alias='stg_stu_school', join_cols=['k_student', 'k_school', 'entry_date']) }}
+    {{ add_cds_joins_v2(custom_data_sources=custom_data_sources) }}
     where true
    {% if var('edu:enroll:exclude_exit_before_first_day', True) -%}
       -- exclude students who exited before the first school day

--- a/models/core_warehouse/fct_student_school_attendance_event.sql
+++ b/models/core_warehouse/fct_student_school_attendance_event.sql
@@ -13,6 +13,9 @@
   )
 }}
 
+{{ cds_depends_on('edu:student_school_attendance_event:custom_data_sources') }}
+{% set custom_data_sources = var('edu:student_school_attendance_event:custom_data_sources', []) %}
+
 with stg_stu_sch_attend as (
     select * from {{ ref('stg_ef3__student_school_attendance_events') }}
 ),
@@ -107,15 +110,15 @@ deduped as (
 ),
 formatted as (
     select
-        k_student,
+        deduped.k_student,
         k_student_xyear,
-        k_school,
-        k_calendar_date,
-        k_session,
+        deduped.k_school,
+        deduped.k_calendar_date,
+        deduped.k_session,
         tenant_code,
         school_year,
         calendar_date,
-        attendance_event_category,
+        deduped.attendance_event_category,
         attendance_event_reason,
         is_absent,
         attendance_excusal_status,
@@ -126,6 +129,13 @@ formatted as (
         educational_environment
         {# add any extension columns configured from stg_ef3__student_school_attendance_events #}
         {{ edu_edfi_source.extract_extension(model_name='stg_ef3__student_school_attendance_events', flatten=False) }}
+
+        -- custom data sources columns
+        {{ add_cds_columns(custom_data_sources=custom_data_sources) }}
     from deduped
+
+    -- custom data sources
+    {{ add_cds_joins_v1(custom_data_sources=custom_data_sources, driving_alias='deduped', join_cols=['k_student', 'k_school', 'k_session', 'attendance_event_category', 'k_calendar_date']) }}
+    {{ add_cds_joins_v2(custom_data_sources=custom_data_sources) }}
 )
 select * from formatted

--- a/models/core_warehouse/fct_student_school_food_service_program_associations.sql
+++ b/models/core_warehouse/fct_student_school_food_service_program_associations.sql
@@ -14,6 +14,8 @@
   )
 }}
 
+{{ cds_depends_on('edu:student_school_food_service_program_association:custom_data_sources') }}
+{% set custom_data_sources = var('edu:student_school_food_service_program_association:custom_data_sources', []) %}
 
 with stage as (
     select * from {{ ref('stg_ef3__student_school_food_service_program_association') }}
@@ -46,6 +48,9 @@ formatted as (
         stage.served_outside_of_regular_session
         {# add any extension columns configured from stg_ef3__student_school_food_service_program_association #}
         {{ edu_edfi_source.extract_extension(model_name='stg_ef3__student_school_food_service_program_association', flatten=False) }}
+
+        -- custom data sources columns
+        {{ add_cds_columns(custom_data_sources=custom_data_sources) }}
     from stage
 
     inner join dim_student
@@ -53,6 +58,10 @@ formatted as (
     
     inner join dim_program
         on stage.k_program = dim_program.k_program
+
+    -- custom data sources
+    {{ add_cds_joins_v1(custom_data_sources=custom_data_sources, driving_alias='stage', join_cols=['k_student_program']) }}
+    {{ add_cds_joins_v2(custom_data_sources=custom_data_sources) }}
 )
 
 select * from formatted

--- a/models/core_warehouse/fct_student_school_food_service_program_associations.sql
+++ b/models/core_warehouse/fct_student_school_food_service_program_associations.sql
@@ -1,11 +1,13 @@
 {{
   config(
     post_hook=[
+        "alter table {{ this }} alter column k_student_program set not null",
         "alter table {{ this }} alter column k_student set not null",
         "alter table {{ this }} alter column k_student_xyear set not null",
         "alter table {{ this }} alter column k_program set not null",
         "alter table {{ this }} alter column program_enroll_begin_date set not null",
-        "alter table {{ this }} add primary key (k_student, k_student_xyear, k_program, program_enroll_begin_date)",
+        "alter table {{ this }} alter column ed_org_id set not null",
+        "alter table {{ this }} add primary key (k_student_program)",
         "alter table {{ this }} add constraint fk_{{ this.name }}_student foreign key (k_student) references {{ ref('dim_student') }}",
         "alter table {{ this }} add constraint fk_{{ this.name }}_program foreign key (k_program) references {{ ref('dim_program') }}",
     ]
@@ -27,11 +29,14 @@ dim_program as (
 
 formatted as (
     select
+        stage.k_student_program,
         dim_student.k_student,
         dim_student.k_student_xyear,
         dim_program.k_program,
         dim_program.k_lea,
         dim_program.k_school,
+        stage.ed_org_id,
+        
         stage.tenant_code,
         dim_program.school_year,
         stage.program_enroll_begin_date,

--- a/models/core_warehouse/fct_student_school_food_service_program_associations.yml
+++ b/models/core_warehouse/fct_student_school_food_service_program_associations.yml
@@ -7,8 +7,7 @@ models:
         This fact table contains student food service program enrollment information.
 
       ##### Primary Key:
-        `k_student, k_student_xyear, k_program, program_enroll_begin_date` -- There 
-        is one record per student, year, program enrol begin date, and food service program.
+        `k_student_program` -- There is one record per student, year, ed_org_id, program enroll begin date, and food service program.
 
     config:
       tags: ['food_service']
@@ -20,13 +19,17 @@ models:
             combination_of_columns:
               - k_student
               - k_program
+              - ed_org_id
+              - program_enroll_begin_date
 
     columns:
+      - name: k_student_program
       - name: k_student
       - name: k_student_xyear
       - name: k_program
       - name: k_lea
       - name: k_school
+      - name: ed_org_id
       - name: tenant_code
       - name: school_year
       - name: program_enroll_begin_date

--- a/models/core_warehouse/fct_student_section_association.sql
+++ b/models/core_warehouse/fct_student_section_association.sql
@@ -11,6 +11,9 @@
   )
 }}
 
+{{ cds_depends_on('edu:student_section_association:custom_data_sources') }}
+{% set custom_data_sources = var('edu:student_section_association:custom_data_sources', []) %}
+
 with stg_stu_section as (
     select * from {{ ref('stg_ef3__student_section_associations') }}
 ),
@@ -48,10 +51,17 @@ formatted as (
         stg_stu_section.repeat_identifier
         {# add any extension columns configured from stg_ef3__student_section_associations #}
         {{ edu_edfi_source.extract_extension(model_name='stg_ef3__student_section_associations', flatten=False) }}
+
+        -- custom data sources columns
+        {{ add_cds_columns(custom_data_sources=custom_data_sources) }}
     from stg_stu_section
     join dim_student 
         on stg_stu_section.k_student = dim_student.k_student
     join dim_course_section
         on stg_stu_section.k_course_section = dim_course_section.k_course_section
+        
+    -- custom data sources
+    {{ add_cds_joins_v1(custom_data_sources=custom_data_sources, driving_alias='stg_stu_section', join_cols=['k_student', 'k_course_section', 'begin_date']) }}
+    {{ add_cds_joins_v2(custom_data_sources=custom_data_sources) }}
 )
 select * from formatted

--- a/models/core_warehouse/fct_student_section_attendance_event.sql
+++ b/models/core_warehouse/fct_student_section_attendance_event.sql
@@ -12,6 +12,9 @@
   )
 }}
 
+{{ cds_depends_on('edu:student_section_attendance_event:custom_data_sources') }}
+{% set custom_data_sources = var('edu:student_section_attendance_event:custom_data_sources', []) %}
+
 with stg_stu_section_attendance as (
     select * from {{ ref('stg_ef3__student_section_attendance_events') }}
 ),
@@ -43,6 +46,9 @@ formatted as (
         stg_stu_section_attendance.educational_environment
         {# add any extension columns configured from stg_ef3__student_section_attendance_events #}
         {{ edu_edfi_source.extract_extension(model_name='stg_ef3__student_section_attendance_events', flatten=False) }}
+
+        -- custom data sources columns
+        {{ add_cds_columns(custom_data_sources=custom_data_sources) }}
     from stg_stu_section_attendance
     join dim_student
         on stg_stu_section_attendance.k_student = dim_student.k_student
@@ -50,5 +56,9 @@ formatted as (
         on stg_stu_section_attendance.k_course_section = dim_course_section.k_course_section
     join xwalk_att_events
         on stg_stu_section_attendance.attendance_event_category = xwalk_att_events.attendance_event_descriptor
+        
+    -- custom data sources
+    {{ add_cds_joins_v1(custom_data_sources=custom_data_sources, driving_alias='stg_stu_section_attendance', join_cols=['k_student', 'k_course_section', 'attendance_event_category', 'attendance_event_date']) }}
+    {{ add_cds_joins_v2(custom_data_sources=custom_data_sources) }}
 )
 select * from formatted

--- a/models/core_warehouse/fct_student_special_education_program_association.sql
+++ b/models/core_warehouse/fct_student_special_education_program_association.sql
@@ -1,11 +1,13 @@
 {{
   config(
     post_hook=[
+        "alter table {{ this }} alter column k_student_program set not null",
         "alter table {{ this }} alter column k_student set not null",
         "alter table {{ this }} alter column k_student_xyear set not null",
         "alter table {{ this }} alter column k_program set not null",
         "alter table {{ this }} alter column program_enroll_begin_date set not null",
-        "alter table {{ this }} add primary key (k_student, k_student_xyear, k_program, program_enroll_begin_date)",
+        "alter table {{ this }} alter column ed_org_id set not null",
+        "alter table {{ this }} add primary key (k_student_program)",
         "alter table {{ this }} add constraint fk_{{ this.name }}_student foreign key (k_student) references {{ ref('dim_student') }}",
         "alter table {{ this }} add constraint fk_{{ this.name }}_program foreign key (k_program) references {{ ref('dim_program') }}",
     ]
@@ -35,11 +37,13 @@ bld_primary_disability as (
 
 formatted as (
     select
+        stage.k_student_program,
         dim_student.k_student,
         dim_student.k_student_xyear,
         dim_program.k_program,
         dim_program.k_lea,
         dim_program.k_school,
+        stage.ed_org_id,
         stage.tenant_code,
         dim_program.school_year,
         stage.program_enroll_begin_date,

--- a/models/core_warehouse/fct_student_special_education_program_association.sql
+++ b/models/core_warehouse/fct_student_special_education_program_association.sql
@@ -14,6 +14,8 @@
   )
 }}
 
+{{ cds_depends_on('edu:student_special_education_program_association:custom_data_sources') }}
+{% set custom_data_sources = var('edu:student_special_education_program_association:custom_data_sources', []) %}
 
 with stage as (
     select * from {{ ref('stg_ef3__student_special_education_program_associations') }}
@@ -68,6 +70,9 @@ formatted as (
         bld_primary_disability.disability_type as primary_disability_type
         {# add any extension columns configured from stg_ef3__student_special_education_program_associations #}
         {{ edu_edfi_source.extract_extension(model_name='stg_ef3__student_special_education_program_associations', flatten=False) }}
+
+        -- custom data sources columns
+        {{ add_cds_columns(custom_data_sources=custom_data_sources) }}
     from stage
     
         inner join dim_student
@@ -86,6 +91,10 @@ formatted as (
             on stage.k_student = bld_primary_disability.k_student
             and stage.k_program = bld_primary_disability.k_program
             and stage.program_enroll_begin_date = bld_primary_disability.program_enroll_begin_date
+
+    -- custom data sources
+    {{ add_cds_joins_v1(custom_data_sources=custom_data_sources, driving_alias='stage', join_cols=['k_student_program']) }}
+    {{ add_cds_joins_v2(custom_data_sources=custom_data_sources) }}
 )
 
 select * from formatted

--- a/models/core_warehouse/fct_student_special_education_program_association.yml
+++ b/models/core_warehouse/fct_student_special_education_program_association.yml
@@ -7,8 +7,7 @@ models:
         This fact table contains student special education program enrollment information.
 
       ##### Primary Key:
-        `k_student, k_student_xyear, k_program, program_enroll_begin_date` -- There is one 
-        record per student, year, program enrol begin date, and special education program
+        `k_student_program` -- There is one record per student, year, ed_org_id, program enroll begin date, and special education program
 
     config:
       tags: ['special_ed']
@@ -19,13 +18,16 @@ models:
             combination_of_columns:
               - k_student
               - k_program
+              - ed_org_id
               - program_enroll_begin_date
     columns:
+      - name: k_student_program
       - name: k_student
       - name: k_student_xyear
       - name: k_program
       - name: k_lea
       - name: k_school
+      - name: ed_org_id
       - name: tenant_code
       - name: school_year
       - name: program_enroll_begin_date

--- a/models/core_warehouse/fct_student_title_i_part_a_program_association.sql
+++ b/models/core_warehouse/fct_student_title_i_part_a_program_association.sql
@@ -1,11 +1,13 @@
 {{
   config(
     post_hook=[
+        "alter table {{ this }} alter column k_student_program set not null",
         "alter table {{ this }} alter column k_student set not null",
         "alter table {{ this }} alter column k_student_xyear set not null",
         "alter table {{ this }} alter column k_program set not null",
         "alter table {{ this }} alter column program_enroll_begin_date set not null",
-        "alter table {{ this }} add primary key (k_student, k_student_xyear, k_program, program_enroll_begin_date)",
+        "alter table {{ this }} alter column ed_org_id set not null",
+        "alter table {{ this }} add primary key (k_student_program)",
         "alter table {{ this }} add constraint fk_{{ this.name }}_student foreign key (k_student) references {{ ref('dim_student') }}",
         "alter table {{ this }} add constraint fk_{{ this.name }}_program foreign key (k_program) references {{ ref('dim_program') }}",
     ]
@@ -26,11 +28,13 @@ dim_program as (
 
 formatted as (
     select
+        stage.k_student_program,
         dim_student.k_student,
         dim_student.k_student_xyear,
         dim_program.k_program,
         dim_program.k_lea,
         dim_program.k_school,
+        stage.ed_org_id,
         stage.tenant_code,
         dim_program.school_year,
         stage.program_enroll_begin_date,

--- a/models/core_warehouse/fct_student_title_i_part_a_program_association.sql
+++ b/models/core_warehouse/fct_student_title_i_part_a_program_association.sql
@@ -14,6 +14,9 @@
   )
 }}
 
+{{ cds_depends_on('edu:student_title_i_part_a_program_association:custom_data_sources') }}
+{% set custom_data_sources = var('edu:student_title_i_part_a_program_association:custom_data_sources', []) %}
+
 with stage as (
     select * from {{ ref('stg_ef3__student_title_i_part_a_program_associations') }}
 ),
@@ -48,6 +51,9 @@ formatted as (
         stage.reason_exited
         {# add any extension columns configured from stg_ef3__student_title_i_part_a_program_associations #}
         {{ edu_edfi_source.extract_extension(model_name='stg_ef3__student_title_i_part_a_program_associations', flatten=False) }}
+
+        -- custom data sources columns
+        {{ add_cds_columns(custom_data_sources=custom_data_sources) }}
     from stage
 
         inner join dim_student
@@ -55,6 +61,10 @@ formatted as (
 
         inner join dim_program
             on stage.k_program = dim_program.k_program
+
+    -- custom data sources
+    {{ add_cds_joins_v1(custom_data_sources=custom_data_sources, driving_alias='stage', join_cols=['k_student_program']) }}
+    {{ add_cds_joins_v2(custom_data_sources=custom_data_sources) }}
 )
 
 select * from formatted

--- a/models/core_warehouse/fct_student_title_i_part_a_program_association.yml
+++ b/models/core_warehouse/fct_student_title_i_part_a_program_association.yml
@@ -7,8 +7,7 @@ models:
         This fact table contains student Title I Part A program enrollment information.
 
       ##### Primary Key:
-        k_student, k_student_xyear, k_program, program_enroll_begin_date` -- There is one 
-        record per student, year, program enrol begin date, and Title I Part A program.
+        k_student_program` -- There is one record per student, year, ed_org_id, program enroll begin date, and Title I Part A program.
 
     config:
       tags: ['title_i']
@@ -20,15 +19,17 @@ models:
             combination_of_columns:
               - k_student
               - k_program
-              - k_student_xyear
+              - ed_org_id
               - program_enroll_begin_date
 
     columns:
+      - name: k_student_program
       - name: k_student
       - name: k_student_xyear
       - name: k_program
       - name: k_lea
       - name: k_school
+      - name: ed_org_id
       - name: tenant_code
       - name: school_year
       - name: program_enroll_begin_date

--- a/models/core_warehouse/msr_student_cumulative_attendance.sql
+++ b/models/core_warehouse/msr_student_cumulative_attendance.sql
@@ -11,6 +11,9 @@
   )
 }}
 
+{{ cds_depends_on('edu:msr_student_cumulative_attendance:custom_data_sources') }}
+{% set custom_data_sources = var('edu:msr_student_cumulative_attendance:custom_data_sources', []) %}
+
 with stu_daily_attendance as (
     select * from {{ ref('fct_student_daily_attendance') }}
 ),
@@ -49,9 +52,16 @@ metric_labels as (
             when meets_enrollment_threshold then metric_absentee_categories.level_label
             else null
         end as absentee_category_label
+
+        -- custom data sources columns
+        {{ add_cds_columns(custom_data_sources=custom_data_sources) }}
     from aggregated
     left join metric_absentee_categories
         on attendance_rate > metric_absentee_categories.threshold_lower
         and attendance_rate <= metric_absentee_categories.threshold_upper
+        
+    -- custom data sources
+    {{ add_cds_joins_v1(custom_data_sources=custom_data_sources, driving_alias='aggregated', join_cols=['k_student', 'k_school', 'school_year']) }}
+    {{ add_cds_joins_v2(custom_data_sources=custom_data_sources) }}
 )
 select * from metric_labels


### PR DESCRIPTION
## Description & motivation
The current EA CDS implementation is only on some tables probably because it was added only at the time it was needed by some customer. TDOE has added CDS to all dims and facts. Additionally, TDOE has enhanced the CDS implementation to be more flexible, but the current CDS implementation still works. So this should be backward compatible. The new impl allows a developer to directly control the joins and the output columns, as well as what the output column should be aliased as AND a default value if there is no row for the join.

IMPORTANT: This PR DEPENDS ON the enhancements to the Student Program Association tables and related tables. The reason for the dependency is because some of the current tables related to that contain a bug dealing with ed_org_id, which warranted fixes across the board, introducing a new PK for many of those tables. That PK, in many cases, is what the old CDS impl would have relied upon.

Here is an example of a CDS that is configured both ways:
```
  'edu:stu_demos:custom_data_sources': 
    cds_student_additional_columns:
      state_student_id:
        where: stateStudentId
      date_entered_us:
        where: dateenteredus
    cds_student_statuses:
      joins: 
        - cds_student_statuses.k_student = stg_student.k_student
      cds_additional_cols:
        tdoe_severity_code: { as: tdoe_severity_code, default: 0 }
        tdoe_severity: { as: tdoe_severity, default: "'good'" }
```

Here is an example of a CDS that simply adds columns to a dim/fact. The CDS model still has to exist, but it can be mainly empty. This would produce a cross-join... so know what you're doing:
```
  'edu:subgroup:custom_data_sources':
    cds_default_severity_columns:
      joins: [true]
      cds_additional_cols:
        tdoe_severity_code: { as: tdoe_severity_code, default: 0 }
        tdoe_severity: { as: tdoe_severity, default: "'good'" }
```

## Breaking changes introduced by this PR:
There should not be any breaking changes introduced by this PR. But as the existing CDS code was physically moved into macros and, in some cases, changed in what CTE the code was located there COULD be breaking changes. However, before this impl we were using some originally CDSs and when systematically modified everything, my original CDS impls were still working.

## PR Merge Priority:
- [X] Low
- [ ] Medium
- [ ] High

## Changes to existing files:
`macros/accordion_columns.sql` : Enhanced this macro to be able to deal with trailing commas. This enhancement is backwards compatible with the current codebase.
`models/core_warehouse/dim_assessment.sql` : Modified to support original CDS impl and TDOE CDS impl.
`models/core_warehouse/dim_calendar_date.sql` : Modified to support original CDS impl and TDOE CDS impl.
`models/core_warehouse/dim_class_period.sql` : Modified to support original CDS impl and TDOE CDS impl.
`models/core_warehouse/dim_classroom.sql` : Modified to support original CDS impl and TDOE CDS impl.
`models/core_warehouse/dim_cohort.sql` : Modified to support original CDS impl and TDOE CDS impl.
`models/core_warehouse/dim_course.sql` : Modified to support original CDS impl and TDOE CDS impl.
`models/core_warehouse/dim_course_section.sql` : Modified to support original CDS impl and TDOE CDS impl.
`models/core_warehouse/dim_discipline_incident.sql` : Modified to support original CDS impl and TDOE CDS impl.
`models/core_warehouse/dim_esc.sql` : Modified to support original CDS impl and TDOE CDS impl.
`models/core_warehouse/dim_grading_period.sql` : Modified to support original CDS impl and TDOE CDS impl.
`models/core_warehouse/dim_graduation_plan.sql` : Modified to support original CDS impl and TDOE CDS impl.
`models/core_warehouse/dim_lea.sql` : Modified to support original CDS impl and TDOE CDS impl.
`models/core_warehouse/dim_learning_standard.sql` : Modified to support original CDS impl and TDOE CDS impl.
`models/core_warehouse/dim_network.sql` : Modified to support original CDS impl and TDOE CDS impl.
`models/core_warehouse/dim_objective_assessment.sql` : Modified to support original CDS impl and TDOE CDS impl.
`models/core_warehouse/dim_parent.sql` : Modified to support original CDS impl and TDOE CDS impl.
`models/core_warehouse/dim_program.sql` : Modified to support original CDS impl and TDOE CDS impl.
`models/core_warehouse/dim_school.sql` : Modified to support original CDS impl and TDOE CDS impl.
`models/core_warehouse/dim_school_calendar.sql` : Modified to support original CDS impl and TDOE CDS impl.
`models/core_warehouse/dim_session.sql` : Modified to support original CDS impl and TDOE CDS impl.
`models/core_warehouse/dim_staff.sql` : Modified to support original CDS impl and TDOE CDS impl.
`models/core_warehouse/dim_student.sql` : Modified to support original CDS impl and TDOE CDS impl.
`models/core_warehouse/dim_subgroup.sql` : Modified to support original CDS impl and TDOE CDS impl.
`models/core_warehouse/fct_course_transcripts.sql` : Modified to support original CDS impl and TDOE CDS impl.
`models/core_warehouse/fct_staff_school_association.sql` : Modified to support original CDS impl and TDOE CDS impl.
`models/core_warehouse/fct_staff_section_association.sql` : Modified to support original CDS impl and TDOE CDS impl.
`models/core_warehouse/fct_student_academic_record.sql` : Modified to support original CDS impl and TDOE CDS impl.
`models/core_warehouse/fct_student_assessment.sql` : Modified to support original CDS impl and TDOE CDS impl.
`models/core_warehouse/fct_student_cohort_association.sql` : Modified to support original CDS impl and TDOE CDS impl.
`models/core_warehouse/fct_student_cte_program_associations.sql` : Modified to support original CDS impl and TDOE CDS impl.
`models/core_warehouse/fct_student_cte_program_associations.yml` : Modified to support original CDS impl and TDOE CDS impl.
`models/core_warehouse/fct_student_daily_attendance.sql` : Modified to support original CDS impl and TDOE CDS impl.
`models/core_warehouse/fct_student_diploma.sql` : Modified to support original CDS impl and TDOE CDS impl.
`models/core_warehouse/fct_student_discipline_actions.sql` : Modified to support original CDS impl and TDOE CDS impl.
`models/core_warehouse/fct_student_discipline_actions_summary.sql` : Modified to support original CDS impl and TDOE CDS impl.
`models/core_warehouse/fct_student_discipline_incident_behaviors.sql` : Modified to support original CDS impl and TDOE CDS impl.
`models/core_warehouse/fct_student_discipline_incident_non_offenders.sql` : Modified to support original CDS impl and TDOE CDS impl.
`models/core_warehouse/fct_student_discipline_incident_summary.sql` : Modified to support original CDS impl and TDOE CDS impl.
`models/core_warehouse/fct_student_gpa.sql` : Modified to support original CDS impl and TDOE CDS impl.
`models/core_warehouse/fct_student_grades.sql` : Modified to support original CDS impl and TDOE CDS impl.
`models/core_warehouse/fct_student_homeless_program_association.sql` : Modified to support original CDS impl and TDOE CDS impl.
`models/core_warehouse/fct_student_homeless_program_association.yml` : Modified to support original CDS impl and TDOE CDS impl.
`models/core_warehouse/fct_student_language_instruction_program_association.sql` : Modified to support original CDS impl and TDOE CDS impl.
`models/core_warehouse/fct_student_language_instruction_program_association.yml` : Modified to support original CDS impl and TDOE CDS impl.
`models/core_warehouse/fct_student_learning_standard_grades.sql` : Modified to support original CDS impl and TDOE CDS impl.
`models/core_warehouse/fct_student_migrant_education_program_associations.sql` : Modified to support original CDS impl and TDOE CDS impl.
`models/core_warehouse/fct_student_migrant_education_program_associations.yml` : Modified to support original CDS impl and TDOE CDS impl.
`models/core_warehouse/fct_student_objective_assessment.sql` : Modified to support original CDS impl and TDOE CDS impl.
`models/core_warehouse/fct_student_parent_association.sql` : Modified to support original CDS impl and TDOE CDS impl.
`models/core_warehouse/fct_student_program_association.sql` : Modified to support original CDS impl and TDOE CDS impl.
`models/core_warehouse/fct_student_program_association.yml` : Modified to support original CDS impl and TDOE CDS impl.
`models/core_warehouse/fct_student_program_service.sql` : Modified to support original CDS impl and TDOE CDS impl.
`models/core_warehouse/fct_student_program_service.yml` : Modified to support original CDS impl and TDOE CDS impl.
`models/core_warehouse/fct_student_school_association.sql` : Modified to support original CDS impl and TDOE CDS impl.
`models/core_warehouse/fct_student_school_attendance_event.sql` : Modified to support original CDS impl and TDOE CDS impl.
`models/core_warehouse/fct_student_school_food_service_program_associations.sql` : Modified to support original CDS impl and TDOE CDS impl.
`models/core_warehouse/fct_student_school_food_service_program_associations.yml` : Modified to support original CDS impl and TDOE CDS impl.
`models/core_warehouse/fct_student_section_association.sql` : Modified to support original CDS impl and TDOE CDS impl.
`models/core_warehouse/fct_student_section_attendance_event.sql` : Modified to support original CDS impl and TDOE CDS impl.
`models/core_warehouse/fct_student_special_education_program_association.sql` : Modified to support original CDS impl and TDOE CDS impl.
`models/core_warehouse/fct_student_special_education_program_association.yml` : Modified to support original CDS impl and TDOE CDS impl.
`models/core_warehouse/fct_student_subgroup.sql` : Modified to support original CDS impl and TDOE CDS impl.
`models/core_warehouse/fct_student_title_i_part_a_program_association.sql` : Modified to support original CDS impl and TDOE CDS impl.
`models/core_warehouse/fct_student_title_i_part_a_program_association.yml` : Modified to support original CDS impl and TDOE CDS impl.
`models/core_warehouse/msr_student_cumulative_attendance.sql` : Modified to support original CDS impl and TDOE CDS impl.

## New files created:
`macros/custom_data_sources_macros.sql` : This is a new set of macros for all CDS implementations, both EA's original design plus TDOE's implementation.
`models/build/edfi_3/students/bld_ef3__student__disabilities.sql` : New build model which contains all student's disabilities.
`models/build/edfi_3/students/bld_ef3__student__wide_disability_designations.sql` : New build model which contains all the disability designations for all student's disabilities.
`models/core_warehouse/fct_student_disability.sql` : Modified to support original CDS impl and TDOE CDS impl.
`models/core_warehouse/fct_student_disability.yml` : Modified to support original CDS impl and TDOE CDS impl.
`models/core_warehouse/fct_student_program_participation_status.sql` : Modified to support original CDS impl and TDOE CDS impl.
`models/core_warehouse/fct_student_program_participation_status.yml` : Modified to support original CDS impl and TDOE CDS impl.

## Tests and QC done:
TDOE uses both types of CDS extensively across basically all dims and facts. This is all working for us.

## edu_wh PR Review Checklist:
Make sure the following have been completed before approving this PR:
- [ ] Description of changes has been added to Unreleased section of [CHANGELOG.md](/CHANGELOG.md). Add under `## New Features` for features, etc.
- [ ] Code has been tested/checked for Databricks and Snowflake compatibility - EA engineers see Databricks checklist [here](https://edanalytics.slite.com/app/docs/LRjXFxVRAWA5ST) 
- [ ] Reviewer confirms the grain of all tables are unchanged, OR any changes are expected, communicated, and this PR is flagged as a breaking change (not for patch release)
- [ ] If a new configuration xwalk was added:
  - [ ] The code is written such that the xwalk is optional (preferred), and this behavior was tested, OR
  - [ ] The code is written such that the xwalk is required, and the required xwalk is added to edu_project_template, and this PR is flagged as breaking change (not for patch release)
  - [ ] A description for the new xwalk has been added to EDU documentation site [here](https://github.com/edanalytics/edu_docs/blob/main/docs/docs/manage_extend/reference/configure_dbt_xwalks.md) 
- [ ] If a new configuration variable was added:
  - [ ] The code is written such that the variable is optional (preferred), and this behavior was tested, OR
  - [ ] The code is written such that the variable is required, and a default value was added to edu_project_template, and this PR is flagged as breaking change (not for patch release)
  - [ ] A description for the new variable has been added to EDU documentation site [here](https://github.com/edanalytics/edu_docs/blob/main/docs/docs/manage_extend/reference/configure_dbt_vars.md) 