### PR TITLE
add logic to allow separate var including students who exit on frist day

### DIFF
--- a/models/core_warehouse/fct_student_school_association.sql
+++ b/models/core_warehouse/fct_student_school_association.sql
@@ -138,8 +138,10 @@ formatted as (
         on stg_stu_school.entry_grade_level = xwalk_grade_levels.grade_level
     where true
    {% if var('edu:enroll:exclude_exit_before_first_day', True) -%}
+      {#- allow implementations with exclusive exit dates to still keep first-day exits -#}
+      {%- set first_day_inclusive = var('edu:enroll:first_day_exit_date_inclusive', var('edu:enroll:exit_withdraw_date_inclusive', True)) -%}
       -- exclude students who exited before the first school day
-      and ({{ date_within_end_date('bld_school_calendar_windows.first_school_day', 'exit_withdraw_date', var('edu:enroll:exit_withdraw_date_inclusive', True)) }}
+      and ({{ date_within_end_date('bld_school_calendar_windows.first_school_day', 'exit_withdraw_date', first_day_inclusive) }}
           or bld_school_calendar_windows.first_school_day is null
           )
     {% endif %}


### PR DESCRIPTION
<!---
Provide Title above, ensure it summarizes the work in the PR. Example PR titles templates:
* "feature/ (or build/): describe new functionality"
* "hotfix/: describe issue fix for immediate release"
* "bugfix/ (or fix/): describe issue fix, not necessary for immediate release"
* "docs/: adding or updating documentation"
-->

## Description & motivation
<!---
High level description your PR, and why you're making it. Is this linked to slack thread, Monday board, open
issue, a continuation to a previous PR? Link it here if relevant (use the "#" symbol for issues/PRs).
-->

## New config: `edu:enroll:first_day_exit_date_inclusive`

### Background

Two existing vars interact when filtering out students who never really attended:

- `edu:enroll:exclude_exit_before_first_day` (default: `True`) — drops enrollments where the student exited before the first school day
- `edu:enroll:exit_withdraw_date_inclusive` (default: `True`) — controls whether exit dates are treated as inclusive (`<=`) or exclusive (`<`) throughout enrollment logic

When an implementation sets `exit_withdraw_date_inclusive: False`, the first-day exit check inherits that exclusivity — meaning a student who exited **on** the first day of school is treated the same as one who exited the day before and gets dropped.

### The problem

| exit_withdraw_date | first_school_day | exit_withdraw_date_inclusive | included? |
|--------------------|-----------------|------------------------------|-----------|
| Aug 25 (first day) | Aug 25          | `True`                       | ✅ kept   |
| Aug 25 (first day) | Aug 25          | `False`                      | ❌ dropped |
| Aug 24 (day before)| Aug 25          | `True`                       | ❌ dropped |
| Aug 24 (day before)| Aug 25          | `False`                      | ❌ dropped |
| Aug 26 (day after) | Aug 25          | `True`                       | ✅ kept   |
| Aug 26 (day after) | Aug 25          | `False`                      | ✅ kept   |

Implementations using exclusive exit dates lose first-day attendees even though that's not the intent of the filter.

### The fix

A new var `edu:enroll:first_day_exit_date_inclusive` controls inclusivity for **only** the first-day exit check. It defaults to whatever `exit_withdraw_date_inclusive` is set to (preserving existing behavior), but can be set independently.

| exit_withdraw_date_inclusive | first_day_exit_date_inclusive | first-day exit result |
|------------------------------|-------------------------------|-----------------------|
| `True` (default)             | not set (inherits `True`)     | ✅ kept               |
| `False`                      | not set (inherits `False`)    | ❌ dropped            |
| `False`                      | `True`                        | ✅ kept               |

### Usage

Implementations that use exclusive exit dates but want to retain students who exited on the first day can add to `dbt_project.yml`:

```yaml
vars:
  'edu:enroll:exit_withdraw_date_inclusive': False
  'edu:enroll:first_day_exit_date_inclusive': True
```


## Breaking changes introduced by this PR:
<!---
Describe any breaking changes that are introduced. Take a wide approach to what might be 'breaking'. One example of a 'hidden' breaking change could be adding a new column. For most applications, this will not cause error, but if someone has configured a downstream query that references this column name from elsewhere, their query could break.

Make sure to include these breaking changes in the CHANGELOG.md
-->

None

## PR Merge Priority:
<!---
This checklist helps the reviewers understand the level of priority for merging this PR.
A loose description of merging priority levels is:
Low: A week or more.
Medium: Within 3 days or less.
High: As soon as possible.
-->
- [ ] Low
- [ ] Medium
- [x] High

<!---
If High Priority, explain why as a comment below.
-->

## Changes to existing files:
<!---
Include this section if you are changing any existing files or creating breaking changes to existing files. Label the model name and describe the logic behind the changes made, try to be very descriptive here. For example:
- `stg_model` : Describe any changes made to `stg_model` and why the changes where made.
- `src_staging` : Describe any changes made to `src_staging` and why the changes where made.
-->

## New files created:
<!---
Include this section if you are creating any new files. Label the model name and describe the logic behind the changes made, try to be very descriptive here. For example:
- `stg_new_model` : Describe the purpose of `stg_new_model` and the logic behind creating the model.
- `src_new_staging` : Describe the purpose of `src_new_staging`.
-->

## Tests and QC done:
<!---
Describe any process that confirms that the files do what is expected, include screenshots if relevant. For example:
- Analyst replication confirmed that updates to `stg_model` new counts were correct.
- Executed a dbt project run and ensured it was successful.
-->

Ran in SC, did quick check -- 

```
select * from dev_analytics.dev_rl_wh.fct_student_school_association
where k_student not in (select k_student from analytics.prod_wh.fct_student_school_association)
-- uncomment this to prove that all the student's we're adding exited on the first day of school
-- and k_student not in (select k_student from analytics.prod_stage.stg_ef3__student_school_associations
--                         join analytics.prod_build.bld_ef3__school_calendar_windows
--                           using(k_school_calendar)
--                         where exit_withdraw_date = first_school_day 
--                         )
;
```

Needs deeper QC on wider warehouse impacts

## edu_wh PR Review Checklist:
Make sure the following have been completed before approving this PR:
- [ ] Description of changes has been added to Unreleased section of [CHANGELOG.md](/CHANGELOG.md). Add under `## New Features` for features, etc.
- [ ] Code has been tested/checked for Databricks and Snowflake compatibility - EA engineers see Databricks checklist [here](https://edanalytics.slite.com/app/docs/LRjXFxVRAWA5ST) 
- [ ] Reviewer confirms the grain of all tables are unchanged, OR any changes are expected, communicated, and this PR is flagged as a breaking change (not for patch release)
- [ ] If a new configuration xwalk was added:
  - [ ] The code is written such that the xwalk is optional (preferred), and this behavior was tested, OR
  - [ ] The code is written such that the xwalk is required, and the required xwalk is added to edu_project_template, and this PR is flagged as breaking change (not for patch release)
  - [ ] A description for the new xwalk has been added to EDU documentation site [here](https://github.com/edanalytics/edu_docs/blob/main/docs/docs/manage_extend/reference/configure_dbt_xwalks.md) 
- [ ] If a new configuration variable was added:
  - [ ] The code is written such that the variable is optional (preferred), and this behavior was tested, OR
  - [ ] The code is written such that the variable is required, and a default value was added to edu_project_template, and this PR is flagged as breaking change (not for patch release)
  - [ ] A description for the new variable has been added to EDU documentation site [here](https://github.com/edanalytics/edu_docs/blob/main/docs/docs/manage_extend/reference/configure_dbt_vars.md) 

<!---## Future ToDos & Questions:-->
<!---
[Optional] Include any future steps and questions related to this PR.
-->
