### PR TITLE
docs/constraints and column descriptions

### DIFF
--- a/models/core_warehouse/brg_course_section_program.yml
+++ b/models/core_warehouse/brg_course_section_program.yml
@@ -11,6 +11,21 @@ models:
 
     config:
       tags: ['core', 'course']
+
+    constraints:
+      - type: primary_key
+        columns: [k_course_section, k_program]
+      - type: foreign_key
+        name: fk__brg_course_section_program__k_course_section
+        columns: [k_course_section]
+        to: ref('dim_course_section')
+        to_columns: [k_course_section]
+      - type: foreign_key
+        name: fk__brg_course_section_program__k_program
+        columns: [k_program]
+        to: ref('dim_program')
+        to_columns: [k_program]
+
     columns:
       - name: tenant_code
       - name: k_course_section

--- a/models/core_warehouse/dim_assessment.yml
+++ b/models/core_warehouse/dim_assessment.yml
@@ -12,6 +12,11 @@ models:
     config:
       tags: ['assessment']
       enabled: "{{ var('src:domain:assessment:enabled', True) }}"
+
+    constraints:
+      - type: primary_key
+        columns: [k_assessment]
+
     columns:
       - name: k_assessment
         description: Generated primary key composed of `tenant_code`, `api_year`, `academicSubjectDescriptor`, `assessmentIdentifier`, and `namespace`.

--- a/models/core_warehouse/dim_calendar_date.yml
+++ b/models/core_warehouse/dim_calendar_date.yml
@@ -29,35 +29,35 @@ models:
 
     columns:
       - name: k_calendar_date
-        description: >
-          Generated primary key for an individual day in a single calendar
-          at a single school.
+        description: Generated primary key for an individual day in a single calendar at a single school.
         tests:
           - unique
       - name: k_school_calendar
         description: Association to a single named calendar at a school.
       - name: k_school
-        description: Association to a single school
+        description: Association to a single school.
       - name: tenant_code
+        description: The tenant associated with the record.
       - name: calendar_code
-        description: Descriptive label for a calendar
+        description: Descriptive label for a calendar.
       - name: school_year
-        description: > 
-          School year specified by Spring year,
-          e.g. the 2021-2022 year would be 2022.
+        description: School year specified by Spring year, e.g. the 2021-2022 year would be 2022.
       - name: calendar_date
+        description: Date on school calendar.
+        config:
+            meta:
+                type: 'date'
       - name: calendar_event
-        description: A descriptor code for types of days within a school calendar
+        description: A descriptor code for types of days within a school calendar.
       - name: calendar_events_array
         description: The list of events for this day, if there are multiple.
       - name: is_school_day
         description: Is this an instructional day?
       - name: day_of_school_year
-        description: Counting across instructional days
+        description: Counting across instructional days.
       - name: week_day
-        description: Labeled day of the week
+        description: Labeled day of the week.
       - name: week_of_calendar_year
-        description: Counting across calendar weeks
+        description: Counting across calendar weeks.
       - name: week_of_school_year
-        description: Counting across weeks of the school year
-      
+        description: Counting across weeks of the school year.

--- a/models/core_warehouse/dim_calendar_date.yml
+++ b/models/core_warehouse/dim_calendar_date.yml
@@ -12,6 +12,21 @@ models:
 
     config:
       tags: ['core']
+
+    constraints:
+      - type: primary_key
+        columns: [k_calendar_date]
+      - type: foreign_key
+        name: fk_dim_calendar_date_school_calendar
+        columns: [k_school_calendar]
+        to: ref('dim_school_calendar')
+        to_columns: [k_school_calendar]
+      - type: foreign_key
+        name: fk_dim_calendar_date_school
+        columns: [k_school]
+        to: ref('dim_school')
+        to_columns: [k_school]
+
     columns:
       - name: k_calendar_date
         description: >

--- a/models/core_warehouse/dim_calendar_date.yml
+++ b/models/core_warehouse/dim_calendar_date.yml
@@ -17,12 +17,12 @@ models:
       - type: primary_key
         columns: [k_calendar_date]
       - type: foreign_key
-        name: fk_dim_calendar_date_school_calendar
+        name: fk__dim_calendar_date__k_school_calendar
         columns: [k_school_calendar]
         to: ref('dim_school_calendar')
         to_columns: [k_school_calendar]
       - type: foreign_key
-        name: fk_dim_calendar_date_school
+        name: fk__dim_calendar_date__k_school
         columns: [k_school]
         to: ref('dim_school')
         to_columns: [k_school]

--- a/models/core_warehouse/dim_class_period.yml
+++ b/models/core_warehouse/dim_class_period.yml
@@ -4,3 +4,7 @@ models:
   - name: dim_class_period
     config:
       tags: ['core']
+
+    constraints:
+      - type: primary_key
+        columns: [k_class_period]

--- a/models/core_warehouse/dim_classroom.yml
+++ b/models/core_warehouse/dim_classroom.yml
@@ -11,6 +11,16 @@ models:
 
     config:
       tags: ['core']
+
+    constraints:
+      - type: primary_key
+        columns: [k_classroom]
+      - type: foreign_key
+        name: fk__dim_classroom__k_school
+        columns: [k_school]
+        to: ref('dim_school')
+        to_columns: [k_school]
+
     columns:
       - name: k_classroom
         description: Defining key for school locations

--- a/models/core_warehouse/dim_cohort.yml
+++ b/models/core_warehouse/dim_cohort.yml
@@ -17,6 +17,11 @@ models:
     config:
       tags: ['cohort']
       enabled: "{{ var('src:domain:cohort:enabled', True) }}"
+
+    constraints:
+      - type: primary_key
+        columns: [k_cohort]
+
     columns:
       - name: k_cohort
         description: Defining key for cohorts. Surrogate key for [`api_year` + `ed_org_id` + `cohort_id`]

--- a/models/core_warehouse/dim_course.yml
+++ b/models/core_warehouse/dim_course.yml
@@ -11,6 +11,11 @@ models:
           `k_course` - There is one record per course, year, and ed-org. (note that `k_course` is an annualized identifier)
     config:
       tags: ['core', 'course']
+
+    constraints:
+      - type: primary_key
+        columns: [k_course]
+
     columns:
       - name: k_course
         description: Defining key for courses. Generated primary key composed of `tenant_code`, `api_year`, `course_code`, and `ed_org_id`.

--- a/models/core_warehouse/dim_course_section.yml
+++ b/models/core_warehouse/dim_course_section.yml
@@ -21,6 +21,26 @@ models:
       
     config:
       tags: ['core', 'course']
+
+    constraints:
+      - type: primary_key
+        columns: [k_course_section]
+      - type: foreign_key
+        name: fk__dim_course_section__k_course
+        columns: [k_course]
+        to: ref('dim_course')
+        to_columns: [k_course]
+      - type: foreign_key
+        name: fk__dim_course_section__k_school
+        columns: [k_school]
+        to: ref('dim_school')
+        to_columns: [k_school]
+      - type: foreign_key
+        name: fk__dim_course_section__k_session
+        columns: [k_session]
+        to: ref('dim_session')
+        to_columns: [k_session]
+
     columns:
       - name: k_course_section
         description: Defining key for course sections

--- a/models/core_warehouse/dim_discipline_incident.yml
+++ b/models/core_warehouse/dim_discipline_incident.yml
@@ -8,6 +8,15 @@ models:
 
       ##### Primary Key:
         `k_discipline_incident` - There is one record per incident ID, school, and year.
+    constraints:
+      - type: primary_key
+        columns: [k_discipline_incident]
+      - type: foreign_key
+        name: fk__dim_discipline_incident__k_school
+        columns: [k_school]
+        to: ref('dim_school')
+        to_columns: [k_school]
+
     columns:
       - name: k_discipline_incident
         description: Generated primary key composed of `tenant_code`, `api_year`, `incident_id`, and `school_id`.

--- a/models/core_warehouse/dim_esc.yml
+++ b/models/core_warehouse/dim_esc.yml
@@ -12,3 +12,7 @@ models:
     config:
       tags: ['esc']
       enabled: "{{ var('src:ed_orgs:esc:enabled', True) }}"
+
+    constraints:
+      - type: primary_key
+        columns: [k_esc]

--- a/models/core_warehouse/dim_grading_period.yml
+++ b/models/core_warehouse/dim_grading_period.yml
@@ -10,6 +10,16 @@ models:
           `k_grading_period` - There is one record per grading period.
     config:
       tags: ['core', 'course']
