### PR TITLE
Feature/sedm clean

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Unreleased
 ## New features
-- Add fct models `fct_student_iep`, `fct_idea_event`, and `fct_student_iep_disability`
+- **Breaking Change**: Add fct models `fct_student_iep`, `fct_idea_event`, and `fct_student_iep_disability`.  These new models require adding the corresponding sources.
 ## Under the hood
 ## Fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Unreleased
 ## New features
+- Add fct models `fct_student_iep`, `fct_idea_event`, and `fct_student_iep_disability`
 ## Under the hood
 ## Fixes
 

--- a/dbt_project.yml
+++ b/dbt_project.yml
@@ -29,6 +29,9 @@ models:
         +enabled: "{{ var('edu:tpdm:enabled', False) }}"
     core_warehouse:
       +schema: wh
+    sedm_warehouse:
+      +schema: wh
+      +enabled: "{{ var('edu:sedm:enabled', False) }}"
     tpdm_warehouse:
       +schema: wh
       +enabled: "{{ var('edu:tpdm:enabled', False) }}"

--- a/models/sedm_warehouse/fct_idea_event.sql
+++ b/models/sedm_warehouse/fct_idea_event.sql
@@ -1,0 +1,43 @@
+{{
+  config(
+    post_hook=[
+        "alter table {{ this }} alter column k_idea_event set not null",
+        "alter table {{ this }} alter column k_student set not null",
+        "alter table {{ this }} alter column k_student_xyear set not null",
+        "alter table {{ this }} add primary key (k_idea_event)",
+        "alter table {{ this }} add constraint fk_{{ this.name }}_student foreign key (k_student) references {{ ref('dim_student') }}",
+    ]
+  )
+}}
+
+with stage as (
+    select * from {{ ref('stg_sedm__idea_events') }}
+),
+
+dim_student as (
+    select * from {{ ref('dim_student') }}
+),
+
+formatted as (
+    select
+        stage.k_idea_event,
+        dim_student.k_student,
+        dim_student.k_student_xyear,
+        stage.tenant_code,
+        stage.school_year,
+        stage.idea_event_id,
+        stage.ed_org_id,
+        stage.ed_org_type,
+        stage.idea_event,
+        stage.event_begin_date,
+        stage.event_end_date,
+        stage.event_narrative,
+        stage.event_reason,
+        stage.event_compliance
+        {{ edu_edfi_source.extract_extension(model_name='stg_sedm__idea_events', flatten=False) }}
+    from stage
+        inner join dim_student
+            on stage.k_student = dim_student.k_student
+)
+
+select * from formatted

--- a/models/sedm_warehouse/fct_idea_event.yml
+++ b/models/sedm_warehouse/fct_idea_event.yml
@@ -12,6 +12,7 @@ models:
 
     config:
       tags: ['sedm']
+      enabled: "{{ var('edu:sedm:enabled', False) }}"
 
     constraints:
       - type: primary_key

--- a/models/sedm_warehouse/fct_idea_event.yml
+++ b/models/sedm_warehouse/fct_idea_event.yml
@@ -35,11 +35,18 @@ models:
       - name: tenant_code
       - name: school_year
       - name: idea_event_id
+        description: A unique identifier for the event record as assigned by the provider of IEP services.
       - name: ed_org_id
       - name: ed_org_type
       - name: idea_event
+        description: The specific legal step, procedure, or standard event milestone captured as part of IDEA compliance requirements.
       - name: event_begin_date
+        description: The date when the IDEA related event started.
       - name: event_end_date
+        description: The date when the IDEA related event concluded.
       - name: event_narrative
+        description: Detailed and summary notes recorded during the event.
       - name: event_reason
+        description: The reason why the IDEA event occurred.
       - name: event_compliance
+        description: The type of compliance represented by this event.

--- a/models/sedm_warehouse/fct_idea_event.yml
+++ b/models/sedm_warehouse/fct_idea_event.yml
@@ -1,0 +1,44 @@
+version: 2
+
+models:
+  - name: fct_idea_event
+    description: >
+      ##### Overview:
+        This fact table contains IDEA-related events for students (for example, meetings,
+        evaluations, or other documented IDEA processes), keyed to the warehouse student.
+
+      ##### Primary Key:
+        `k_idea_event` -- There is one record per IDEA event association in the source data.
+
+    config:
+      tags: ['sedm']
+
+    constraints:
+      - type: primary_key
+        columns: [k_idea_event]
+      - type: foreign_key
+        name: fk__fct_idea_event__k_student
+        columns: [k_student]
+        to: ref('dim_student')
+        to_columns: [k_student]
+
+    columns:
+      - name: k_idea_event
+        tests:
+          - unique
+          - not_null
+      - name: k_student
+        description: Defining key for the student in this school year.
+      - name: k_student_xyear
+        description: Defining key for the student, which is consistent across years.
+      - name: tenant_code
+      - name: school_year
+      - name: idea_event_id
+      - name: ed_org_id
+      - name: ed_org_type
+      - name: idea_event
+      - name: event_begin_date
+      - name: event_end_date
+      - name: event_narrative
+      - name: event_reason
+      - name: event_compliance

