### PR TITLE
feature/:Enhanced dim_course_section to expose section_characteristics descriptors

### DIFF
--- a/models/build/edfi_3/courses/bld_ef3__section__wide_section_characteristics.sql
+++ b/models/build/edfi_3/courses/bld_ef3__section__wide_section_characteristics.sql
@@ -1,0 +1,35 @@
+with sections as (
+    select * from {{ ref('stg_ef3__sections') }}
+),
+xwalk_section_characteristics as (
+    select * from {{ ref('xwalk_section_characteristics') }}
+),
+flattened as (
+    select 
+        k_course_section,
+        {{ edu_edfi_source.extract_descriptor('section_chars.value:sectionCharacteristicDescriptor::string') }} as section_characteristic
+    from sections
+        {{ edu_edfi_source.json_flatten('v_section_characteristics', 'section_chars', outer=true) }}
+),
+pivoted as (
+    select 
+        k_course_section,
+        {{ edu_edfi_source.json_array_agg(
+            'section_characteristic',
+            order_by='section_characteristic',
+            is_terminal=True
+        ) }} as section_characteristics_array
+        {%- if not is_empty_model('xwalk_section_characteristics') -%},
+            {{ ea_pivot(
+                    column='indicator_name',
+                    values=dbt_utils.get_column_values(ref('xwalk_section_characteristics'), 'indicator_name'),
+                    cast='boolean',
+            ) }}
+        {%- endif %}
+    from flattened
+    left outer join xwalk_section_characteristics 
+        on flattened.section_characteristic = xwalk_section_characteristics.section_characteristic_descriptor
+    group by all
+)
+select *
+from pivoted

--- a/models/core_warehouse/dim_course_section.sql
+++ b/models/core_warehouse/dim_course_section.sql
@@ -22,8 +22,11 @@ stg_ef3__sections as (
 dim_course as (
     select * from {{ ref('dim_course') }}
 ),
-section_chars as (
+course_level_chars as (
     select * from {{ ref('bld_ef3__course_char__combined_wide') }}
+),
+section_chars as (
+    select * from {{ ref('bld_ef3__section__wide_section_characteristics') }}
 ),
 joined as (
     select 
@@ -47,14 +50,23 @@ joined as (
         stg_ef3__sections.is_official_attendance_period,
         stg_ef3__sections.sequence_of_course,
 
-        -- section characteristics
+        -- course level characteristics
         {{ accordion_columns(
             source_table='bld_ef3__course_char__combined_wide',
             exclude_columns=['tenant_code', 'api_year', 'k_course', 'k_course_offering', 'k_course_section', 'course_level_characteristics_array'],
+            source_alias='course_level_chars',
+            coalesce_value = 'FALSE'
+        ) }}
+        course_level_chars.course_level_characteristics_array,
+
+        -- section characteristics
+        {{ accordion_columns(
+            source_table='bld_ef3__section__wide_section_characteristics',
+            exclude_columns=['k_course_section', 'section_characteristics_array'],
             source_alias='section_chars',
             coalesce_value = 'FALSE'
         ) }}
-        section_chars.course_level_characteristics_array,
+        section_chars.section_characteristics_array,
 
         stg_ef3__sections.educational_environment_type,
         stg_ef3__sections.instruction_language,
@@ -79,6 +91,8 @@ joined as (
         on stg_ef3__sections.k_course_offering = offering.k_course_offering
     join dim_course 
         on offering.k_course = dim_course.k_course
+    left join course_level_chars 
+        on stg_ef3__sections.k_course_section = course_level_chars.k_course_section
     left join section_chars 
         on stg_ef3__sections.k_course_section = section_chars.k_course_section
     -- custom data sources


### PR DESCRIPTION
## Description & motivation
After the fix for course_level_characteristics, the visibility of section characteristics was gone. This set of changes brings that visibility back.

## Breaking changes introduced by this PR:
This change requires a new xwalk: `xwalk_section_characteristics.csv`. An example looks like this:
```
section_characteristic_descriptor,indicator_name
Fall Block,is_fall_block
Spring Block,is_spring_block
Year-long,is_year_long
``` 

## PR Merge Priority:
- [X] Low
- [ ] Medium
- [ ] High

## Changes to existing files:
- `models/core_warehouse/dim_course_section.sql` : Uses a new build model to expose the descriptors that come in on the sections_characteristics field.

## New files created:
- `models/build/edfi_3/courses/bld_ef3__section__wide_section_characteristics.sql` : Builds a set of wide columns that can be accordioned in dim_course_section.

## Tests and QC done:
This has been tested within stadium_tennessee.

## edu_wh PR Review Checklist:
Make sure the following have been completed before approving this PR:
- [ ] Description of changes has been added to Unreleased section of [CHANGELOG.md](/CHANGELOG.md). Add under `## New Features` for features, etc.
- [ ] Code has been tested/checked for Databricks and Snowflake compatibility - EA engineers see Databricks checklist [here](https://edanalytics.slite.com/app/docs/LRjXFxVRAWA5ST) 
- [ ] Reviewer confirms the grain of all tables are unchanged, OR any changes are expected, communicated, and this PR is flagged as a breaking change (not for patch release)
- [ ] If a new configuration xwalk was added:
  - [ ] The code is written such that the xwalk is optional (preferred), and this behavior was tested, OR
  - [ ] The code is written such that the xwalk is required, and the required xwalk is added to edu_project_template, and this PR is flagged as breaking change (not for patch release)
  - [ ] A description for the new xwalk has been added to EDU documentation site [here](https://github.com/edanalytics/edu_docs/blob/main/docs/docs/manage_extend/reference/configure_dbt_xwalks.md) 
- [ ] If a new configuration variable was added:
  - [ ] The code is written such that the variable is optional (preferred), and this behavior was tested, OR
  - [ ] The code is written such that the variable is required, and a default value was added to edu_project_template, and this PR is flagged as breaking change (not for patch release)
  - [ ] A description for the new variable has been added to EDU documentation site [here](https://github.com/edanalytics/edu_docs/blob/main/docs/docs/manage_extend/reference/configure_dbt_vars.md) 