### PR TITLE
update `is_active_enrollment` logic for year-end

### DIFF
--- a/models/core_warehouse/fct_student_school_association.sql
+++ b/models/core_warehouse/fct_student_school_association.sql
@@ -68,12 +68,17 @@ formatted as (
             and (
                 -- standard: not yet exited as of today
                 {{ date_within_end_date('current_date()', 'exit_withdraw_date', var('edu:enroll:exit_withdraw_date_inclusive', True)) }}
-                {% if var('edu:enroll:year_end_active_extension', False) %}
-                -- extended: enrolled through end of school year; stays active until next year's data loads
-                or exit_withdraw_date >= dateadd(
+
+                {% set buffer_days = var('edu:enroll:year_end_active_buffer_days', false) %}
+                {% if buffer_days %}
+                -- extended: if configured, enrolled through end of school year; stays active until next year's data loads
+                or (exit_withdraw_date >= dateadd(
                     day,
-                    -{{ var('edu:enroll:year_end_active_buffer_days', 7) }},
+                    -{{ buffer_days }},
                     bld_school_calendar_windows.last_school_day
+                    )
+                    -- only apply to cases where calendar end is in the current year (exclude from active if calendar ended in Fall or previous year, or tenant only has data from last year)
+                    AND year(bld_school_calendar_windows.last_school_day) = year(current_date())
                 )
                 {% endif %}
             )

--- a/models/core_warehouse/fct_student_school_association.sql
+++ b/models/core_warehouse/fct_student_school_association.sql
@@ -62,28 +62,40 @@ formatted as (
         stg_stu_school.enrollment_type,
         -- create indicator for active enrollment
         iff(
-            -- is highest school year observed by tenant
+            -- is highest school year observed by tenant. 
             stg_stu_school.school_year = max(stg_stu_school.school_year)
                 over(partition by stg_stu_school.tenant_code)
+            -- enrollment has begun
+            and entry_date <= current_date()
+            -- not yet exited, or 'year-end extension' if configured
             and (
                 -- standard: not yet exited as of today
                 {{ date_within_end_date('current_date()', 'exit_withdraw_date', var('edu:enroll:exit_withdraw_date_inclusive', True)) }}
+                
+                -- extended: if configured, students who exit at the end of the school year are still active until the next year's data loads
+                {%- set buffer_days = var('edu:enroll:year_end_active_buffer_days', none) -%}
+                {%- if buffer_days is not none %}
+                    or (exit_withdraw_date >= dateadd(
+                        day,
+                        -- Adjust last_school_day by buffer_days to determine the cutoff date for "active enrollment":
+                        -- If buffer_days > 0: Move cutoff date earlier (prior to last_school_day) (use to keep students active who exit during the last buffer_days days of the school year)
+                        -- If buffer_days < 0: Move cutoff date later (after last_school_day) (use to keep students active who exit after the last school day)
+                        -- If buffer_days == 0: Use last_school_day as-is (use to keep students active who exit on or after the last school day)
+                        {% if buffer_days > 0 %}
+                            -{{ buffer_days }}
+                        {% elif buffer_days < 0 %}
+                            {{ -buffer_days }}
+                        {% else %}
+                            0
+                        {% endif %},
 
-                {% set buffer_days = var('edu:enroll:year_end_active_buffer_days', false) %}
-                {% if buffer_days %}
-                -- extended: if configured, enrolled through end of school year; stays active until next year's data loads
-                or (exit_withdraw_date >= dateadd(
-                    day,
-                    -{{ buffer_days }},
-                    bld_school_calendar_windows.last_school_day
+                        bld_school_calendar_windows.last_school_day
+                        )
+                        -- only apply to cases where calendar end is in the current year (exclude from active if calendar ended in Fall or previous year, or tenant only has data from last year)
+                        AND year(bld_school_calendar_windows.last_school_day) = year(current_date())
                     )
-                    -- only apply to cases where calendar end is in the current year (exclude from active if calendar ended in Fall or previous year, or tenant only has data from last year)
-                    AND year(bld_school_calendar_windows.last_school_day) = year(current_date())
-                )
                 {% endif %}
-            )
-            -- enrollment has begun
-            and entry_date <= current_date(),
+            ),
             true, false
         ) as is_active_enrollment,
         stg_stu_school.entry_grade_level,

--- a/models/core_warehouse/fct_student_school_association.sql
+++ b/models/core_warehouse/fct_student_school_association.sql
@@ -63,10 +63,20 @@ formatted as (
         -- create indicator for active enrollment
         iff(
             -- is highest school year observed by tenant
-            stg_stu_school.school_year = max(stg_stu_school.school_year) 
+            stg_stu_school.school_year = max(stg_stu_school.school_year)
                 over(partition by stg_stu_school.tenant_code)
-            -- not yet exited
-            and {{ date_within_end_date('current_date()', 'exit_withdraw_date', var('edu:enroll:exit_withdraw_date_inclusive', True)) }}
+            and (
+                -- standard: not yet exited as of today
+                {{ date_within_end_date('current_date()', 'exit_withdraw_date', var('edu:enroll:exit_withdraw_date_inclusive', True)) }}
+                {% if var('edu:enroll:year_end_active_extension', False) %}
+                -- extended: enrolled through end of school year; stays active until next year's data loads
+                or exit_withdraw_date >= dateadd(
+                    day,
+                    -{{ var('edu:enroll:year_end_active_buffer_days', 7) }},
+                    bld_school_calendar_windows.last_school_day
+                )
+                {% endif %}
+            )
             -- enrollment has begun
             and entry_date <= current_date(),
             true, false


### PR DESCRIPTION
## Description & motivation

Adds an optional year-end active enrollment extension to `fct_student_school_association`. By default, a student's `is_active_enrollment` flag goes to `false` as soon as their `exit_withdraw_date` passes. For districts that want students to remain "active" through the summer (until next year's data loads), this PR introduces a single configurable variable — `edu:enroll:year_end_active_buffer_days` — that extends the active window for students who were enrolled through the end of the school year.

When set, a student is also considered active if their exit date falls within `N` days before the last school day on their school calendar. This covers the common case where a district marks all students as exited on the final day but expects them to appear active until new enrollment data arrives in the fall.

## Breaking changes introduced by this PR:

None. The new variable is optional and defaults to `false` (feature disabled). Existing behavior is unchanged when the variable is not set.

## PR Merge Priority:
- [ ] Low
- [ ] Medium
- [x] High:  **needed in SC by 5/19** 

## Changes to existing files:

- `fct_student_school_association`: Adds a conditional branch to the `is_active_enrollment` logic. When `edu:enroll:year_end_active_buffer_days` is set to a positive integer, a student is also marked active if `exit_withdraw_date >= last_school_day - N days`. The feature is disabled when the variable is unset or `false`. This replaces an earlier two-variable design (`year_end_active_extension` boolean + `year_end_active_buffer_days` integer) with a single variable that is falsy by default and acts as both the feature gate and the buffer configuration.

## New files created:

N/A

## Tests and QC done:

- [x] Validated that `is_active_enrollment` is unchanged when `edu:enroll:year_end_active_buffer_days` is not set
- [x] Validated that students with `exit_withdraw_date` within the buffer window are marked active when the variable is configured
- [x] Ran dbt compile to confirm Jinja renders correctly under both conditions

## edu_wh PR Review Checklist:
Make sure the following have been completed before approving this PR:
- [ ] Description of changes has been added to Unreleased section of [CHANGELOG.md](/CHANGELOG.md). Add under `## New Features` for features, etc.
- [ ] Code has been tested/checked for Databricks and Snowflake compatibility - EA engineers see Databricks checklist [here](https://edanalytics.slite.com/app/docs/LRjXFxVRAWA5ST)
- [ ] Reviewer confirms the grain of all tables are unchanged, OR any changes are expected, communicated, and this PR is flagged as a breaking change (not for patch release)
- [ ] If a new configuration variable was added:
  - [x] The code is written such that the variable is optional (preferred), and this behavior was tested
  - [ ] A description for the new variable has been added to EDU documentation site [here](https://github.com/edanalytics/edu_docs/blob/main/docs/docs/manage_extend/reference/configure_dbt_vars.md)
