### PR TITLE
Bugfix/Course Title source in fct_course_transcripts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 ## New features
 ## Under the hood
 ## Fixes
+- Fix null `course_title` values in `fct_course_transcripts` by sourcing the title from `dim_course`, where the field is required rather than optional.
 
 # edu_wh v0.6.3
 ## New features

--- a/models/core_warehouse/fct_course_transcripts.sql
+++ b/models/core_warehouse/fct_course_transcripts.sql
@@ -33,7 +33,7 @@ formatted as (
         fct_student_academic_record.school_year,
         fct_student_academic_record.academic_term,
         course_transcripts.course_attempt_result,
-        course_transcripts.course_title,
+        dim_course.course_title,
         course_transcripts.alternative_course_code,
         course_transcripts.alternative_course_title,
         course_transcripts.when_taken_grade_level,
@@ -63,5 +63,7 @@ formatted as (
     from course_transcripts
     join fct_student_academic_record
         on course_transcripts.k_student_academic_record = fct_student_academic_record.k_student_academic_record
+    join dim_course
+        on course_transcripts.k_course = dim_course.k_course
 )
 select * from formatted

--- a/models/core_warehouse/fct_course_transcripts.sql
+++ b/models/core_warehouse/fct_course_transcripts.sql
@@ -33,7 +33,7 @@ formatted as (
         fct_student_academic_record.school_year,
         fct_student_academic_record.academic_term,
         course_transcripts.course_attempt_result,
-        coalesce(course_transcripts.course_title, dim_course.course_title),
+        coalesce(course_transcripts.course_title, dim_course.course_title) as course_title,
         course_transcripts.alternative_course_code,
         course_transcripts.alternative_course_title,
         course_transcripts.when_taken_grade_level,

--- a/models/core_warehouse/fct_course_transcripts.sql
+++ b/models/core_warehouse/fct_course_transcripts.sql
@@ -33,7 +33,7 @@ formatted as (
         fct_student_academic_record.school_year,
         fct_student_academic_record.academic_term,
         course_transcripts.course_attempt_result,
-        dim_course.course_title,
+        coalesce(course_transcripts.course_title, dim_course.course_title),
         course_transcripts.alternative_course_code,
         course_transcripts.alternative_course_title,
         course_transcripts.when_taken_grade_level,


### PR DESCRIPTION
## Description & motivation

This PR changes the source of `course_title` in `fct_course_transcripts` so it comes from `dim_course` (the Ed-Fi `Course` endpoint) instead of `stg_ef3__course_transcripts` (the Ed-Fi `CourseTranscript` endpoint).

The reasoning is the difference between required and optional fields in each endpoint:

- On the `CourseTranscript` endpoint, `CourseTitle` is **optional**, so it could be null on transcript records.
- On the `Course` endpoint, `CourseTitle` is **required**, so this is the most reliable endpoint that sources this data.

`fct_course_transcripts` already references `dim_course` through the `k_course` foreign key, so sourcing the title from the course table is already a pretty easy change.

## PR Merge Priority:
- [x] Low
- [ ] Medium
- [ ] High

## Changes to existing files:
- `models/core_warehouse/fct_course_transcripts.sql`: 
  - Changed `course_title` to select from `dim_course` instead of `course_transcripts` (`course_transcripts.course_title` --> `dim_course.course_title`). 
  - Added a `join` to `dim_course` on `k_course` to make the column available. The join is keyed on `course_transcripts.k_course = dim_course.k_course`.

## Tests and QC done:
- [x] Ran a `dbt run -s fct_course_transcripts` and confirmed a successful build.
- [x] Confirmed `course_title` null counts dropped (or held steady) after switching to the `dim_course` source.