--- a/models/sedm_warehouse/fct_idea_event.yml
+++ b/models/sedm_warehouse/fct_idea_event.yml
@@ -33,11 +33,19 @@ models:
       - name: k_student_xyear
         description: Defining key for the student, which is consistent across years.
       - name: tenant_code
+        description: The tenant associated with the record.
       - name: school_year
+        description: >
+          School year specified by Spring year.
+          e.g. the 2021-2022 year would be 2022.
       - name: idea_event_id
         description: A unique identifier for the event record as assigned by the provider of IEP services.
       - name: ed_org_id
+        description: The identifier for the educational organization associated with the IDEA event.
       - name: ed_org_type
+        description: >
+          The type of educational organization
+          e.g., School or LocalEducationAgency.
       - name: idea_event
         description: The specific legal step, procedure, or standard event milestone captured as part of IDEA compliance requirements.
       - name: event_begin_date

--- a/models/sedm_warehouse/fct_student_iep.sql
+++ b/models/sedm_warehouse/fct_student_iep.sql
@@ -1,0 +1,48 @@
+{{
+  config(
+    post_hook=[
+        "alter table {{ this }} alter column k_student_iep set not null",
+        "alter table {{ this }} alter column k_student set not null",
+        "alter table {{ this }} alter column k_student_xyear set not null",
+        "alter table {{ this }} add primary key (k_student_iep)",
+        "alter table {{ this }} add constraint fk_{{ this.name }}_student foreign key (k_student) references {{ ref('dim_student') }}",
+    ]
+  )
+}}
+
+with stage as (
+    select * from {{ ref('stg_sedm__student_ieps') }}
+),
+
+dim_student as (
+    select * from {{ ref('dim_student') }}
+),
+
+formatted as (
+    select
+        stage.k_student_iep,
+        dim_student.k_student,
+        dim_student.k_student_xyear,
+        stage.tenant_code,
+        stage.school_year,
+        stage.student_iep_association_id,
+        stage.ed_org_id,
+        stage.ed_org_type,
+        stage.iep_finalized_date,
+        stage.iep_begin_date,
+        stage.iep_end_date,
+        stage.iep_amended_date,
+        stage.iep_status,
+        stage.reason_exited,
+        stage.special_education_setting,
+        stage.is_medically_fragile,
+        stage.is_multiply_disabled,
+        stage.school_hours_per_week,
+        stage.special_education_hours_per_week
+        {{ edu_edfi_source.extract_extension(model_name='stg_sedm__student_ieps', flatten=False) }}
+    from stage
+        inner join dim_student
+            on stage.k_student = dim_student.k_student
+)
+
+select * from formatted

--- a/models/sedm_warehouse/fct_student_iep.yml
+++ b/models/sedm_warehouse/fct_student_iep.yml
@@ -12,6 +12,7 @@ models:
 
     config:
       tags: ['sedm']
+      enabled: "{{ var('edu:sedm:enabled', False) }}"
 
     constraints:
       - type: primary_key

--- a/models/sedm_warehouse/fct_student_iep.yml
+++ b/models/sedm_warehouse/fct_student_iep.yml
@@ -1,0 +1,49 @@
+version: 2
+
+models:
+  - name: fct_student_iep
+    description: >
+      ##### Overview:
+        This fact table contains student Individualized Education Program (IEP) records,
+        keyed to the warehouse student.
+
+      ##### Primary Key:
+        `k_student_iep` -- There is one record per student IEP association in the source data.
+
+    config:
+      tags: ['sedm']
+
+    constraints:
+      - type: primary_key
+        columns: [k_student_iep]
+      - type: foreign_key
+        name: fk__fct_student_iep__k_student
+        columns: [k_student]
+        to: ref('dim_student')
+        to_columns: [k_student]
+
+    columns:
+      - name: k_student_iep
+        tests:
+          - unique
+          - not_null
+      - name: k_student
+        description: Defining key for the student in this school year.
+      - name: k_student_xyear
+        description: Defining key for the student, which is consistent across years.
+      - name: tenant_code
+      - name: school_year
+      - name: student_iep_association_id
+      - name: ed_org_id
+      - name: ed_org_type
+      - name: iep_finalized_date
+      - name: iep_begin_date
+      - name: iep_end_date
+      - name: iep_amended_date
+      - name: iep_status
+      - name: reason_exited
+      - name: special_education_setting
+      - name: is_medically_fragile
+      - name: is_multiply_disabled
+      - name: school_hours_per_week
+      - name: special_education_hours_per_week