+
+    constraints:
+      - type: primary_key
+        columns: [k_grading_period]
+      - type: foreign_key
+        name: fk__dim_grading_period__k_school
+        columns: [k_school]
+        to: ref('dim_school')
+        to_columns: [k_school]
+
     columns:
       - name: k_grading_period
         description: Generated primary key composed of 'grading_period', 'period_sequence', 'school_id', and 'school_year' (generated in [stg_ef3__grading_periods](#!/model/model.edu_edfi_source.stg_ef3__grading_periods))

--- a/models/core_warehouse/dim_graduation_plan.yml
+++ b/models/core_warehouse/dim_graduation_plan.yml
@@ -10,6 +10,11 @@ models:
           `k_graduation_plan` - There is one record per graduation plan (plan type + ed_org_id + graduation_school_year)
     config:
       tags: ['core']
+
+    constraints:
+      - type: primary_key
+        columns: [k_graduation_plan]
+
     columns:
       - name: k_graduation_plan
         description: Generated primary key composed of 'graduation_plan_type', 'ed_org_id', and 'graduation_school_year' (generated in [stg_ef3__graduation_plans](#!/model/model.edu_edfi_source.stg_ef3__graduation_plans))

--- a/models/core_warehouse/dim_lea.yml
+++ b/models/core_warehouse/dim_lea.yml
@@ -4,3 +4,7 @@ models:
   - name: dim_lea
     config:
       tags: ['core']
+
+    constraints:
+      - type: primary_key
+        columns: [k_lea]

--- a/models/core_warehouse/dim_learning_standard.yml
+++ b/models/core_warehouse/dim_learning_standard.yml
@@ -12,6 +12,11 @@ models:
       
     config:
       tags: ['core', 'course']
+
+    constraints:
+      - type: primary_key
+        columns: [k_learning_standard]
+
     columns:
       - name: k_learning_standard
         description: Unique identifier for a learning standard.

--- a/models/core_warehouse/dim_network.yml
+++ b/models/core_warehouse/dim_network.yml
@@ -14,6 +14,10 @@ models:
     config:
       tags: ['core']
 
+    constraints:
+      - type: primary_key
+        columns: [k_network]
+
     columns:
       - name: k_network
       - name: tenant_code

--- a/models/core_warehouse/dim_objective_assessment.yml
+++ b/models/core_warehouse/dim_objective_assessment.yml
@@ -7,6 +7,16 @@ models:
     config:
       tags: ['assessment']
       enabled: "{{ var('src:domain:assessment:enabled', True) }}"
+
+    constraints:
+      - type: primary_key
+        columns: [k_objective_assessment]
+      - type: foreign_key
+        name: fk__dim_objective_assessment__k_assessment
+        columns: [k_assessment]
+        to: ref('dim_assessment')
+        to_columns: [k_assessment]
+
     columns:
       - name: k_objective_assessment
         description: >

--- a/models/core_warehouse/dim_parent.yml
+++ b/models/core_warehouse/dim_parent.yml
@@ -9,6 +9,11 @@ models:
       includes records from both the Parents and Contacts resources.
     config:
       tags: ['core']
+
+    constraints:
+      - type: primary_key
+        columns: [k_parent]
+
     columns:
       - name: k_parent
         description: Defining key for the parent, which is consistent across years.

--- a/models/core_warehouse/dim_program.yml
+++ b/models/core_warehouse/dim_program.yml
@@ -19,6 +19,11 @@ models:
 
     config:
       tags: ['core']
+
+    constraints:
+      - type: primary_key
+        columns: [k_program]
+
     columns:
       - name: k_program
         description: Defining key for programs. Surrogate key for [`api_year` + `ed_org_id` + `program_name` + `program_type`]

--- a/models/core_warehouse/dim_school.yml
+++ b/models/core_warehouse/dim_school.yml
@@ -13,6 +13,11 @@ models:
 
     config:
       tags: ['core']
+
+    constraints:
+      - type: primary_key
+        columns: [k_school]
+
     tests:
       - dbt_utils.unique_combination_of_columns:
           arguments:

--- a/models/core_warehouse/dim_school.yml
+++ b/models/core_warehouse/dim_school.yml
@@ -23,21 +23,30 @@ models:
           arguments:
             combination_of_columns:
               - k_school
+
     columns:
       - name: k_school
+        description: Unique key identifying a school.
       - name: k_lea
+        description: Unique key identifying a Local Education Agency (LEA).
       - name: tenant_code
+        description: The tenant associated with the record.
       - name: school_id
         description: The unique identifier assigned to a school.
       - name: department_school_code
+        description: Department school identifier, if provided.
       - name: local_school_code
-        description: Local school identifier
+        description: Local school identifier, if provided.
       - name: state_school_code
-        description: State school identifier
+        description: State school identifier, if provided.
       - name: school_name
+        description: Name of the school.
       - name: school_short_name
+        description: Short name of the school, if provided.
       - name: lea_name
+        description: Name of the Local Education Agency (LEA) with which the school is associated.
       - name: lea_id
+        description: Identifier of the Local Education Agency (LEA) with which the school is associated.
       - name: school_category
         description: The category of school. For example - High School, Middle School, Elementary School.
       - name: school_type
@@ -55,16 +64,28 @@ models:
       - name: magnet_type
         description: Emphasis of magnet school. A magnet school is a school that has been designed to attract students of different racial/ethnic backgrounds for the purpose of reducing, preventing or eliminating racial isolation; and/or to provide an academic or social focus on a particular theme (e.g., science/math, performing arts, gifted/talented, or foreign language).
       - name: website
+        description: Website associated with a school.
       - name: address_type
+        description: The type of address listed. For example - Physical, Mailing.
       - name: street_address
+        description: Street address a school is associated with.
       - name: city
+        description: City that the school address is associated with.
       - name: name_of_county
+        description: Name of the county the school address is associated with.
       - name: state_code
+        description: 2-character state code. State codes are maintained by the USPS.
       - name: postal_code
+        description: Zip code associated with the school address.
       - name: building_site_number
+        description: Number for a building site, if provided.
       - name: locale
+        description: Locale code associated with the school. Locale codes are maintained by the National Center for Education Statistics (NCES).
       - name: congressional_district
+        description: Congressional districts associated with the school.
       - name: county_fips_code
         description: Definition The Federal Information Processing Standards (FIPS) numeric code for the county issued by the National Institute of Standards and Technology (NIST). Counties are considered to be the "first-order subdivisions" of each State and statistically equivalent entity, regardless of their local designations (county, parish, borough, etc.) Counties in different States will have the same code. A unique county number is created when combined with the 2-digit FIPS State Code.
       - name: latitude
+        description: Latitude of a school building location.
       - name: longitude
+        description: Longitude of a school building location.

--- a/models/core_warehouse/dim_school_calendar.yml
+++ b/models/core_warehouse/dim_school_calendar.yml
@@ -4,3 +4,12 @@ models:
   - name: dim_school_calendar
     config:
       tags: ['core']
+
+    constraints:
+      - type: primary_key
+        columns: [k_school_calendar]
+      - type: foreign_key
+        name: fk__dim_school_calendar__k_school
+        columns: [k_school]
+        to: ref('dim_school')
+        to_columns: [k_school]

--- a/models/core_warehouse/dim_session.yml
+++ b/models/core_warehouse/dim_session.yml
@@ -9,7 +9,7 @@ models:
       - type: primary_key
         columns: [k_session]
       - type: foreign_key
-        name: fk_dim_session_school
+        name: fk__dim_session__k_school
         columns: [k_school]
         to: ref('dim_school')
         to_columns: [k_school]

--- a/models/core_warehouse/dim_session.yml
+++ b/models/core_warehouse/dim_session.yml
@@ -4,3 +4,12 @@ models:
   - name: dim_session
     config:
       tags: ['core']
+
+    constraints:
+      - type: primary_key
+        columns: [k_session]
+      - type: foreign_key
+        name: fk_dim_session_school
+        columns: [k_school]
+        to: ref('dim_school')
+        to_columns: [k_school]

--- a/models/core_warehouse/dim_session.yml
+++ b/models/core_warehouse/dim_session.yml
@@ -13,3 +13,32 @@ models:
         columns: [k_school]
         to: ref('dim_school')
         to_columns: [k_school]
+    
+    columns:
+      - name: k_session
+        description: The unique identifier for a session. Sessions are unique to schools and school years.
+      - name: k_school
+        description: The unique identifier for a school.
+      - name: tenant_code
+        description: The tenant associated with the record.
+      - name: school_year
+        description: School year specified by Spring year, e.g. the 2021-2022 year would be 2022.
+      - name: session_name
+        description: Identifier code for a session.
+      - name: session_begin_date
+        description: The date the session began.
+        config:
+            meta:
+                type: 'date'
+      - name: session_end_date
+        description: The date the session ended.
+        config:
+            meta:
+                type: 'date'
+      - name: total_instructional_days
+        description: The total number of instructional days associated with a session.
+        config:
+            meta:
+                type: 'fact'
+      - name: academic_term
+        description: The name for a session. For example - "Spring Semester", "First Quarter".

--- a/models/core_warehouse/dim_staff.yml
+++ b/models/core_warehouse/dim_staff.yml
@@ -17,6 +17,11 @@ models:
 
     config:
       tags: ['core']
+
+    constraints:
+      - type: primary_key
+        columns: [k_staff]
+
     columns:
       - name: k_staff
         description: "Primary key generated using `tenant_code` and `staff_unique_id`"

--- a/models/core_warehouse/dim_student.yml
+++ b/models/core_warehouse/dim_student.yml
@@ -21,6 +21,11 @@ models:
 
     config:
       tags: ['core', 'special_ed', 'homeless', 'language_instruction', 'title_i']
+    
+    constraints:
+      - type: primary_key
+        columns: [k_student]
+
     columns:
       - name: k_student
         description: Defining key for the student in this school year.

--- a/models/core_warehouse/dim_student.yml
+++ b/models/core_warehouse/dim_student.yml
@@ -37,6 +37,7 @@ models:
         tests:
           - not_null
       - name: tenant_code
+        description: The tenant associated with the record.
       - name: school_year
         description: >
           School year specified by Spring year.
@@ -55,6 +56,9 @@ models:
         description: The student's last name, first name, and middle initial.
       - name: birth_date
         description: The student's birthday formatted as YYYY-MM-DD.
+        config:
+            meta:
+                type: 'date'
       - name: birth_country
         description: The student's birth country.
       - name: lep_code

--- a/models/core_warehouse/dim_subgroup.yml
+++ b/models/core_warehouse/dim_subgroup.yml
@@ -17,6 +17,11 @@ models:
 
     config:
       tags: ['core']
+
+    constraints:
+      - type: primary_key
+        columns: [k_subgroup]
+
     columns:
       - name: k_subgroup
         description: Defining key for subgroups. A surrogate key for [`subgroup_category` + `subgroup_value`]

--- a/models/core_warehouse/fct_course_transcripts.yml
+++ b/models/core_warehouse/fct_course_transcripts.yml
@@ -39,6 +39,26 @@ models:
 
     config:
       tags: ['core']
+
+    constraints:
+      - type: primary_key
+        columns: [k_course, k_student_academic_record, course_attempt_result]
+      - type: foreign_key
+        name: fk__fct_course_transcripts__k_course
+        columns: [k_course]
+        to: ref('dim_course')
+        to_columns: [k_course]
+      - type: foreign_key
+        name: fk__fct_course_transcripts__k_student_academic_record
+        columns: [k_student_academic_record]
+        to: ref('fct_student_academic_record')
+        to_columns: [k_student_academic_record]
+      - type: foreign_key
+        name: fk__fct_course_transcripts__k_student
+        columns: [k_student]
+        to: ref('dim_student')
+        to_columns: [k_student]
+
     tests:
       - dbt_utils.unique_combination_of_columns:
           arguments:

--- a/models/core_warehouse/fct_staff_school_association.yml
+++ b/models/core_warehouse/fct_staff_school_association.yml
@@ -4,6 +4,21 @@ models:
   - name: fct_staff_school_association
     config:
       tags: ['core']
+
+    constraints:
+      - type: primary_key
+        columns: [k_staff_school_association]
+      - type: foreign_key
+        name: fk__fct_staff_school_association__k_staff
+        columns: [k_staff]
+        to: ref('dim_staff')
+        to_columns: [k_staff]
+      - type: foreign_key
+        name: fk__fct_staff_school_association__k_school
+        columns: [k_school]
+        to: ref('dim_school')
+        to_columns: [k_school]
+
     description: >
      ##### Overview:
        This fact table provides information on the associations between Staff and Schools. It includes both active and historic associations.

--- a/models/core_warehouse/fct_staff_section_association.yml
+++ b/models/core_warehouse/fct_staff_section_association.yml
@@ -17,6 +17,21 @@ models:
 
     config:
       tags: ['core']
+
+    constraints:
+      - type: primary_key
+        columns: [k_staff, k_course_section, begin_date]
+      - type: foreign_key
+        name: fk__fct_staff_section_association__k_staff
+        columns: [k_staff]
+        to: ref('dim_staff')
+        to_columns: [k_staff]
+      - type: foreign_key
+        name: fk__fct_staff_section_association__k_course_section
+        columns: [k_course_section]
+        to: ref('dim_course_section')
+        to_columns: [k_course_section]
+
     columns:
       - name: k_staff
         description: "Unique key for staff, foreign key reference to `dim_staff`"

--- a/models/core_warehouse/fct_student_academic_record.yml
+++ b/models/core_warehouse/fct_student_academic_record.yml
@@ -28,6 +28,16 @@ models:
 
     config:
       tags: ['core']
+
+    constraints:
+      - type: primary_key
+        columns: [k_student_academic_record]
+      - type: foreign_key
+        name: fk__fct_student_academic_record__k_student
+        columns: [k_student]
+        to: ref('dim_student')
+        to_columns: [k_student]
+
     columns:
       - name: k_student_academic_record
       - name: k_student_xyear

--- a/models/core_warehouse/fct_student_assessment.yml
+++ b/models/core_warehouse/fct_student_assessment.yml
@@ -43,6 +43,21 @@ models:
     config:
       tags: ['assessment']
       enabled: "{{ var('src:domain:assessment:enabled', True) }}"
+
+    constraints:
+      - type: primary_key
+        columns: [k_student_assessment]
+      - type: foreign_key
+        name: fk__fct_student_assessment__k_assessment
+        columns: [k_assessment]
+        to: ref('dim_assessment')
+        to_columns: [k_assessment]
+      - type: foreign_key
+        name: fk__fct_student_assessment__k_student
+        columns: [k_student]
+        to: ref('dim_student')
+        to_columns: [k_student]
+
     columns:
       - name: k_student_assessment
         description: >

--- a/models/core_warehouse/fct_student_cohort_association.yml
+++ b/models/core_warehouse/fct_student_cohort_association.yml
@@ -12,6 +12,21 @@ models:
     config:
       tags: ['cohort']
       enabled: "{{ var('src:domain:cohort:enabled', True) }}"
+
+    constraints:
+      - type: primary_key
+        columns: [k_student, k_cohort, cohort_begin_date]
+      - type: foreign_key
+        name: fk__fct_student_cohort_association__k_student
+        columns: [k_student]
+        to: ref('dim_student')
+        to_columns: [k_student]
+      - type: foreign_key
+        name: fk__fct_student_cohort_association__k_cohort
+        columns: [k_cohort]
+        to: ref('dim_cohort')
+        to_columns: [k_cohort]
+
     tests:
       - dbt_utils.unique_combination_of_columns:
           arguments:

--- a/models/core_warehouse/fct_student_cte_program_associations.sql
+++ b/models/core_warehouse/fct_student_cte_program_associations.sql
@@ -3,10 +3,9 @@
   config(
     post_hook=[
         "alter table {{ this }} alter column k_student set not null",
-        "alter table {{ this }} alter column k_student_xyear set not null",
         "alter table {{ this }} alter column k_program set not null",
         "alter table {{ this }} alter column program_enroll_begin_date set not null",
-        "alter table {{ this }} add primary key (k_student, k_student_xyear, k_program, program_enroll_begin_date)",
+        "alter table {{ this }} add primary key (k_student, k_program, program_enroll_begin_date)",
         "alter table {{ this }} add constraint fk_{{ this.name }}_student foreign key (k_student) references {{ ref('dim_student') }}",
         "alter table {{ this }} add constraint fk_{{ this.name }}_program foreign key (k_program) references {{ ref('dim_program') }}"
     ]

--- a/models/core_warehouse/fct_student_cte_program_associations.yml
+++ b/models/core_warehouse/fct_student_cte_program_associations.yml
@@ -7,12 +7,26 @@ models:
         This fact table contains student cte program enrollment information.
 
       ##### Primary Key:
-        `k_student, k_student_xyear, k_program, program_enroll_begin_date` -- There 
+        `k_student, k_program, program_enroll_begin_date` -- There 
         is one record per student, year, program enrol begin date, and cte program.
 
     config:
       tags: ['cte']
       enabled: "{{ var('src:program:cte:enabled', True) }}"
+
+    constraints:
+      - type: primary_key
+        columns: [k_student, k_program, program_enroll_begin_date]
+      - type: foreign_key
+        name: fk__fct_student_cte_program_associations__k_student
+        columns: [k_student]
+        to: ref('dim_student')
+        to_columns: [k_student]
+      - type: foreign_key
+        name: fk__fct_student_cte_program_associations__k_program
+        columns: [k_program]
+        to: ref('dim_program')
+        to_columns: [k_program]
 
     tests:
       - dbt_utils.unique_combination_of_columns:

--- a/models/core_warehouse/fct_student_daily_attendance.yml
+++ b/models/core_warehouse/fct_student_daily_attendance.yml
@@ -23,6 +23,26 @@ models:
 
     config:
       tags: ['core']
+
+    constraints:
+      - type: primary_key
+        columns: [k_student, k_school, k_calendar_date]
+      - type: foreign_key
+        name: fk_fct_student_daily_attendance_student
+        columns: [k_student]
+        to: ref('dim_student')
+        to_columns: [k_student]
+      - type: foreign_key
+        name: fk_fct_student_daily_attendance_school
+        columns: [k_school]
+        to: ref('dim_school')
+        to_columns: [k_school]
+      - type: foreign_key
+        name: fk_fct_student_daily_attendance_calendar_date
+        columns: [k_calendar_date]
+        to: ref('dim_school')
+        to_columns: [k_calendar_date]
+      
     tests:
       - dbt_utils.unique_combination_of_columns:
           arguments:

--- a/models/core_warehouse/fct_student_daily_attendance.yml
+++ b/models/core_warehouse/fct_student_daily_attendance.yml
@@ -28,17 +28,17 @@ models:
       - type: primary_key
         columns: [k_student, k_school, k_calendar_date]
       - type: foreign_key
-        name: fk_fct_student_daily_attendance_student
+        name: fk__fct_student_daily_attendance__k_student
         columns: [k_student]
         to: ref('dim_student')
         to_columns: [k_student]
       - type: foreign_key
-        name: fk_fct_student_daily_attendance_school
+        name: fk__fct_student_daily_attendance__k_school
         columns: [k_school]
         to: ref('dim_school')
         to_columns: [k_school]
       - type: foreign_key
-        name: fk_fct_student_daily_attendance_calendar_date
+        name: fk__fct_student_daily_attendance__k_calendar_date
         columns: [k_calendar_date]
         to: ref('dim_school')
         to_columns: [k_calendar_date]

--- a/models/core_warehouse/fct_student_daily_attendance.yml
+++ b/models/core_warehouse/fct_student_daily_attendance.yml
@@ -52,12 +52,22 @@ models:
               - calendar_date
     columns:
       - name: k_student
+        description: Unique identifier for a student.
       - name: k_school
+        description: Unique identifier for a school
       - name: k_calendar_date
+        description: Unique identifier for an individual day in a single calendar at a single school.
       - name: school_year
+        description: School year specified by Spring year, e.g. the 2021-2022 year would be 2022.
       - name: calendar_date
+        description: Date on school calendar.
+        config:
+            meta:
+                type: 'date'
       - name: k_session
+        description: Unique identifier for a session. A session is an instructional span of time such as a term or semester.
       - name: tenant_code
+        description: The tenant associated with the record.
       - name: attendance_event_category
         description: >
           The descriptor value from AttendanceEventDescriptor
@@ -66,19 +76,36 @@ models:
       - name: is_present
         description: Inverse of `is_absent`, for use in calculations. Can be fractional.
       - name: is_enrolled
+        description: Whether the student is enrolled as of this day.
       - name: total_days_enrolled
+        description: Total days enrolled, up to the date specified in the row.
+        config:
+            meta:
+                type: 'fact'
       - name: cumulative_days_absent
         description: >
           Cumulative count, up to the day specified in the row.
+        config:
+            meta:
+                type: 'fact'
       - name: cumulative_days_enrolled
         description: >
           Cumulative count, up to the day specified in the row.
+        config:
+            meta:
+                type: 'fact'
       - name: cumulative_days_attended
         description: >
           Cumulative count, up to the day specified in the row.
+        config:
+            meta:
+                type: 'fact'
       - name: cumulative_attendance_rate
         description: >
           Cumulative count, up to the day specified in the row.
+        config:
+            meta:
+                type: 'fact'
       - name: is_chronic_absentee
         description: >
           Whether the student was considered chronically absent as of this day.
@@ -99,3 +126,6 @@ models:
       - name: consecutive_days_by_excusal_status
         description: >
           A rolling number of a student's consecutive unexcused absences on school days. 
+        config:
+            meta:
+                type: 'fact'

--- a/models/core_warehouse/fct_student_diploma.yml
+++ b/models/core_warehouse/fct_student_diploma.yml
@@ -7,17 +7,20 @@ models:
        This fact table contains information about diploma/credentials that is awarded to a student. 
 
       ##### Primary Key:
-       `k_student, k_student_xyear, school_year, k_school, diploma_type, diploma_award_date` -- There is one record
+ `k_student, school_year, k_school, diploma_type, diploma_award_date` -- There is one record
        per student, school, year, diploma type and award date.
 
       {{ doc(var('edu:custom_docs:fct_student_diploma')) if var('edu:custom_docs:fct_student_diploma', '') }}
+
+    constraints:
+      - type: primary_key
+        columns: [k_student, school_year, k_school, diploma_type, diploma_award_date]
 
     tests:
       - dbt_utils.unique_combination_of_columns:
           arguments:
             combination_of_columns:
               - k_student
-              - k_student_xyear
               - school_year
               - k_lea
               - k_school

--- a/models/core_warehouse/fct_student_discipline_actions.yml
+++ b/models/core_warehouse/fct_student_discipline_actions.yml
@@ -118,12 +118,26 @@ models:
     config:
       tags: ['discipline']
       enabled: "{{ var('src:domain:discipline:enabled', True) }}"
+
+    constraints:
+      - type: primary_key
+        columns: [k_student, k_discipline_actions_event, discipline_action]
+      - type: foreign_key
+        name: fk__fct_student_discipline_actions__k_student
+        columns: [k_student]
+        to: ref('dim_student')
+        to_columns: [k_student]
+      - type: foreign_key
+        name: fk__fct_student_discipline_actions__k_school
+        columns: [k_school]
+        to: ref('dim_school')
+        to_columns: [k_school]
+
     tests:
       - dbt_utils.unique_combination_of_columns:
           arguments:
             combination_of_columns:
               - k_student
-              - k_student_xyear
               - k_discipline_actions_event
               - discipline_action
     columns:

--- a/models/core_warehouse/fct_student_discipline_actions_summary.sql
+++ b/models/core_warehouse/fct_student_discipline_actions_summary.sql
@@ -2,9 +2,8 @@
   config(
     post_hook=[
         "alter table {{ this }} alter column k_student set not null",
-        "alter table {{ this }} alter column k_student_xyear set not null",
         "alter table {{ this }} alter column k_discipline_actions_event set not null",
-        "alter table {{ this }} add primary key (k_student, k_student_xyear, k_discipline_actions_event)",
+        "alter table {{ this }} add primary key (k_student, k_discipline_actions_event)",
         "alter table {{ this }} add constraint fk_{{ this.name }}_student foreign key (k_student) references {{ ref('dim_student') }}"]
   )
 }}

--- a/models/core_warehouse/fct_student_discipline_actions_summary.yml
+++ b/models/core_warehouse/fct_student_discipline_actions_summary.yml
@@ -15,14 +15,22 @@ models:
 
       Rows represent a student and discipline action event.
 
-      *Primary Key:* k_student, k_student_xyear, k_discipline_actions_event
+      *Primary Key:* k_student, k_discipline_actions_event
+
+    constraints:
+      - type: primary_key
+        columns: [k_student, k_discipline_actions_event]
+      - type: foreign_key
+        name: fk__fct_student_discipline_actions_summary__k_student
+        columns: [k_student]
+        to: ref('dim_student')
+        to_columns: [k_student]
 
     tests:
       - dbt_utils.unique_combination_of_columns:
           arguments:
             combination_of_columns:
               - k_student
-              - k_student_xyear
               - k_discipline_actions_event
     columns:
       - name: k_student

--- a/models/core_warehouse/fct_student_discipline_incident_behaviors.sql
+++ b/models/core_warehouse/fct_student_discipline_incident_behaviors.sql
@@ -2,10 +2,9 @@
   config(
     post_hook=[
         "alter table {{ this }} alter column k_student set not null",
-        "alter table {{ this }} alter column k_student_xyear set not null",
         "alter table {{ this }} alter column k_discipline_incident set not null",
         "alter table {{ this }} alter column behavior_type set not null",
-        "alter table {{ this }} add primary key (k_student, k_student_xyear, k_discipline_incident, behavior_type)",
+        "alter table {{ this }} add primary key (k_student, k_discipline_incident, behavior_type)",
         "alter table {{ this }} add constraint fk_{{ this.name }}_student foreign key (k_student) references {{ ref('dim_student') }}",
         "alter table {{ this }} add constraint fk_{{ this.name }}_school foreign key (k_school) references {{ ref('dim_school') }}",
         "alter table {{ this }} add constraint fk_{{ this.name }}_discipline_incident foreign key (k_discipline_incident) references {{ ref('dim_discipline_incident') }}"

--- a/models/core_warehouse/fct_student_discipline_incident_behaviors.yml
+++ b/models/core_warehouse/fct_student_discipline_incident_behaviors.yml
@@ -11,12 +11,30 @@ models:
       ##### Primary Key:
         `k_student, k_discipline_incident, behavior_type` -- There is one record per student, year, incident ID, school, and behavior.
 
+    constraints:
+      - type: primary_key
+        columns: [k_student, k_discipline_incident, behavior_type]
+      - type: foreign_key
+        name: fk__fct_student_discipline_incident_behaviors__k_student
+        columns: [k_student]
+        to: ref('dim_student')
+        to_columns: [k_student]
+      - type: foreign_key
+        name: fk__fct_student_discipline_incident_behaviors__k_school
+        columns: [k_school]
+        to: ref('dim_school')
+        to_columns: [k_school]
+      - type: foreign_key
+        name: fk__fct_student_discipline_incident_behaviors__k_discipline_incident
+        columns: [k_discipline_incident]
+        to: ref('dim_discipline_incident')
+        to_columns: [k_discipline_incident]
+
     tests:
       - dbt_utils.unique_combination_of_columns:
           arguments:
             combination_of_columns:
               - k_student
-              - k_student_xyear
               - k_discipline_incident
               - behavior_type
     columns:

--- a/models/core_warehouse/fct_student_discipline_incident_non_offenders.sql
+++ b/models/core_warehouse/fct_student_discipline_incident_non_offenders.sql
@@ -2,9 +2,8 @@
   config(
     post_hook=[
         "alter table {{ this }} alter column k_student set not null",
-        "alter table {{ this }} alter column k_student_xyear set not null",
         "alter table {{ this }} alter column k_discipline_incident set not null",
-        "alter table {{ this }} add primary key (k_student, k_student_xyear, k_discipline_incident)",
+        "alter table {{ this }} add primary key (k_student, k_discipline_incident)",
         "alter table {{ this }} add constraint fk_{{ this.name }}_student foreign key (k_student) references {{ ref('dim_student') }}",
         "alter table {{ this }} add constraint fk_{{ this.name }}_school foreign key (k_school) references {{ ref('dim_school') }}"
     ]

--- a/models/core_warehouse/fct_student_discipline_incident_non_offenders.yml
+++ b/models/core_warehouse/fct_student_discipline_incident_non_offenders.yml
@@ -11,12 +11,25 @@ models:
       ##### Primary Key:
         `k_student, k_discipline_incident` -- There is one record per student, year, incident ID, and school.
 
+    constraints:
+      - type: primary_key
+        columns: [k_student, k_discipline_incident]
+      - type: foreign_key
+        name: fk__fct_student_discipline_incident_non_offenders__k_student
+        columns: [k_student]
+        to: ref('dim_student')
+        to_columns: [k_student]
+      - type: foreign_key
+        name: fk__fct_student_discipline_incident_non_offenders__k_school
+        columns: [k_school]
+        to: ref('dim_school')
+        to_columns: [k_school]
+
     tests:
       - dbt_utils.unique_combination_of_columns:
           arguments:
             combination_of_columns:
               - k_student
-              - k_student_xyear
               - k_discipline_incident
     columns:
       - name: k_student

--- a/models/core_warehouse/fct_student_discipline_incident_summary.sql
+++ b/models/core_warehouse/fct_student_discipline_incident_summary.sql
@@ -2,9 +2,8 @@
   config(
     post_hook=[
         "alter table {{ this }} alter column k_student set not null",
-        "alter table {{ this }} alter column k_student_xyear set not null",
         "alter table {{ this }} alter column k_discipline_incident set not null",
-        "alter table {{ this }} add primary key (k_student, k_student_xyear, k_discipline_incident)",
+        "alter table {{ this }} add primary key (k_student, k_discipline_incident)",
         "alter table {{ this }} add constraint fk_{{ this.name }}_student foreign key (k_student) references {{ ref('dim_student') }}",
         "alter table {{ this }} add constraint fk_{{ this.name }}_discipline_incidents foreign key (k_discipline_incident) references {{ ref('dim_discipline_incident') }}"
     ]

--- a/models/core_warehouse/fct_student_discipline_incident_summary.yml
+++ b/models/core_warehouse/fct_student_discipline_incident_summary.yml
@@ -15,14 +15,27 @@ models:
 
       Rows represent a student and discipline incident.
 
-      *Primary Key:* k_student, k_student_xyear, k_discipline_incident
+      *Primary Key:* k_student, k_discipline_incident
+
+    constraints:
+      - type: primary_key
+        columns: [k_student, k_discipline_incident]
+      - type: foreign_key
+        name: fk__fct_student_discipline_incident_summary__k_student
+        columns: [k_student]
+        to: ref('dim_student')
+        to_columns: [k_student]
+      - type: foreign_key
+        name: fk__fct_student_discipline_incident_summary__k_discipline_incident
+        columns: [k_discipline_incident]
+        to: ref('dim_discipline_incident')
+        to_columns: [k_discipline_incident]
 
     tests:
       - dbt_utils.unique_combination_of_columns:
           arguments:
             combination_of_columns:
               - k_student
-              - k_student_xyear
               - k_discipline_incident
     columns:
       - name: k_student

--- a/models/core_warehouse/fct_student_gpa.yml
+++ b/models/core_warehouse/fct_student_gpa.yml
@@ -31,6 +31,21 @@ models:
 
     config:
       tags: ['core']
+
+    constraints:
+      - type: primary_key
+        columns: [k_student_academic_record, gpa_type]
+      - type: foreign_key
+        name: fk__fct_student_gpa__k_student_academic_record
+        columns: [k_student_academic_record]
+        to: ref('fct_student_academic_record')
+        to_columns: [k_student_academic_record]
+      - type: foreign_key
+        name: fk__fct_student_gpa__k_student
+        columns: [k_student]
+        to: ref('dim_student')
+        to_columns: [k_student]
+
     columns:
       - name: k_student_academic_record
       - name: k_student_xyear

--- a/models/core_warehouse/fct_student_grades.yml
+++ b/models/core_warehouse/fct_student_grades.yml
@@ -22,6 +22,31 @@ models:
 
     config:
       tags: ['core', 'course']
+
+    constraints:
+      - type: primary_key
+        columns: [k_grading_period, k_student, k_school, k_course_section, grade_type]
+      - type: foreign_key
+        name: fk__fct_student_grades__k_grading_period
+        columns: [k_grading_period]
+        to: ref('dim_grading_period')
+        to_columns: [k_grading_period]
+      - type: foreign_key
+        name: fk__fct_student_grades__k_student
+        columns: [k_student]
+        to: ref('dim_student')
+        to_columns: [k_student]
+      - type: foreign_key
+        name: fk__fct_student_grades__k_school
+        columns: [k_school]
+        to: ref('dim_school')
+        to_columns: [k_school]
+      - type: foreign_key
+        name: fk__fct_student_grades__k_course_section
+        columns: [k_course_section]
+        to: ref('dim_course_section')
+        to_columns: [k_course_section]
+
     tests:
       - dbt_utils.unique_combination_of_columns:
           arguments:

--- a/models/core_warehouse/fct_student_homeless_program_association.sql
+++ b/models/core_warehouse/fct_student_homeless_program_association.sql
@@ -2,10 +2,9 @@
   config(
     post_hook=[
         "alter table {{ this }} alter column k_student set not null",
-        "alter table {{ this }} alter column k_student_xyear set not null",
         "alter table {{ this }} alter column k_program set not null",
         "alter table {{ this }} alter column program_enroll_begin_date set not null",
-        "alter table {{ this }} add primary key (k_student, k_student_xyear, k_program, program_enroll_begin_date)",
+        "alter table {{ this }} add primary key (k_student, k_program, program_enroll_begin_date)",
         "alter table {{ this }} add constraint fk_{{ this.name }}_student foreign key (k_student) references {{ ref('dim_student') }}",
         "alter table {{ this }} add constraint fk_{{ this.name }}_program foreign key (k_program) references {{ ref('dim_program') }}",
     ]

--- a/models/core_warehouse/fct_student_homeless_program_association.yml
+++ b/models/core_warehouse/fct_student_homeless_program_association.yml
@@ -7,12 +7,26 @@ models:
         This fact table contains student homeless program enrollment information.
 
       ##### Primary Key:
-        `k_student, k_student_xyear, k_program, program_enroll_begin_date` -- There is one 
+        `k_student, k_program, program_enroll_begin_date` -- There is one 
         record per student, year, program enrol begin date, and homeless program.
 
     config:
       tags: ['homeless']
       enabled: "{{ var('src:program:homeless:enabled', True) }}"
+
+    constraints:
+      - type: primary_key
+        columns: [k_student, k_program, program_enroll_begin_date]
+      - type: foreign_key
+        name: fk__fct_student_homeless_program_association__k_student
+        columns: [k_student]
+        to: ref('dim_student')
+        to_columns: [k_student]
+      - type: foreign_key
+        name: fk__fct_student_homeless_program_association__k_program
+        columns: [k_program]
+        to: ref('dim_program')
+        to_columns: [k_program]
 
     tests:
       - dbt_utils.unique_combination_of_columns:

--- a/models/core_warehouse/fct_student_language_instruction_program_association.sql
+++ b/models/core_warehouse/fct_student_language_instruction_program_association.sql
@@ -2,10 +2,9 @@
   config(
     post_hook=[
         "alter table {{ this }} alter column k_student set not null",
-        "alter table {{ this }} alter column k_student_xyear set not null",
         "alter table {{ this }} alter column k_program set not null",
         "alter table {{ this }} alter column program_enroll_begin_date set not null",
-        "alter table {{ this }} add primary key (k_student, k_student_xyear, k_program, program_enroll_begin_date)",
+        "alter table {{ this }} add primary key (k_student, k_program, program_enroll_begin_date)",
         "alter table {{ this }} add constraint fk_{{ this.name }}_student foreign key (k_student) references {{ ref('dim_student') }}",
         "alter table {{ this }} add constraint fk_{{ this.name }}_program foreign key (k_program) references {{ ref('dim_program') }}",
     ]

--- a/models/core_warehouse/fct_student_language_instruction_program_association.yml
+++ b/models/core_warehouse/fct_student_language_instruction_program_association.yml
@@ -7,12 +7,26 @@ models:
         This fact table contains student language instruction program enrollment information.
 
       ##### Primary Key:
-        `k_student, k_student_xyear, k_program, program_enroll_begin_date` -- There is one 
+        `k_student, k_program, program_enroll_begin_date` -- There is one 
         record per student, year, program enrol begin date, and language instruction program.
 
     config:
       tags: ['language_instruction']
       enabled: "{{ var('src:program:language_instruction:enabled', True) }}"
+
+    constraints:
+      - type: primary_key
+        columns: [k_student, k_program, program_enroll_begin_date]
+      - type: foreign_key
+        name: fk__fct_student_language_instruction_program_association__k_student
+        columns: [k_student]
+        to: ref('dim_student')
+        to_columns: [k_student]
+      - type: foreign_key
+        name: fk__fct_student_language_instruction_program_association__k_program
+        columns: [k_program]
+        to: ref('dim_program')
+        to_columns: [k_program]
 
     tests:
       - dbt_utils.unique_combination_of_columns:

--- a/models/core_warehouse/fct_student_learning_standard_grades.yml
+++ b/models/core_warehouse/fct_student_learning_standard_grades.yml
@@ -33,6 +33,36 @@ models:
 
     config:
       tags: ['core', 'course']
+
+    constraints:
+      - type: primary_key
+        columns: [k_grading_period, k_student, k_school, k_course_section, grade_type, k_learning_standard]
+      - type: foreign_key
+        name: fk__fct_student_learning_standard_grades__k_grading_period
+        columns: [k_grading_period]
+        to: ref('dim_grading_period')
+        to_columns: [k_grading_period]
+      - type: foreign_key
+        name: fk__fct_student_learning_standard_grades__k_student
+        columns: [k_student]
+        to: ref('dim_student')
+        to_columns: [k_student]
+      - type: foreign_key
+        name: fk__fct_student_learning_standard_grades__k_school
+        columns: [k_school]
+        to: ref('dim_school')
+        to_columns: [k_school]
+      - type: foreign_key
+        name: fk__fct_student_learning_standard_grades__k_course_section
+        columns: [k_course_section]
+        to: ref('dim_course_section')
+        to_columns: [k_course_section]
+      - type: foreign_key
+        name: fk__fct_student_learning_standard_grades__k_learning_standard
+        columns: [k_learning_standard]
+        to: ref('dim_learning_standard')
+        to_columns: [k_learning_standard]
+
     tests:
       - dbt_utils.unique_combination_of_columns:
           arguments:

--- a/models/core_warehouse/fct_student_migrant_education_program_associations.sql
+++ b/models/core_warehouse/fct_student_migrant_education_program_associations.sql
@@ -2,16 +2,14 @@
   config(
     post_hook=[
         "alter table {{ this }} alter column k_student set not null",
-        "alter table {{ this }} alter column k_student_xyear set not null",
         "alter table {{ this }} alter column k_program set not null",
         "alter table {{ this }} alter column program_enroll_begin_date set not null",
-        "alter table {{ this }} add primary key (k_student, k_student_xyear, k_program, program_enroll_begin_date)",
+        "alter table {{ this }} add primary key (k_student, k_program, program_enroll_begin_date)",
         "alter table {{ this }} add constraint fk_{{ this.name }}_student foreign key (k_student) references {{ ref('dim_student') }}",
         "alter table {{ this }} add constraint fk_{{ this.name }}_program foreign key (k_program) references {{ ref('dim_program') }}",
     ]
   )
 }}
-
 
 with stage as (
     select * from {{ ref('stg_ef3__student_migrant_education_program_associations') }}

--- a/models/core_warehouse/fct_student_migrant_education_program_associations.yml
+++ b/models/core_warehouse/fct_student_migrant_education_program_associations.yml
@@ -7,12 +7,26 @@ models:
         This fact table contains student migrant education program enrollment information.
 
       ##### Primary Key:
-        `k_student, k_student_xyear, k_program, program_enroll_begin_date` -- There is one 
+        `k_student, k_program, program_enroll_begin_date` -- There is one 
         record per student, year, program enrol begin date, and migrant education program.
 
     config:
       tags: ['migrant_education']
       enabled: "{{ var('src:program:migrant_education:enabled', True) }}"
+
+    constraints:
+      - type: primary_key
+        columns: [k_student, k_program, program_enroll_begin_date]
+      - type: foreign_key
+        name: fk__fct_student_migrant_education_program_associations__k_student
+        columns: [k_student]
+        to: ref('dim_student')
+        to_columns: [k_student]
+      - type: foreign_key
+        name: fk__fct_student_migrant_education_program_associations__k_program
+        columns: [k_program]
+        to: ref('dim_program')
+        to_columns: [k_program]
 
     tests:
       - dbt_utils.unique_combination_of_columns:

--- a/models/core_warehouse/fct_student_objective_assessment.yml
+++ b/models/core_warehouse/fct_student_objective_assessment.yml
@@ -27,6 +27,26 @@ models:
     config:
       tags: ['assessment']
       enabled: "{{ var('src:domain:assessment:enabled', True) }}"
+
+    constraints:
+      - type: primary_key
+        columns: [k_student_objective_assessment]
+      - type: foreign_key
+        name: fk__fct_student_objective_assessment__k_objective_assessment
+        columns: [k_objective_assessment]
+        to: ref('dim_objective_assessment')
+        to_columns: [k_objective_assessment]
+      - type: foreign_key
+        name: fk__fct_student_objective_assessment__k_assessment
+        columns: [k_assessment]
+        to: ref('dim_assessment')
+        to_columns: [k_assessment]
+      - type: foreign_key
+        name: fk__fct_student_objective_assessment__k_student
+        columns: [k_student]
+        to: ref('dim_student')
+        to_columns: [k_student]
+
     columns:
       - name: k_student_objective_assessment
         description: >

--- a/models/core_warehouse/fct_student_parent_association.yml
+++ b/models/core_warehouse/fct_student_parent_association.yml
@@ -16,6 +16,21 @@ models:
       *Primary Key:* `k_student, k_parent`
     config:
       tags: ['core']
+
+    constraints:
+      - type: primary_key
+        columns: [k_student, k_parent]
+      - type: foreign_key
+        name: fk__fct_student_parent_association__k_student
+        columns: [k_student]
+        to: ref('dim_student')
+        to_columns: [k_student]
+      - type: foreign_key
+        name: fk__fct_student_parent_association__k_parent
+        columns: [k_parent]
+        to: ref('dim_parent')
+        to_columns: [k_parent]
+
     tests:
       - dbt_utils.unique_combination_of_columns:
           arguments:

--- a/models/core_warehouse/fct_student_program_association.sql
+++ b/models/core_warehouse/fct_student_program_association.sql
@@ -2,10 +2,9 @@
   config(
     post_hook=[
         "alter table {{ this }} alter column k_student set not null",
-        "alter table {{ this }} alter column k_student_xyear set not null",
         "alter table {{ this }} alter column k_program set not null",
         "alter table {{ this }} alter column program_enroll_begin_date set not null",
-        "alter table {{ this }} add primary key (k_student, k_student_xyear, k_program, program_enroll_begin_date)",
+        "alter table {{ this }} add primary key (k_student, k_program, program_enroll_begin_date)",
         "alter table {{ this }} add constraint fk_{{ this.name }}_student foreign key (k_student) references {{ ref('dim_student') }}",
         "alter table {{ this }} add constraint fk_{{ this.name }}_program foreign key (k_program) references {{ ref('dim_program') }}",
     ]

--- a/models/core_warehouse/fct_student_program_association.yml
+++ b/models/core_warehouse/fct_student_program_association.yml
@@ -9,6 +9,21 @@ models:
 
     config:
       tags: ['core']
+
+    constraints:
+      - type: primary_key
+        columns: [k_student, k_program, program_enroll_begin_date]
+      - type: foreign_key
+        name: fk__fct_student_program_association__k_student
+        columns: [k_student]
+        to: ref('dim_student')
+        to_columns: [k_student]
+      - type: foreign_key
+        name: fk__fct_student_program_association__k_program
+        columns: [k_program]
+        to: ref('dim_program')
+        to_columns: [k_program]
+
     tests:
       - dbt_utils.unique_combination_of_columns:
           arguments:

--- a/models/core_warehouse/fct_student_program_service.yml
+++ b/models/core_warehouse/fct_student_program_service.yml
@@ -76,7 +76,21 @@ models:
         {%- else -%}
            {{ True  | as_bool }}
         {%- endif -%}
-        
+
+
+    constraints:
+      - type: primary_key
+        columns: [k_student, k_program, program_enroll_begin_date, program_service]
+      - type: foreign_key
+        name: fk__fct_student_program_service__k_student
+        columns: [k_student]
+        to: ref('dim_student')
+        to_columns: [k_student]
+      - type: foreign_key
+        name: fk__fct_student_program_service__k_program
+        columns: [k_program]
+        to: ref('dim_program')
+        to_columns: [k_program]
 
     tests:
       - dbt_utils.unique_combination_of_columns:

--- a/models/core_warehouse/fct_student_school_association.yml
+++ b/models/core_warehouse/fct_student_school_association.yml
@@ -58,12 +58,12 @@ models:
       - type: primary_key
         columns: [k_student, k_school, k_entry_date]
       - type: foreign_key
-        name: fk_fct_student_school_association_student
+        name: fk__fct_student_school_association__k_student
         columns: [k_student]
         to: ref('dim_student')
         to_columns: [k_student]
       - type: foreign_key
-        name: fk_fct_student_school_association_school
+        name: fk__fct_student_school_association__k_school
         columns: [k_school]
         to: ref('dim_school')
         to_columns: [k_school]

--- a/models/core_warehouse/fct_student_school_association.yml
+++ b/models/core_warehouse/fct_student_school_association.yml
@@ -53,6 +53,21 @@ models:
 
     config:
       tags: ['core']
+
+    constraints:
+      - type: primary_key
+        columns: [k_student, k_school, k_entry_date]
+      - type: foreign_key
+        name: fk_fct_student_school_association_student
+        columns: [k_student]
+        to: ref('dim_student')
+        to_columns: [k_student]
+      - type: foreign_key
+        name: fk_fct_student_school_association_school
+        columns: [k_school]
+        to: ref('dim_school')
+        to_columns: [k_school]
+      
     tests:
       - dbt_utils.unique_combination_of_columns:
           arguments:

--- a/models/core_warehouse/fct_student_school_association.yml
+++ b/models/core_warehouse/fct_student_school_association.yml
@@ -96,13 +96,21 @@ models:
           The school calendar used by the student. This is important for 
           calculating attendance.
       - name: tenant_code
+        description: The tenant associated with the record.
       - name: school_year
+        description: School year specified by Spring year, e.g. the 2021-2022 year would be 2022.
       - name: entry_date
         description: > 
           The month, day, and year on which an individual enters and begins to 
           receive instructional services in a school.
+        config:
+            meta:
+                type: 'date'
       - name: exit_withdraw_date
         description: The recorded exit or withdraw date for the student.	
+        config:
+            meta:
+                type: 'date'
       - name: is_primary_school
         description: > 
           Indicates if a given enrollment record should be considered the primary

--- a/models/core_warehouse/fct_student_school_attendance_event.yml
+++ b/models/core_warehouse/fct_student_school_attendance_event.yml
@@ -16,6 +16,21 @@ models:
 
     config:
       tags: ['core']
+
+    constraints:
+      - type: primary_key
+        columns: [k_student, k_school, k_session, attendance_event_category, k_calendar_date]
+      - type: foreign_key
+        name: fk__fct_student_school_attendance_event__k_student
+        columns: [k_student]
+        to: ref('dim_student')
+        to_columns: [k_student]
+      - type: foreign_key
+        name: fk__fct_student_school_attendance_event__k_school
+        columns: [k_school]
+        to: ref('dim_school')
+        to_columns: [k_school]
+
     tests:
       - dbt_utils.unique_combination_of_columns:
           arguments:

--- a/models/core_warehouse/fct_student_school_food_service_program_associations.sql
+++ b/models/core_warehouse/fct_student_school_food_service_program_associations.sql
@@ -2,16 +2,14 @@
   config(
     post_hook=[
         "alter table {{ this }} alter column k_student set not null",
-        "alter table {{ this }} alter column k_student_xyear set not null",
         "alter table {{ this }} alter column k_program set not null",
         "alter table {{ this }} alter column program_enroll_begin_date set not null",
-        "alter table {{ this }} add primary key (k_student, k_student_xyear, k_program, program_enroll_begin_date)",
+        "alter table {{ this }} add primary key (k_student, k_program, program_enroll_begin_date)",
         "alter table {{ this }} add constraint fk_{{ this.name }}_student foreign key (k_student) references {{ ref('dim_student') }}",
         "alter table {{ this }} add constraint fk_{{ this.name }}_program foreign key (k_program) references {{ ref('dim_program') }}",
     ]
   )
 }}
-
 
 with stage as (
     select * from {{ ref('stg_ef3__student_school_food_service_program_association') }}

--- a/models/core_warehouse/fct_student_school_food_service_program_associations.yml
+++ b/models/core_warehouse/fct_student_school_food_service_program_associations.yml
@@ -7,12 +7,26 @@ models:
         This fact table contains student food service program enrollment information.
 
       ##### Primary Key:
-        `k_student, k_student_xyear, k_program, program_enroll_begin_date` -- There 
+        `k_student, k_program, program_enroll_begin_date` -- There 
         is one record per student, year, program enrol begin date, and food service program.
 
     config:
       tags: ['food_service']
       enabled: "{{ var('src:program:food_service:enabled', True) }}"
+
+    constraints:
+      - type: primary_key
+        columns: [k_student, k_program, program_enroll_begin_date]
+      - type: foreign_key
+        name: fk__fct_student_school_food_service_program_associations__k_student
+        columns: [k_student]
+        to: ref('dim_student')
+        to_columns: [k_student]
+      - type: foreign_key
+        name: fk__fct_student_school_food_service_program_associations__k_program
+        columns: [k_program]
+        to: ref('dim_program')
+        to_columns: [k_program]
 
     tests:
       - dbt_utils.unique_combination_of_columns:

--- a/models/core_warehouse/fct_student_section_association.yml
+++ b/models/core_warehouse/fct_student_section_association.yml
@@ -14,6 +14,21 @@ models:
 
     config:
       tags: ['core']
+
+    constraints:
+      - type: primary_key
+        columns: [k_student, k_course_section, begin_date]
+      - type: foreign_key
+        name: fk__fct_student_section_association__k_student
+        columns: [k_student]
+        to: ref('dim_student')
+        to_columns: [k_student]
+      - type: foreign_key
+        name: fk__fct_student_section_association__k_course_section
+        columns: [k_course_section]
+        to: ref('dim_course_section')
+        to_columns: [k_course_section]
+
     tests:
       - dbt_utils.unique_combination_of_columns:
           arguments:

--- a/models/core_warehouse/fct_student_section_attendance_event.yml
+++ b/models/core_warehouse/fct_student_section_attendance_event.yml
@@ -15,6 +15,21 @@ models:
 
     config:
       tags: ['core']
+
+    constraints:
+      - type: primary_key
+        columns: [k_student, k_course_section, attendance_event_category, attendance_event_date]
+      - type: foreign_key
+        name: fk__fct_student_section_attendance_event__k_student
+        columns: [k_student]
+        to: ref('dim_student')
+        to_columns: [k_student]
+      - type: foreign_key
+        name: fk__fct_student_section_attendance_event__k_course_section
+        columns: [k_course_section]
+        to: ref('dim_course_section')
+        to_columns: [k_course_section]
+
     tests:
       - dbt_utils.unique_combination_of_columns:
           arguments:

--- a/models/core_warehouse/fct_student_special_education_program_association.sql
+++ b/models/core_warehouse/fct_student_special_education_program_association.sql
@@ -2,16 +2,14 @@
   config(
     post_hook=[
         "alter table {{ this }} alter column k_student set not null",
-        "alter table {{ this }} alter column k_student_xyear set not null",
         "alter table {{ this }} alter column k_program set not null",
         "alter table {{ this }} alter column program_enroll_begin_date set not null",
-        "alter table {{ this }} add primary key (k_student, k_student_xyear, k_program, program_enroll_begin_date)",
+        "alter table {{ this }} add primary key (k_student, k_program, program_enroll_begin_date)",
         "alter table {{ this }} add constraint fk_{{ this.name }}_student foreign key (k_student) references {{ ref('dim_student') }}",
         "alter table {{ this }} add constraint fk_{{ this.name }}_program foreign key (k_program) references {{ ref('dim_program') }}",
     ]
   )
 }}
-
 
 with stage as (
     select * from {{ ref('stg_ef3__student_special_education_program_associations') }}

--- a/models/core_warehouse/fct_student_special_education_program_association.yml
+++ b/models/core_warehouse/fct_student_special_education_program_association.yml
@@ -7,12 +7,27 @@ models:
         This fact table contains student special education program enrollment information.
 
       ##### Primary Key:
-        `k_student, k_student_xyear, k_program, program_enroll_begin_date` -- There is one 
+        `k_student, k_program, program_enroll_begin_date` -- There is one 
         record per student, year, program enrol begin date, and special education program
 
     config:
       tags: ['special_ed']
-      enabled: "{{ var('src:program:special_ed:enabled', True) }}" 
+      enabled: "{{ var('src:program:special_ed:enabled', True) }}"
+
+    constraints:
+      - type: primary_key
+        columns: [k_student, k_program, program_enroll_begin_date]
+      - type: foreign_key
+        name: fk__fct_student_special_education_program_association__k_student
+        columns: [k_student]
+        to: ref('dim_student')
+        to_columns: [k_student]
+      - type: foreign_key
+        name: fk__fct_student_special_education_program_association__k_program
+        columns: [k_program]
+        to: ref('dim_program')
+        to_columns: [k_program]
+
     tests:
       - dbt_utils.unique_combination_of_columns:
           arguments:

--- a/models/core_warehouse/fct_student_subgroup.yml
+++ b/models/core_warehouse/fct_student_subgroup.yml
@@ -78,6 +78,16 @@ models:
 
     config:
       tags: ['core']
+
+    constraints:
+      - type: primary_key
+        columns: [k_student, k_subgroup]
+      - type: foreign_key
+        name: fk__fct_student_subgroup__k_student
+        columns: [k_student]
+        to: ref('dim_student')
+        to_columns: [k_student]
+
     tests:
       - dbt_utils.unique_combination_of_columns:
           arguments:

--- a/models/core_warehouse/fct_student_title_i_part_a_program_association.sql
+++ b/models/core_warehouse/fct_student_title_i_part_a_program_association.sql
@@ -2,10 +2,9 @@
   config(
     post_hook=[
         "alter table {{ this }} alter column k_student set not null",
-        "alter table {{ this }} alter column k_student_xyear set not null",
         "alter table {{ this }} alter column k_program set not null",
         "alter table {{ this }} alter column program_enroll_begin_date set not null",
-        "alter table {{ this }} add primary key (k_student, k_student_xyear, k_program, program_enroll_begin_date)",
+        "alter table {{ this }} add primary key (k_student, k_program, program_enroll_begin_date)",
         "alter table {{ this }} add constraint fk_{{ this.name }}_student foreign key (k_student) references {{ ref('dim_student') }}",
         "alter table {{ this }} add constraint fk_{{ this.name }}_program foreign key (k_program) references {{ ref('dim_program') }}",
     ]

--- a/models/core_warehouse/fct_student_title_i_part_a_program_association.yml
+++ b/models/core_warehouse/fct_student_title_i_part_a_program_association.yml
@@ -7,12 +7,26 @@ models:
         This fact table contains student Title I Part A program enrollment information.
 
       ##### Primary Key:
-        k_student, k_student_xyear, k_program, program_enroll_begin_date` -- There is one 
+        k_student, k_program, program_enroll_begin_date` -- There is one 
         record per student, year, program enrol begin date, and Title I Part A program.
 
     config:
       tags: ['title_i']
       enabled: "{{ var('src:program:title_i:enabled', True) }}"
+
+    constraints:
+      - type: primary_key
+        columns: [k_student, k_program, program_enroll_begin_date]
+      - type: foreign_key
+        name: fk__fct_student_title_i_part_a_program_association__k_student
+        columns: [k_student]
+        to: ref('dim_student')
+        to_columns: [k_student]
+      - type: foreign_key
+        name: fk__fct_student_title_i_part_a_program_association__k_program
+        columns: [k_program]
+        to: ref('dim_program')
+        to_columns: [k_program]
 
     tests:
       - dbt_utils.unique_combination_of_columns:

--- a/models/core_warehouse/msr_student_cumulative_attendance.yml
+++ b/models/core_warehouse/msr_student_cumulative_attendance.yml
@@ -9,12 +9,12 @@ models:
       - type: primary_key
         columns: [k_student, k_school, school_year]
       - type: foreign_key
-        name: fk_msr_student_cumulative_attendance_student
+        name: fk__msr_student_cumulative_attendance__k_student
         columns: [k_student]
         to: ref('dim_student')
         to_columns: [k_student]
       - type: foreign_key
-        name: fk_msr_student_cumulative_attendance_school
+        name: fk__msr_student_cumulative_attendance__k_school
         columns: [k_school]
         to: ref('dim_school')
         to_columns: [k_school]

--- a/models/core_warehouse/msr_student_cumulative_attendance.yml
+++ b/models/core_warehouse/msr_student_cumulative_attendance.yml
@@ -4,3 +4,17 @@ models:
   - name: msr_student_cumulative_attendance
     config:
       tags: ['core']
+    
+    constraints:
+      - type: primary_key
+        columns: [k_student, k_school, school_year]
+      - type: foreign_key
+        name: fk_msr_student_cumulative_attendance_student
+        columns: [k_student]
+        to: ref('dim_student')
+        to_columns: [k_student]
+      - type: foreign_key
+        name: fk_msr_student_cumulative_attendance_school
+        columns: [k_school]
+        to: ref('dim_school')
+        to_columns: [k_school]

--- a/models/core_warehouse/msr_student_cumulative_attendance.yml
+++ b/models/core_warehouse/msr_student_cumulative_attendance.yml
@@ -18,3 +18,43 @@ models:
         columns: [k_school]
         to: ref('dim_school')
         to_columns: [k_school]
+
+    columns:
+      - name: k_student
+        description: Unique identifier for a student in a particular year.
+      - name: k_student_xyear
+        description: Unique identifier for a student across all years the student is present in the data.
+      - name: k_school
+        description: Unique identifier for a school.
+      - name: school_year
+        description: School year specified by Spring year, e.g. the 2021-2022 year would be 2022.
+      - name: tenant_code
+        description: The tenant associated with the record.
+      - name: days_absent
+        description: Number of days a student has been absent from a school.
+        config:
+            meta:
+                type: 'fact'
+      - name: days_attended
+        description: Number of days a astudent has attended at a school.
+        config:
+            meta:
+                type: 'fact'
+      - name: days_enrolled
+        description: Number of days a student has been enrolled at a school.
+        config:
+            meta:
+                type: 'fact'
+      - name: attendance_rate
+        description: Percentage of enrolled days a student has attended. days_attended/days_enrolled.
+        config:
+            meta:
+                type: 'fact'
+      - name: meets_enrollment_threshold
+        description: Whether the student meets the minimum enrollment threshold.
+      - name: is_chronic_absentee
+        description: Whether the student is classified as chronically absent.
+      - name: absentee_category_rank
+        description: The category of absenteeism a student falls into.
+      - name: absentee_category_label
+        description: The label for the category of absenteeism the student is in.


### PR DESCRIPTION
## Description & motivation
This PR adds a `constraints` section to the `yml` files for WH models. This is useful because it exposes PK and FKs to dbt docs, which can then be more easily incorporated into our semantic layer. Previously, PKs and FKs were only captured in the post hooks in the model code.

Future additions to this PR may include expanded column descriptions and column-level implementation of the `meta` attribute.

## Breaking changes introduced by this PR:
None

## PR Merge Priority:
- [x ] Low
- [ ] Medium
- [ ] High


## Changes to existing files:
- `dim_calendar_date.yml`
- `dim_school.yml`
- `dim_session.yml`
- `dim_student.yml`
- `fct_student_daily_attendance.yml`
- `fct_student_school_association.yml`
- `msr_student_cumulative_attendance.yml`

All files have a `constraints` section added.

## New files created:
None

## Tests and QC done:

- Ran `dbt docs generate` to confirm changes were reflected in `manifest.json`

## edu_wh PR Review Checklist:
Make sure the following have been completed before approving this PR:
- [ ] Description of changes has been added to Unreleased section of [CHANGELOG.md](/CHANGELOG.md). Add under `## New Features` for features, etc.
- [ ] Code has been tested/checked for Databricks and Snowflake compatibility - EA engineers see Databricks checklist [here](https://edanalytics.slite.com/app/docs/LRjXFxVRAWA5ST) 
- [ ] Reviewer confirms the grain of all tables are unchanged, OR any changes are expected, communicated, and this PR is flagged as a breaking change (not for patch release)
- [ ] If a new configuration xwalk was added:
  - [ ] The code is written such that the xwalk is optional (preferred), and this behavior was tested, OR
  - [ ] The code is written such that the xwalk is required, and the required xwalk is added to edu_project_template, and this PR is flagged as breaking change (not for patch release)
  - [ ] A description for the new xwalk has been added to EDU documentation site [here](https://github.com/edanalytics/edu_docs/blob/main/docs/docs/manage_extend/reference/configure_dbt_xwalks.md) 
- [ ] If a new configuration variable was added:
  - [ ] The code is written such that the variable is optional (preferred), and this behavior was tested, OR
  - [ ] The code is written such that the variable is required, and a default value was added to edu_project_template, and this PR is flagged as breaking change (not for patch release)
  - [ ] A description for the new variable has been added to EDU documentation site [here](https://github.com/edanalytics/edu_docs/blob/main/docs/docs/manage_extend/reference/configure_dbt_vars.md) 

<!---## Future ToDos & Questions:-->
- Build out documentation for more models.
