### PR TITLE
fix/Fix whitepace in multiline string causing YAML parsing error

### DIFF
--- a/models/core_warehouse/fct_student_diploma.yml
+++ b/models/core_warehouse/fct_student_diploma.yml
@@ -7,8 +7,8 @@ models:
        This fact table contains information about diploma/credentials that is awarded to a student. 
 
       ##### Primary Key:
- `k_student, school_year, k_school, diploma_type, diploma_award_date` -- There is one record
-       per student, school, year, diploma type and award date.
+      `k_student, school_year, k_school, diploma_type, diploma_award_date` -- There is one record
+      per student, school, year, diploma type and award date.
 
       {{ doc(var('edu:custom_docs:fct_student_diploma')) if var('edu:custom_docs:fct_student_diploma', '') }}
 


### PR DESCRIPTION
Hit the following YAML parsing error on the updated docs running dbt 1.11 and 1.10--working after the fix, so assuming this doesn't affect any other docs. Not sure if this is dbt-core version-dependent. 

```
16:22:23  Running with dbt=1.11.8
16:22:23  Registered adapter: snowflake=1.11.4
16:22:24  Encountered an error:
Parsing Error
  Error reading edu_wh: core_warehouse/fct_student_diploma.yml - Runtime Error
    Syntax error near line 10
    ------------------------------
    7  |        This fact table contains information about diploma/credentials that is awarded to a student.
    8  |
    9  |       ##### Primary Key:
    10 |  `k_student, school_year, k_school, diploma_type, diploma_award_date` -- There is one record
    11 |        per student, school, year, diploma type and award date.
    12 |
    13 |       {{ doc(var('edu:custom_docs:fct_student_diploma')) if var('edu:custom_docs:fct_student_diploma', '') }}

    Raw Error:
    ------------------------------
    while scanning for the next token
    found character that cannot start any token
      in "<unicode string>", line 10, column 2
```