--- a/models/sedm_warehouse/fct_student_iep_disability.sql
+++ b/models/sedm_warehouse/fct_student_iep_disability.sql
@@ -1,0 +1,27 @@
+{{
+  config(
+    post_hook=[
+        "alter table {{ this }} add constraint fk_{{ this.name }}_student_iep foreign key (k_student_iep) references {{ ref('fct_student_iep') }}",
+    ]
+  )
+}}
+
+with disabilities as (
+    select * from {{ ref('stg_sedm__student_iep_disability_collections') }}
+),
+
+formatted as (
+    select
+        disabilities.k_student_iep,
+        disabilities.tenant_code,
+        disabilities.school_year,
+        disabilities.ed_org_id,
+        disabilities.disability_descriptor,
+        disabilities.disability_determination_source_type_descriptor,
+        disabilities.disability_diagnosis,
+        disabilities.order_of_disability
+        {{ edu_edfi_source.extract_extension(model_name='stg_sedm__student_iep_disability_collections', flatten=False) }}
+    from disabilities
+)
+
+select * from formatted

--- a/models/sedm_warehouse/fct_student_iep_disability.yml
+++ b/models/sedm_warehouse/fct_student_iep_disability.yml
@@ -1,0 +1,39 @@
+version: 2
+
+models:
+  - name: fct_student_iep_disability
+    description: >
+      ##### Overview:
+        This fact table lists disabilities associated with each student IEP, as recorded
+        in the source disability collection.
+
+      ##### Grain:
+        One row per IEP disability entry, typically unique by `k_student_iep` and
+        `order_of_disability`.
+
+    config:
+      tags: ['sedm']
+
+    constraints:
+      - type: foreign_key
+        name: fk__fct_student_iep_disability__k_student_iep
+        columns: [k_student_iep]
+        to: ref('fct_student_iep')
+        to_columns: [k_student_iep]
+
+    tests:
+      - dbt_utils.unique_combination_of_columns:
+          arguments:
+            combination_of_columns:
+              - k_student_iep
+              - order_of_disability
+
+    columns:
+      - name: k_student_iep
+      - name: tenant_code
+      - name: school_year
+      - name: ed_org_id
+      - name: disability_descriptor
+      - name: disability_determination_source_type_descriptor
+      - name: disability_diagnosis
+      - name: order_of_disability

--- a/models/sedm_warehouse/fct_student_iep_disability.yml
+++ b/models/sedm_warehouse/fct_student_iep_disability.yml
@@ -13,6 +13,7 @@ models:
 
     config:
       tags: ['sedm']
+      enabled: "{{ var('edu:sedm:enabled', False) }}"
 
     constraints:
       - type: foreign_key


### PR DESCRIPTION
# feature/sedm: Add SEDM warehouse facts for student IEPs, IDEA events, and IEP disability lines
## Description & motivation
This PR adds warehouse dbt models for the **SEDM (Special Education Data Model)** extension so analysts can use SEDM IEP and IDEA event data alongside existing core special-ed facts. Staging for these resources lives in `edu_edfi_source` (`stg_sedm__student_ieps`, `stg_sedm__idea_events`, `stg_sedm__student_iep_disability_collections`); this work materializes the corresponding **facts** in `edu_wh` under `models/sedm_warehouse/`, with **inner joins to `dim_student`** so `k_student` and `k_student_xyear` match the warehouse student dimension (same pattern as other student-centric facts).
Motivation: to support local education agencies' ability to support students with IEPs and facilitate mandated reporting requirements.
## Breaking changes introduced by this PR:
- **This is a breaking change.**  The following sources and corresponding raw tables must be added:
```
  - name: idea_events
    description: >

    enabled: true
    columns: *column_defaults
  - name: student_ieps
    description: >

    enabled: true
    columns: *column_defaults
  - name: student_iep_disability_collections
    description: >

    enabled: true
    columns: *column_defaults
```
- Models are intended to be gated by `edu:sedm:enabled` (default `False`) via `dbt_project.yml` once those configs are committed.
## PR Merge Priority:
- [ ] Low
- [x] Medium
- [ ] High
## Changes to existing files:
**CHANGELOG** entry under `## New Features`.
## New files created:
- **`models/sedm_warehouse/fct_student_iep.sql`:** One row per **student IEP** from `stg_sedm__student_ieps`, keyed by `k_student_iep`. Resolves `k_student` / `k_student_xyear` from `dim_student` for referential integrity. Surrogate extension columns come from `edu_edfi_source.extract_extension` for `stg_sedm__student_ieps`. Post-hooks enforce **PK** on `k_student_iep` and **NOT NULL** on `k_student_iep`, `k_student`, `k_student_xyear`, plus an **FK** from `k_student` to `dim_student`.
- **`models/sedm_warehouse/fct_idea_event.sql`:** One row per **IDEA event** from `stg_sedm__idea_events`, keyed by `k_idea_event`, with the same `dim_student` join and extension extraction pattern. Post-hooks: PK on `k_idea_event`, NOT NULL on key columns, FK to `dim_student`.
- **`models/sedm_warehouse/fct_student_iep_disability.sql`:** Long-format rows for **disabilities on an IEP** from `stg_sedm__student_iep_disability_collections`, keyed by staging’s `k_student_iep` (and related descriptors / order). Post-hook adds an **FK** from `k_student_iep` to **`fct_student_iep`**.
**Follow-ups (recommended before or right after merge, if not already on the branch):**
- Add **`sedm_warehouse`** folder config in `dbt_project.yml` (schema `wh`, enable via `edu:sedm:enabled`).
## Tests and QC done:
- dbt run --target data_dev successful in stadium_boston dev and stadium_south_carolina dev for all 3 new models

### Submitter checklist
Make sure the following have been completed before approving this PR:
- [x] Description of changes has been added to Unreleased section of [CHANGELOG.md](/CHANGELOG.md). Add under `## New Features` for features, etc.
- [x] Code has been tested/checked for Databricks and Snowflake compatibility - EA engineers see Databricks checklist [here](https://edanalytics.slite.com/app/docs/LRjXFxVRAWA5ST)
- [x] Reviewer confirms the grain of all tables are unchanged, OR any changes are expected, communicated, and this PR is flagged as a breaking change (not for patch release) *No changes to existing models*
- [x] If a new configuration xwalk was added: *n/a*
 - [x] The code is written such that the xwalk is optional (preferred), and this behavior was tested, OR *n/a*
 - [x] The code is written such that the xwalk is required, and the required xwalk is added to edu_project_template, and this PR is flagged as breaking change (not for patch release) *n/a*
 - [x] A description for the new xwalk has been added to EDU documentation site [here](https://github.com/edanalytics/edu_docs/blob/main/docs/docs/manage_extend/reference/configure_dbt_xwalks.md)
- [x] If a new configuration variable was added:
 - [x] The code is written such that the variable is optional (preferred), and this behavior was tested, OR
 - [x] The code is written such that the variable is required, and a default value was added to edu_project_template, and this PR is flagged as breaking change (not for patch release) *Variable to enable was added to dbt_project.yml with default set to False. No other configuration variables required.*

## edu_wh PR Review Checklist:
Make sure the following have been completed before approving this PR:
- [ ] Description of changes has been added to Unreleased section of [CHANGELOG.md](/CHANGELOG.md). Add under `## New Features` for features, etc.
- [ ] Code has been tested/checked for Databricks and Snowflake compatibility - EA engineers see Databricks checklist [here](https://edanalytics.slite.com/app/docs/LRjXFxVRAWA5ST)
- [ ] Reviewer confirms the grain of all tables are unchanged, OR any changes are expected, communicated, and this PR is flagged as a breaking change (not for patch release)
- [ ] If a new configuration xwalk was added:
 - [ ] The code is written such that the xwalk is optional (preferred), and this behavior was tested, OR
 - [ ] The code is written such that the xwalk is required, and the required xwalk is added to edu_project_template, and this PR is flagged as breaking change (not for patch release)
 - [ ] A description for the new xwalk has been added to EDU documentation site [here](https://github.com/edanalytics/edu_docs/blob/main/docs/docs/manage_extend/reference/configure_dbt_xwalks.md)
- [ ] If a new configuration variable was added:
 - [ ] The code is written such that the variable is optional (preferred), and this behavior was tested, OR
 - [ ] The code is written such that the variable is required, and a default value was added to edu_project_template, and this PR is flagged as breaking change (not for patch release)
