### PR TITLE
Docs/: Update school year description in all prod_wh tables

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Unreleased
 ## New features
+* Update descriptions of `school_year` to increase comprehensiveness and add clarity on both format and sourcing mechanism.
 ## Under the hood
 ## Fixes
 

--- a/models/core_warehouse/dim_assessment.yml
+++ b/models/core_warehouse/dim_assessment.yml
@@ -24,6 +24,7 @@ models:
           - unique
       - name: tenant_code
       - name: school_year
+        description: School year specified by Spring year, e.g. the 2021-2022 year would be 2022. The school year is populated based on the year associated with the source ODS, which is assumed to contain data for only that school year (with rare exceptions for transcript/academic record data).
       - name: assessment_identifier
         description: A unique number or alphanumeric code assigned to an assessment.
       - name: namespace

--- a/models/core_warehouse/dim_assessment.yml
+++ b/models/core_warehouse/dim_assessment.yml
@@ -24,7 +24,7 @@ models:
           - unique
       - name: tenant_code
       - name: school_year
-        description: "School year specified by Spring year, e.g. the 2021-2022 year would be 2022. For assessment records, `school_year` is primarily populated based on the year associated with the source ODS, which is assumed to contain data for only that school year. If not available from the ODS, it is inferred from `administration_date` using a school-year cutoff date that can vary by implementation (e.g. defaulting to 8/1, meaning an assessment administered on or after 8/1/2021 and before 8/1/2022 is assigned school year 2022). Some implementations may also configure a school year crosswalk to override the ODS-sourced or inferred year for specific assessments or date ranges."
+        description: "{{ doc('school_year_assessment') }}"
       - name: assessment_identifier
         description: A unique number or alphanumeric code assigned to an assessment.
       - name: namespace

--- a/models/core_warehouse/dim_assessment.yml
+++ b/models/core_warehouse/dim_assessment.yml
@@ -24,7 +24,7 @@ models:
           - unique
       - name: tenant_code
       - name: school_year
-        description: School year specified by Spring year, e.g. the 2021-2022 year would be 2022. The school year is populated based on the year associated with the source ODS, which is assumed to contain data for only that school year (with rare exceptions for transcript/academic record data).
+        description: "School year specified by Spring year, e.g. the 2021-2022 year would be 2022. For assessment records, `school_year` is primarily populated based on the year associated with the source ODS, which is assumed to contain data for only that school year. If not available from the ODS, it is inferred from `administration_date` using a school-year cutoff date that can vary by implementation (e.g. defaulting to 8/1, meaning an assessment administered on or after 8/1/2021 and before 8/1/2022 is assigned school year 2022). Some implementations may also configure a school year crosswalk to override the ODS-sourced or inferred year for specific assessments or date ranges."
       - name: assessment_identifier
         description: A unique number or alphanumeric code assigned to an assessment.
       - name: namespace

--- a/models/core_warehouse/dim_calendar_date.yml
+++ b/models/core_warehouse/dim_calendar_date.yml
@@ -41,7 +41,7 @@ models:
       - name: calendar_code
         description: Descriptive label for a calendar.
       - name: school_year
-        description: School year specified by Spring year, e.g. the 2021-2022 year would be 2022. The school year is populated based on the year associated with the source ODS, which is assumed to contain data for only that school year (with rare exceptions for transcript/academic record data).
+        description: "School year specified by Spring year, e.g. the 2021-2022 year would be 2022. Unlike most other tables, `school_year` here reflects a school year reference embedded directly in the source Ed-Fi record, rather than the year of the source ODS pull — so it can differ from the pull year in edge cases (e.g. calendar or schedule data that spans a year boundary)."
       - name: calendar_date
         description: Date on school calendar.
         config:

--- a/models/core_warehouse/dim_calendar_date.yml
+++ b/models/core_warehouse/dim_calendar_date.yml
@@ -41,7 +41,7 @@ models:
       - name: calendar_code
         description: Descriptive label for a calendar.
       - name: school_year
-        description: "School year specified by Spring year, e.g. the 2021-2022 year would be 2022. Unlike most other tables, `school_year` here reflects a school year reference embedded directly in the source Ed-Fi record, rather than the year of the source ODS pull — so it can differ from the pull year in edge cases (e.g. calendar or schedule data that spans a year boundary)."
+        description: "{{ doc('school_year_source_reference') }}"
       - name: calendar_date
         description: Date on school calendar.
         config:

--- a/models/core_warehouse/dim_calendar_date.yml
+++ b/models/core_warehouse/dim_calendar_date.yml
@@ -41,7 +41,7 @@ models:
       - name: calendar_code
         description: Descriptive label for a calendar.
       - name: school_year
-        description: School year specified by Spring year, e.g. the 2021-2022 year would be 2022.
+        description: School year specified by Spring year, e.g. the 2021-2022 year would be 2022. The school year is populated based on the year associated with the source ODS, which is assumed to contain data for only that school year (with rare exceptions for transcript/academic record data).
       - name: calendar_date
         description: Date on school calendar.
         config:

--- a/models/core_warehouse/dim_class_period.yml
+++ b/models/core_warehouse/dim_class_period.yml
@@ -8,3 +8,7 @@ models:
     constraints:
       - type: primary_key
         columns: [k_class_period]
+
+    columns:
+      - name: school_year
+        description: School year specified by Spring year, e.g. the 2021-2022 year would be 2022. The school year is populated based on the year associated with the source ODS, which is assumed to contain data for only that school year.

--- a/models/core_warehouse/dim_class_period.yml
+++ b/models/core_warehouse/dim_class_period.yml
@@ -11,4 +11,4 @@ models:
 
     columns:
       - name: school_year
-        description: School year specified by Spring year, e.g. the 2021-2022 year would be 2022. The school year is populated based on the year associated with the source ODS, which is assumed to contain data for only that school year.
+        description: "{{ doc('school_year_ods_pull') }}"

--- a/models/core_warehouse/dim_cohort.yml
+++ b/models/core_warehouse/dim_cohort.yml
@@ -33,7 +33,7 @@ models:
         description: Association to the school with the cohort.
       - name: tenant_code
       - name: school_year
-        description: School year specified by Spring year, e.g. the 2021-2022 year would be 2022. The school year is populated based on the year associated with the source ODS, which is assumed to contain data for only that school year (with rare exceptions for transcript/academic record data).
+        description: School year specified by Spring year, e.g. the 2021-2022 year would be 2022. The school year is populated based on the year associated with the source ODS, which is assumed to contain data for only that school year.
       - name: ed_org_id
         description: The identifier for the educational organization with the cohort.
       - name: ed_org_type

--- a/models/core_warehouse/dim_cohort.yml
+++ b/models/core_warehouse/dim_cohort.yml
@@ -33,7 +33,7 @@ models:
         description: Association to the school with the cohort.
       - name: tenant_code
       - name: school_year
-        description: School year specified by Spring year, e.g. the 2021-2022 year would be 2022. The school year is populated based on the year associated with the source ODS, which is assumed to contain data for only that school year.
+        description: "{{ doc('school_year_ods_pull') }}"
       - name: ed_org_id
         description: The identifier for the educational organization with the cohort.
       - name: ed_org_type

--- a/models/core_warehouse/dim_cohort.yml
+++ b/models/core_warehouse/dim_cohort.yml
@@ -33,9 +33,7 @@ models:
         description: Association to the school with the cohort.
       - name: tenant_code
       - name: school_year
-        description: > 
-          School year specified by Spring year.
-          e.g., the 2021-2022 year would be 2022.
+        description: School year specified by Spring year, e.g. the 2021-2022 year would be 2022. The school year is populated based on the year associated with the source ODS, which is assumed to contain data for only that school year (with rare exceptions for transcript/academic record data).
       - name: ed_org_id
         description: The identifier for the educational organization with the cohort.
       - name: ed_org_type

--- a/models/core_warehouse/dim_course.yml
+++ b/models/core_warehouse/dim_course.yml
@@ -24,7 +24,7 @@ models:
       - name: tenant_code
         description: "Code defining the Tenant (may be an LEA, SEA, etc.) of the Ed-Fi ODS from which this record was pulled"
       - name: school_year
-        description: "The school year passed to the Ed-Fi API when pulling this record from Course"
+        description: School year specified by Spring year, e.g. the 2021-2022 year would be 2022. The school year is populated based on the year associated with the source ODS, which is assumed to contain data for only that school year (with rare exceptions for transcript/academic record data).
       - name: course_code
         description: "A unique alphanumeric code assigned to a course."
       - name: course_title

--- a/models/core_warehouse/dim_course.yml
+++ b/models/core_warehouse/dim_course.yml
@@ -24,7 +24,7 @@ models:
       - name: tenant_code
         description: "Code defining the Tenant (may be an LEA, SEA, etc.) of the Ed-Fi ODS from which this record was pulled"
       - name: school_year
-        description: School year specified by Spring year, e.g. the 2021-2022 year would be 2022. The school year is populated based on the year associated with the source ODS, which is assumed to contain data for only that school year.
+        description: "{{ doc('school_year_ods_pull') }}"
       - name: course_code
         description: "A unique alphanumeric code assigned to a course."
       - name: course_title

--- a/models/core_warehouse/dim_course.yml
+++ b/models/core_warehouse/dim_course.yml
@@ -24,7 +24,7 @@ models:
       - name: tenant_code
         description: "Code defining the Tenant (may be an LEA, SEA, etc.) of the Ed-Fi ODS from which this record was pulled"
       - name: school_year
-        description: School year specified by Spring year, e.g. the 2021-2022 year would be 2022. The school year is populated based on the year associated with the source ODS, which is assumed to contain data for only that school year (with rare exceptions for transcript/academic record data).
+        description: School year specified by Spring year, e.g. the 2021-2022 year would be 2022. The school year is populated based on the year associated with the source ODS, which is assumed to contain data for only that school year.
       - name: course_code
         description: "A unique alphanumeric code assigned to a course."
       - name: course_title

--- a/models/core_warehouse/dim_course_section.yml
+++ b/models/core_warehouse/dim_course_section.yml
@@ -92,7 +92,7 @@ models:
           portion of the instruction for which a grade or report is assigned (e.g., reading, 
           composition, spelling, and language arts).
       - name: school_year
-        description: School year specified by Spring year, e.g. the 2021-2022 year would be 2022. The school year is populated based on the year associated with the source ODS, which is assumed to contain data for only that school year (with rare exceptions for transcript/academic record data).
+        description: "School year specified by Spring year, e.g. the 2021-2022 year would be 2022. Unlike most other tables, `school_year` here reflects a school year reference embedded directly in the source Ed-Fi record, rather than the year of the source ODS pull — so it can differ from the pull year in edge cases (e.g. calendar or schedule data that spans a year boundary)."
       - name: session_name
         description: >
           (sourced from Course Offering) -- The session in which the course is offered at the school.

--- a/models/core_warehouse/dim_course_section.yml
+++ b/models/core_warehouse/dim_course_section.yml
@@ -92,7 +92,7 @@ models:
           portion of the instruction for which a grade or report is assigned (e.g., reading, 
           composition, spelling, and language arts).
       - name: school_year
-        description: "School year specified by Spring year, e.g. the 2021-2022 year would be 2022. Unlike most other tables, `school_year` here reflects a school year reference embedded directly in the source Ed-Fi record, rather than the year of the source ODS pull — so it can differ from the pull year in edge cases (e.g. calendar or schedule data that spans a year boundary)."
+        description: "{{ doc('school_year_source_reference') }}"
       - name: session_name
         description: >
           (sourced from Course Offering) -- The session in which the course is offered at the school.

--- a/models/core_warehouse/dim_course_section.yml
+++ b/models/core_warehouse/dim_course_section.yml
@@ -92,6 +92,7 @@ models:
           portion of the instruction for which a grade or report is assigned (e.g., reading, 
           composition, spelling, and language arts).
       - name: school_year
+        description: School year specified by Spring year, e.g. the 2021-2022 year would be 2022. The school year is populated based on the year associated with the source ODS, which is assumed to contain data for only that school year (with rare exceptions for transcript/academic record data).
       - name: session_name
         description: >
           (sourced from Course Offering) -- The session in which the course is offered at the school.

--- a/models/core_warehouse/dim_discipline_incident.yml
+++ b/models/core_warehouse/dim_discipline_incident.yml
@@ -29,7 +29,7 @@ models:
       - name: tenant_code
         description: "Code defining the Tenant (may be an LEA, SEA, etc.) of the Ed-Fi ODS from which this record was pulled"
       - name: school_year
-        description: School year specified by Spring year, e.g. the 2021-2022 year would be 2022. The school year is populated based on the year associated with the source ODS, which is assumed to contain data for only that school year.
+        description: "{{ doc('school_year_ods_pull') }}"
       - name: incident_id
         description: >
           A locally assigned unique identifier (within the school or school district) to identify each specific DisciplineIncident 

--- a/models/core_warehouse/dim_discipline_incident.yml
+++ b/models/core_warehouse/dim_discipline_incident.yml
@@ -29,7 +29,7 @@ models:
       - name: tenant_code
         description: "Code defining the Tenant (may be an LEA, SEA, etc.) of the Ed-Fi ODS from which this record was pulled"
       - name: school_year
-        description: School year specified by Spring year, e.g. the 2021-2022 year would be 2022. The school year is populated based on the year associated with the source ODS, which is assumed to contain data for only that school year (with rare exceptions for transcript/academic record data).
+        description: School year specified by Spring year, e.g. the 2021-2022 year would be 2022. The school year is populated based on the year associated with the source ODS, which is assumed to contain data for only that school year.
       - name: incident_id
         description: >
           A locally assigned unique identifier (within the school or school district) to identify each specific DisciplineIncident 

--- a/models/core_warehouse/dim_discipline_incident.yml
+++ b/models/core_warehouse/dim_discipline_incident.yml
@@ -29,7 +29,7 @@ models:
       - name: tenant_code
         description: "Code defining the Tenant (may be an LEA, SEA, etc.) of the Ed-Fi ODS from which this record was pulled"
       - name: school_year
-        description: "Sourced from the year of the ODS, since Ed-Fi does not include school year in the model for discipline incidents"
+        description: School year specified by Spring year, e.g. the 2021-2022 year would be 2022. The school year is populated based on the year associated with the source ODS, which is assumed to contain data for only that school year (with rare exceptions for transcript/academic record data).
       - name: incident_id
         description: >
           A locally assigned unique identifier (within the school or school district) to identify each specific DisciplineIncident 

--- a/models/core_warehouse/dim_grading_period.yml
+++ b/models/core_warehouse/dim_grading_period.yml
@@ -34,7 +34,7 @@ models:
       - name: period_sequence
         description: The sequential order of this period relative to other periods.
       - name: school_year
-        description: School year specified by Spring year, e.g. the 2021-2022 year would be 2022. The school year is populated based on the year associated with the source ODS, which is assumed to contain data for only that school year (with rare exceptions for transcript/academic record data).
+        description: "School year specified by Spring year, e.g. the 2021-2022 year would be 2022. Unlike most other tables, `school_year` here reflects a school year reference embedded directly in the source Ed-Fi record, rather than the year of the source ODS pull — so it can differ from the pull year in edge cases (e.g. calendar or schedule data that spans a year boundary)."
       - name: begin_date
         description: Month, day, and year of the first day of the grading period.
       - name: end_date

--- a/models/core_warehouse/dim_grading_period.yml
+++ b/models/core_warehouse/dim_grading_period.yml
@@ -34,7 +34,7 @@ models:
       - name: period_sequence
         description: The sequential order of this period relative to other periods.
       - name: school_year
-        description: The identifier for the grading period school year.
+        description: School year specified by Spring year, e.g. the 2021-2022 year would be 2022. The school year is populated based on the year associated with the source ODS, which is assumed to contain data for only that school year (with rare exceptions for transcript/academic record data).
       - name: begin_date
         description: Month, day, and year of the first day of the grading period.
       - name: end_date

--- a/models/core_warehouse/dim_grading_period.yml
+++ b/models/core_warehouse/dim_grading_period.yml
@@ -34,7 +34,7 @@ models:
       - name: period_sequence
         description: The sequential order of this period relative to other periods.
       - name: school_year
-        description: "School year specified by Spring year, e.g. the 2021-2022 year would be 2022. Unlike most other tables, `school_year` here reflects a school year reference embedded directly in the source Ed-Fi record, rather than the year of the source ODS pull — so it can differ from the pull year in edge cases (e.g. calendar or schedule data that spans a year boundary)."
+        description: "{{ doc('school_year_source_reference') }}"
       - name: begin_date
         description: Month, day, and year of the first day of the grading period.
       - name: end_date

--- a/models/core_warehouse/dim_graduation_plan.yml
+++ b/models/core_warehouse/dim_graduation_plan.yml
@@ -23,7 +23,7 @@ models:
       - name: tenant_code
         description: Code defining the Tenant (may be an LEA, SEA, etc.) of the Ed-Fi ODS from which this record was pulled
       - name: school_year
-        description: School year specified by Spring year, e.g. the 2021-2022 year would be 2022. The school year is populated based on the year associated with the source ODS, which is assumed to contain data for only that school year.
+        description: "{{ doc('school_year_ods_pull') }}"
       - name: k_lea
         description: Association to the LEA with the cohort.
       - name: k_school

--- a/models/core_warehouse/dim_graduation_plan.yml
+++ b/models/core_warehouse/dim_graduation_plan.yml
@@ -23,7 +23,7 @@ models:
       - name: tenant_code
         description: Code defining the Tenant (may be an LEA, SEA, etc.) of the Ed-Fi ODS from which this record was pulled
       - name: school_year
-        description: The identifier for the grading period school year.
+        description: School year specified by Spring year, e.g. the 2021-2022 year would be 2022. The school year is populated based on the year associated with the source ODS, which is assumed to contain data for only that school year (with rare exceptions for transcript/academic record data).
       - name: k_lea
         description: Association to the LEA with the cohort.
       - name: k_school

--- a/models/core_warehouse/dim_graduation_plan.yml
+++ b/models/core_warehouse/dim_graduation_plan.yml
@@ -23,7 +23,7 @@ models:
       - name: tenant_code
         description: Code defining the Tenant (may be an LEA, SEA, etc.) of the Ed-Fi ODS from which this record was pulled
       - name: school_year
-        description: School year specified by Spring year, e.g. the 2021-2022 year would be 2022. The school year is populated based on the year associated with the source ODS, which is assumed to contain data for only that school year (with rare exceptions for transcript/academic record data).
+        description: School year specified by Spring year, e.g. the 2021-2022 year would be 2022. The school year is populated based on the year associated with the source ODS, which is assumed to contain data for only that school year.
       - name: k_lea
         description: Association to the LEA with the cohort.
       - name: k_school

--- a/models/core_warehouse/dim_learning_standard.yml
+++ b/models/core_warehouse/dim_learning_standard.yml
@@ -26,7 +26,7 @@ models:
         description: A reference linking to a hierarchical parent learning standard id.
       - name: tenant_code  
       - name: school_year
-        description: School year specified by Spring year, e.g. the 2021-2022 year would be 2022. The school year is populated based on the year associated with the source ODS, which is assumed to contain data for only that school year (with rare exceptions for transcript/academic record data).
+        description: School year specified by Spring year, e.g. the 2021-2022 year would be 2022. The school year is populated based on the year associated with the source ODS, which is assumed to contain data for only that school year.
       - name: learning_standard_id
         description: A unique number or alphanumeric code assigned to a Learning Standard.
       - name: v_learning_standard_identification_codes

--- a/models/core_warehouse/dim_learning_standard.yml
+++ b/models/core_warehouse/dim_learning_standard.yml
@@ -26,7 +26,7 @@ models:
         description: A reference linking to a hierarchical parent learning standard id.
       - name: tenant_code  
       - name: school_year
-        description: School year specified by Spring year, e.g. the 2021-2022 year would be 2022. The school year is populated based on the year associated with the source ODS, which is assumed to contain data for only that school year.
+        description: "{{ doc('school_year_ods_pull') }}"
       - name: learning_standard_id
         description: A unique number or alphanumeric code assigned to a Learning Standard.
       - name: v_learning_standard_identification_codes

--- a/models/core_warehouse/dim_learning_standard.yml
+++ b/models/core_warehouse/dim_learning_standard.yml
@@ -26,6 +26,7 @@ models:
         description: A reference linking to a hierarchical parent learning standard id.
       - name: tenant_code  
       - name: school_year
+        description: School year specified by Spring year, e.g. the 2021-2022 year would be 2022. The school year is populated based on the year associated with the source ODS, which is assumed to contain data for only that school year (with rare exceptions for transcript/academic record data).
       - name: learning_standard_id
         description: A unique number or alphanumeric code assigned to a Learning Standard.
       - name: v_learning_standard_identification_codes

--- a/models/core_warehouse/dim_objective_assessment.yml
+++ b/models/core_warehouse/dim_objective_assessment.yml
@@ -32,7 +32,7 @@ models:
       - name: k_assessment
       - name: tenant_code
       - name: school_year
-        description: "School year specified by Spring year, e.g. the 2021-2022 year would be 2022. For assessment records, `school_year` is primarily populated based on the year associated with the source ODS, which is assumed to contain data for only that school year. If not available from the ODS, it is inferred from `administration_date` using a school-year cutoff date that can vary by implementation (e.g. defaulting to 8/1, meaning an assessment administered on or after 8/1/2021 and before 8/1/2022 is assigned school year 2022). Some implementations may also configure a school year crosswalk to override the ODS-sourced or inferred year for specific assessments or date ranges."
+        description: "{{ doc('school_year_assessment') }}"
       - name: assessment_identifier
       - name: namespace
       - name: objective_assessment_description

--- a/models/core_warehouse/dim_objective_assessment.yml
+++ b/models/core_warehouse/dim_objective_assessment.yml
@@ -32,7 +32,7 @@ models:
       - name: k_assessment
       - name: tenant_code
       - name: school_year
-        description: School year specified by Spring year, e.g. the 2021-2022 year would be 2022. The school year is populated based on the year associated with the source ODS, which is assumed to contain data for only that school year (with rare exceptions for transcript/academic record data).
+        description: "School year specified by Spring year, e.g. the 2021-2022 year would be 2022. For assessment records, `school_year` is primarily populated based on the year associated with the source ODS, which is assumed to contain data for only that school year. If not available from the ODS, it is inferred from `administration_date` using a school-year cutoff date that can vary by implementation (e.g. defaulting to 8/1, meaning an assessment administered on or after 8/1/2021 and before 8/1/2022 is assigned school year 2022). Some implementations may also configure a school year crosswalk to override the ODS-sourced or inferred year for specific assessments or date ranges."
       - name: assessment_identifier
       - name: namespace
       - name: objective_assessment_description

--- a/models/core_warehouse/dim_objective_assessment.yml
+++ b/models/core_warehouse/dim_objective_assessment.yml
@@ -32,6 +32,7 @@ models:
       - name: k_assessment
       - name: tenant_code
       - name: school_year
+        description: School year specified by Spring year, e.g. the 2021-2022 year would be 2022. The school year is populated based on the year associated with the source ODS, which is assumed to contain data for only that school year (with rare exceptions for transcript/academic record data).
       - name: assessment_identifier
       - name: namespace
       - name: objective_assessment_description

--- a/models/core_warehouse/dim_parent.yml
+++ b/models/core_warehouse/dim_parent.yml
@@ -27,7 +27,7 @@ models:
           - not_null
       - name: tenant_code
       - name: school_year
-        description: School year specified by Spring year, e.g. the 2021-2022 year would be 2022. The school year is populated based on the year associated with the source ODS, which is assumed to contain data for only that school year (with rare exceptions for transcript/academic record data).
+        description: School year specified by Spring year, e.g. the 2021-2022 year would be 2022. The school year is populated based on the year associated with the source ODS, which is assumed to contain data for only that school year.
       - name: parent_unique_id
         description: The parent's unique id number in the education organization.
       - name: person_id

--- a/models/core_warehouse/dim_parent.yml
+++ b/models/core_warehouse/dim_parent.yml
@@ -27,7 +27,7 @@ models:
           - not_null
       - name: tenant_code
       - name: school_year
-        description: School year specified by Spring year, e.g. the 2021-2022 year would be 2022. The school year is populated based on the year associated with the source ODS, which is assumed to contain data for only that school year.
+        description: "{{ doc('school_year_ods_pull') }}"
       - name: parent_unique_id
         description: The parent's unique id number in the education organization.
       - name: person_id

--- a/models/core_warehouse/dim_parent.yml
+++ b/models/core_warehouse/dim_parent.yml
@@ -27,6 +27,7 @@ models:
           - not_null
       - name: tenant_code
       - name: school_year
+        description: School year specified by Spring year, e.g. the 2021-2022 year would be 2022. The school year is populated based on the year associated with the source ODS, which is assumed to contain data for only that school year (with rare exceptions for transcript/academic record data).
       - name: parent_unique_id
         description: The parent's unique id number in the education organization.
       - name: person_id

--- a/models/core_warehouse/dim_program.yml
+++ b/models/core_warehouse/dim_program.yml
@@ -34,9 +34,7 @@ models:
       - name: k_school
         description: Association to the school with the program.
       - name: school_year
-        description: > 
-          School year specified by Spring year.
-          e.g., the 2021-2022 year would be 2022.
+        description: School year specified by Spring year, e.g. the 2021-2022 year would be 2022. The school year is populated based on the year associated with the source ODS, which is assumed to contain data for only that school year (with rare exceptions for transcript/academic record data).
       - name: tenant_code
       - name: ed_org_id
         description: The identifier for the educational organization with the program.

--- a/models/core_warehouse/dim_program.yml
+++ b/models/core_warehouse/dim_program.yml
@@ -34,7 +34,7 @@ models:
       - name: k_school
         description: Association to the school with the program.
       - name: school_year
-        description: School year specified by Spring year, e.g. the 2021-2022 year would be 2022. The school year is populated based on the year associated with the source ODS, which is assumed to contain data for only that school year (with rare exceptions for transcript/academic record data).
+        description: School year specified by Spring year, e.g. the 2021-2022 year would be 2022. The school year is populated based on the year associated with the source ODS, which is assumed to contain data for only that school year.
       - name: tenant_code
       - name: ed_org_id
         description: The identifier for the educational organization with the program.

--- a/models/core_warehouse/dim_program.yml
+++ b/models/core_warehouse/dim_program.yml
@@ -34,7 +34,7 @@ models:
       - name: k_school
         description: Association to the school with the program.
       - name: school_year
-        description: School year specified by Spring year, e.g. the 2021-2022 year would be 2022. The school year is populated based on the year associated with the source ODS, which is assumed to contain data for only that school year.
+        description: "{{ doc('school_year_ods_pull') }}"
       - name: tenant_code
       - name: ed_org_id
         description: The identifier for the educational organization with the program.

--- a/models/core_warehouse/dim_school_calendar.yml
+++ b/models/core_warehouse/dim_school_calendar.yml
@@ -31,6 +31,7 @@ models:
         description: Foreign key to `dim_school`, identifying the school associated with the calendar.
       - name: tenant_code
       - name: school_year
+        description: School year specified by Spring year, e.g. the 2021-2022 year would be 2022. The school year is populated based on the year associated with the source ODS, which is assumed to contain data for only that school year (with rare exceptions for transcript/academic record data).
       - name: calendar_code
         description: Identifier for the calendar.
       - name: calendar_type

--- a/models/core_warehouse/dim_school_calendar.yml
+++ b/models/core_warehouse/dim_school_calendar.yml
@@ -31,7 +31,7 @@ models:
         description: Foreign key to `dim_school`, identifying the school associated with the calendar.
       - name: tenant_code
       - name: school_year
-        description: "School year specified by Spring year, e.g. the 2021-2022 year would be 2022. Unlike most other tables, `school_year` here reflects a school year reference embedded directly in the source Ed-Fi record, rather than the year of the source ODS pull — so it can differ from the pull year in edge cases (e.g. calendar or schedule data that spans a year boundary)."
+        description: "{{ doc('school_year_source_reference') }}"
       - name: calendar_code
         description: Identifier for the calendar.
       - name: calendar_type

--- a/models/core_warehouse/dim_school_calendar.yml
+++ b/models/core_warehouse/dim_school_calendar.yml
@@ -31,7 +31,7 @@ models:
         description: Foreign key to `dim_school`, identifying the school associated with the calendar.
       - name: tenant_code
       - name: school_year
-        description: School year specified by Spring year, e.g. the 2021-2022 year would be 2022. The school year is populated based on the year associated with the source ODS, which is assumed to contain data for only that school year (with rare exceptions for transcript/academic record data).
+        description: "School year specified by Spring year, e.g. the 2021-2022 year would be 2022. Unlike most other tables, `school_year` here reflects a school year reference embedded directly in the source Ed-Fi record, rather than the year of the source ODS pull — so it can differ from the pull year in edge cases (e.g. calendar or schedule data that spans a year boundary)."
       - name: calendar_code
         description: Identifier for the calendar.
       - name: calendar_type

--- a/models/core_warehouse/dim_session.yml
+++ b/models/core_warehouse/dim_session.yml
@@ -32,7 +32,7 @@ models:
       - name: tenant_code
         description: The tenant associated with the record.
       - name: school_year
-        description: School year specified by Spring year, e.g. the 2021-2022 year would be 2022. The school year is populated based on the year associated with the source ODS, which is assumed to contain data for only that school year (with rare exceptions for transcript/academic record data).
+        description: "School year specified by Spring year, e.g. the 2021-2022 year would be 2022. Unlike most other tables, `school_year` here reflects a school year reference embedded directly in the source Ed-Fi record, rather than the year of the source ODS pull — so it can differ from the pull year in edge cases (e.g. calendar or schedule data that spans a year boundary)."
       - name: session_name
         description: Identifier code for a session.
       - name: session_begin_date

--- a/models/core_warehouse/dim_session.yml
+++ b/models/core_warehouse/dim_session.yml
@@ -32,7 +32,7 @@ models:
       - name: tenant_code
         description: The tenant associated with the record.
       - name: school_year
-        description: School year specified by Spring year, e.g. the 2021-2022 year would be 2022.
+        description: School year specified by Spring year, e.g. the 2021-2022 year would be 2022. The school year is populated based on the year associated with the source ODS, which is assumed to contain data for only that school year (with rare exceptions for transcript/academic record data).
       - name: session_name
         description: Identifier code for a session.
       - name: session_begin_date

--- a/models/core_warehouse/dim_session.yml
+++ b/models/core_warehouse/dim_session.yml
@@ -32,7 +32,7 @@ models:
       - name: tenant_code
         description: The tenant associated with the record.
       - name: school_year
-        description: "School year specified by Spring year, e.g. the 2021-2022 year would be 2022. Unlike most other tables, `school_year` here reflects a school year reference embedded directly in the source Ed-Fi record, rather than the year of the source ODS pull — so it can differ from the pull year in edge cases (e.g. calendar or schedule data that spans a year boundary)."
+        description: "{{ doc('school_year_source_reference') }}"
       - name: session_name
         description: Identifier code for a session.
       - name: session_begin_date

--- a/models/core_warehouse/dim_student.yml
+++ b/models/core_warehouse/dim_student.yml
@@ -39,7 +39,7 @@ models:
       - name: tenant_code
         description: The tenant associated with the record.
       - name: school_year
-        description: School year specified by Spring year, e.g. the 2021-2022 year would be 2022. The school year is populated based on the year associated with the source ODS, which is assumed to contain data for only that school year.
+        description: "{{ doc('school_year_ods_pull') }}"
         tests:
           - not_null
       - name: student_unique_id

--- a/models/core_warehouse/dim_student.yml
+++ b/models/core_warehouse/dim_student.yml
@@ -39,9 +39,7 @@ models:
       - name: tenant_code
         description: The tenant associated with the record.
       - name: school_year
-        description: >
-          School year specified by Spring year.
-          e.g. the 2021-2022 year would be 2022.
+        description: School year specified by Spring year, e.g. the 2021-2022 year would be 2022. The school year is populated based on the year associated with the source ODS, which is assumed to contain data for only that school year (with rare exceptions for transcript/academic record data).
         tests:
           - not_null
       - name: student_unique_id

--- a/models/core_warehouse/dim_student.yml
+++ b/models/core_warehouse/dim_student.yml
@@ -39,7 +39,7 @@ models:
       - name: tenant_code
         description: The tenant associated with the record.
       - name: school_year
-        description: School year specified by Spring year, e.g. the 2021-2022 year would be 2022. The school year is populated based on the year associated with the source ODS, which is assumed to contain data for only that school year (with rare exceptions for transcript/academic record data).
+        description: School year specified by Spring year, e.g. the 2021-2022 year would be 2022. The school year is populated based on the year associated with the source ODS, which is assumed to contain data for only that school year.
         tests:
           - not_null
       - name: student_unique_id

--- a/models/core_warehouse/docs/school_year_docs.md
+++ b/models/core_warehouse/docs/school_year_docs.md
@@ -1,0 +1,15 @@
+{% docs school_year_ods_pull %}
+School year specified by Spring year, e.g. the 2021-2022 year would be 2022. The school year is populated based on the year associated with the source ODS, which is assumed to contain data for only that school year.
+{% enddocs %}
+
+{% docs school_year_source_reference %}
+School year specified by Spring year, e.g. the 2021-2022 year would be 2022. Unlike most other tables, `school_year` here reflects a school year reference embedded directly in the source Ed-Fi record, rather than the year of the source ODS pull — so it can differ from the pull year in edge cases (e.g. calendar or schedule data that spans a year boundary).
+{% enddocs %}
+
+{% docs school_year_assessment %}
+School year specified by Spring year, e.g. the 2021-2022 year would be 2022. For assessment records, `school_year` is primarily populated based on the year associated with the source ODS, which is assumed to contain data for only that school year. If not available from the ODS, it is inferred from `administration_date` using a school-year cutoff date that can vary by implementation (e.g. defaulting to 8/1, meaning an assessment administered on or after 8/1/2021 and before 8/1/2022 is assigned school year 2022). Some implementations may also configure a school year crosswalk to override the ODS-sourced or inferred year for specific assessments or date ranges.
+{% enddocs %}
+
+{% docs school_year_academic_record %}
+School year specified by Spring year, e.g. the 2021-2022 year would be 2022. Unlike most other tables, `school_year` here is sourced from the `student_academic_records` Ed-Fi endpoint, where it is a required field provided directly by the source system rather than inferred from a single-year ODS.
+{% enddocs %}

--- a/models/core_warehouse/docs/school_year_docs.md
+++ b/models/core_warehouse/docs/school_year_docs.md
@@ -3,7 +3,7 @@ School year specified by Spring year, e.g. the 2021-2022 year would be 2022. The
 {% enddocs %}
 
 {% docs school_year_source_reference %}
-School year specified by Spring year, e.g. the 2021-2022 year would be 2022. Unlike most other tables, `school_year` here reflects a school year reference embedded directly in the source Ed-Fi record, rather than the year of the source ODS pull — so it can differ from the pull year in edge cases (e.g. calendar or schedule data that spans a year boundary).
+School year specified by Spring year, e.g. the 2021-2022 year would be 2022. The `school_year` here is sourced from a school year endpoint embedded directly in the source Ed-Fi record, rather than inferred based on the year of the source ODS (which is assumed to contain data for only one school year), so it can differ from the ODS year in edge cases (e.g. calendar or schedule data that spans a year boundary).
 {% enddocs %}
 
 {% docs school_year_assessment %}
@@ -11,5 +11,5 @@ School year specified by Spring year, e.g. the 2021-2022 year would be 2022. For
 {% enddocs %}
 
 {% docs school_year_academic_record %}
-School year specified by Spring year, e.g. the 2021-2022 year would be 2022. Unlike most other tables, `school_year` here is sourced from the `student_academic_records` Ed-Fi endpoint, where it is a required field provided directly by the source system rather than inferred from a single-year ODS.
+School year specified by Spring year, e.g. the 2021-2022 year would be 2022. The `school_year` here is sourced from the `student_academic_records` Ed-Fi endpoint, where it is a required field provided directly by the source system rather than inferred from a single-year ODS.
 {% enddocs %}

--- a/models/core_warehouse/fct_course_transcripts.yml
+++ b/models/core_warehouse/fct_course_transcripts.yml
@@ -77,7 +77,7 @@ models:
         description: Defining key for the student in this school year.
       - name: tenant_code
       - name: school_year
-        description: School year specified by Spring year, e.g. the 2021-2022 year would be 2022. The school year is populated based on the year associated with the source ODS, which is assumed to contain data for only that school year (with rare exceptions for transcript/academic record data).
+        description: School year specified by Spring year, e.g. the 2021-2022 year would be 2022. Unlike most other tables, `school_year` here is sourced from the `student_academic_records` Ed-Fi endpoint, where it is a required field provided directly by the source system rather than inferred from a single-year ODS.
       - name: academic_term
       - name: course_attempt_result
         description: The result from the student's attempt to take the course, e.g. Pass or Fail

--- a/models/core_warehouse/fct_course_transcripts.yml
+++ b/models/core_warehouse/fct_course_transcripts.yml
@@ -77,6 +77,7 @@ models:
         description: Defining key for the student in this school year.
       - name: tenant_code
       - name: school_year
+        description: School year specified by Spring year, e.g. the 2021-2022 year would be 2022. The school year is populated based on the year associated with the source ODS, which is assumed to contain data for only that school year (with rare exceptions for transcript/academic record data).
       - name: academic_term
       - name: course_attempt_result
         description: The result from the student's attempt to take the course, e.g. Pass or Fail

--- a/models/core_warehouse/fct_course_transcripts.yml
+++ b/models/core_warehouse/fct_course_transcripts.yml
@@ -77,7 +77,7 @@ models:
         description: Defining key for the student in this school year.
       - name: tenant_code
       - name: school_year
-        description: School year specified by Spring year, e.g. the 2021-2022 year would be 2022. Unlike most other tables, `school_year` here is sourced from the `student_academic_records` Ed-Fi endpoint, where it is a required field provided directly by the source system rather than inferred from a single-year ODS.
+        description: "{{ doc('school_year_academic_record') }}"
       - name: academic_term
       - name: course_attempt_result
         description: The result from the student's attempt to take the course, e.g. Pass or Fail

--- a/models/core_warehouse/fct_staff_school_association.yml
+++ b/models/core_warehouse/fct_staff_school_association.yml
@@ -71,7 +71,7 @@ models:
       - name: tenant_code
         description: "Code defining the Tenant (may be an LEA, SEA, etc.) of the EdFi ODS from which this record was pulled"
       - name: school_year
-        description: "School year specified by Spring year, e.g. the 2021-2022 year would be 2022. Unlike most other tables, `school_year` here reflects a school year reference embedded directly in the source Ed-Fi record, rather than the year of the source ODS pull — so it can differ from the pull year in edge cases (e.g. calendar or schedule data that spans a year boundary). If that reference is missing, `school_year` falls back to the source ODS pull year."
+        description: "{{ doc('school_year_source_reference') }} If that reference is missing, `school_year` falls back to the source ODS pull year."
       - name: program_assignment
         description: "The name of the program for which the individual is assigned; for example: Regular education Title I-Academic Title I-Non-Academic Special Education Bilingual/English as a Second Language.	"
       - name: position_title

--- a/models/core_warehouse/fct_staff_school_association.yml
+++ b/models/core_warehouse/fct_staff_school_association.yml
@@ -71,7 +71,7 @@ models:
       - name: tenant_code
         description: "Code defining the Tenant (may be an LEA, SEA, etc.) of the EdFi ODS from which this record was pulled"
       - name: school_year
-        description: School year specified by Spring year, e.g. the 2021-2022 year would be 2022. The school year is populated based on the year associated with the source ODS, which is assumed to contain data for only that school year (with rare exceptions for transcript/academic record data).
+        description: "School year specified by Spring year, e.g. the 2021-2022 year would be 2022. Unlike most other tables, `school_year` here reflects a school year reference embedded directly in the source Ed-Fi record, rather than the year of the source ODS pull — so it can differ from the pull year in edge cases (e.g. calendar or schedule data that spans a year boundary). If that reference is missing, `school_year` falls back to the source ODS pull year."
       - name: program_assignment
         description: "The name of the program for which the individual is assigned; for example: Regular education Title I-Academic Title I-Non-Academic Special Education Bilingual/English as a Second Language.	"
       - name: position_title

--- a/models/core_warehouse/fct_staff_school_association.yml
+++ b/models/core_warehouse/fct_staff_school_association.yml
@@ -71,6 +71,7 @@ models:
       - name: tenant_code
         description: "Code defining the Tenant (may be an LEA, SEA, etc.) of the EdFi ODS from which this record was pulled"
       - name: school_year
+        description: School year specified by Spring year, e.g. the 2021-2022 year would be 2022. The school year is populated based on the year associated with the source ODS, which is assumed to contain data for only that school year (with rare exceptions for transcript/academic record data).
       - name: program_assignment
         description: "The name of the program for which the individual is assigned; for example: Regular education Title I-Academic Title I-Non-Academic Special Education Bilingual/English as a Second Language.	"
       - name: position_title

--- a/models/core_warehouse/fct_staff_section_association.yml
+++ b/models/core_warehouse/fct_staff_section_association.yml
@@ -40,6 +40,7 @@ models:
       - name: tenant_code
         description: "Code defining the Tenant (may be an LEA, SEA, etc.) of the EdFi ODS from which this record was pulled"
       - name: school_year
+        description: School year specified by Spring year, e.g. the 2021-2022 year would be 2022. The school year is populated based on the year associated with the source ODS, which is assumed to contain data for only that school year (with rare exceptions for transcript/academic record data).
       - name: begin_date
         description: "Month, day, and year of the start or effective date of a staff member's employment, contract, or relationship with the LEA."
       - name: end_date

--- a/models/core_warehouse/fct_staff_section_association.yml
+++ b/models/core_warehouse/fct_staff_section_association.yml
@@ -40,7 +40,7 @@ models:
       - name: tenant_code
         description: "Code defining the Tenant (may be an LEA, SEA, etc.) of the EdFi ODS from which this record was pulled"
       - name: school_year
-        description: School year specified by Spring year, e.g. the 2021-2022 year would be 2022. The school year is populated based on the year associated with the source ODS, which is assumed to contain data for only that school year (with rare exceptions for transcript/academic record data).
+        description: "School year specified by Spring year, e.g. the 2021-2022 year would be 2022. Unlike most other tables, `school_year` here reflects a school year reference embedded directly in the source Ed-Fi record, rather than the year of the source ODS pull — so it can differ from the pull year in edge cases (e.g. calendar or schedule data that spans a year boundary)."
       - name: begin_date
         description: "Month, day, and year of the start or effective date of a staff member's employment, contract, or relationship with the LEA."
       - name: end_date

--- a/models/core_warehouse/fct_staff_section_association.yml
+++ b/models/core_warehouse/fct_staff_section_association.yml
@@ -40,7 +40,7 @@ models:
       - name: tenant_code
         description: "Code defining the Tenant (may be an LEA, SEA, etc.) of the EdFi ODS from which this record was pulled"
       - name: school_year
-        description: "School year specified by Spring year, e.g. the 2021-2022 year would be 2022. Unlike most other tables, `school_year` here reflects a school year reference embedded directly in the source Ed-Fi record, rather than the year of the source ODS pull — so it can differ from the pull year in edge cases (e.g. calendar or schedule data that spans a year boundary)."
+        description: "{{ doc('school_year_source_reference') }}"
       - name: begin_date
         description: "Month, day, and year of the start or effective date of a staff member's employment, contract, or relationship with the LEA."
       - name: end_date

--- a/models/core_warehouse/fct_student_academic_record.yml
+++ b/models/core_warehouse/fct_student_academic_record.yml
@@ -48,7 +48,7 @@ models:
       - name: k_school
       - name: tenant_code
       - name: school_year
-        description: School year specified by Spring year, e.g. the 2021-2022 year would be 2022. The school year is populated based on the year associated with the source ODS, which is assumed to contain data for only that school year (with rare exceptions for transcript/academic record data).
+        description: School year specified by Spring year, e.g. the 2021-2022 year would be 2022. Unlike most other tables, `school_year` here is sourced from the `student_academic_records` Ed-Fi endpoint, where it is a required field provided directly by the source system rather than inferred from a single-year ODS.
       - name: academic_term
       - name: session_earned_credits
         description: The number of credits an individual earned in this session.

--- a/models/core_warehouse/fct_student_academic_record.yml
+++ b/models/core_warehouse/fct_student_academic_record.yml
@@ -48,7 +48,7 @@ models:
       - name: k_school
       - name: tenant_code
       - name: school_year
-        description: School year specified by Spring year, e.g. the 2021-2022 year would be 2022. Unlike most other tables, `school_year` here is sourced from the `student_academic_records` Ed-Fi endpoint, where it is a required field provided directly by the source system rather than inferred from a single-year ODS.
+        description: "{{ doc('school_year_academic_record') }}"
       - name: academic_term
       - name: session_earned_credits
         description: The number of credits an individual earned in this session.

--- a/models/core_warehouse/fct_student_academic_record.yml
+++ b/models/core_warehouse/fct_student_academic_record.yml
@@ -48,6 +48,7 @@ models:
       - name: k_school
       - name: tenant_code
       - name: school_year
+        description: School year specified by Spring year, e.g. the 2021-2022 year would be 2022. The school year is populated based on the year associated with the source ODS, which is assumed to contain data for only that school year (with rare exceptions for transcript/academic record data).
       - name: academic_term
       - name: session_earned_credits
         description: The number of credits an individual earned in this session.

--- a/models/core_warehouse/fct_student_assessment.yml
+++ b/models/core_warehouse/fct_student_assessment.yml
@@ -69,7 +69,7 @@ models:
       - name: k_student
         description: Unique identifier for the student-year. Foreign key reference to `dim_student`.
       - name: school_year
-        description: The school year for which the assessment was administered to a student.	
+        description: School year specified by Spring year, e.g. the 2021-2022 year would be 2022. The school year is populated based on the year associated with the source ODS, which is assumed to contain data for only that school year (with rare exceptions for transcript/academic record data).
       - name: administration_date
         description: The date and time an assessment was completed by the student.
       - name: administration_end_date

--- a/models/core_warehouse/fct_student_assessment.yml
+++ b/models/core_warehouse/fct_student_assessment.yml
@@ -69,7 +69,7 @@ models:
       - name: k_student
         description: Unique identifier for the student-year. Foreign key reference to `dim_student`.
       - name: school_year
-        description: School year specified by Spring year, e.g. the 2021-2022 year would be 2022. The school year is populated based on the year associated with the source ODS, which is assumed to contain data for only that school year (with rare exceptions for transcript/academic record data).
+        description: School year specified by Spring year, e.g. the 2021-2022 year would be 2022. For assessment records, `school_year` is primarily populated based on the year associated with the source ODS, which is assumed to contain data for only that school year. If not available from the ODS, it is inferred from `administration_date` using a school-year cutoff date that can vary by implementation (e.g. defaulting to 8/1, meaning an assessment administered on or after 8/1/2021 and before 8/1/2022 is assigned school year 2022). Some implementations may also configure a school year crosswalk to override the ODS-sourced or inferred year for specific assessments or date ranges.
       - name: administration_date
         description: The date and time an assessment was completed by the student.
       - name: administration_end_date

--- a/models/core_warehouse/fct_student_assessment.yml
+++ b/models/core_warehouse/fct_student_assessment.yml
@@ -69,7 +69,7 @@ models:
       - name: k_student
         description: Unique identifier for the student-year. Foreign key reference to `dim_student`.
       - name: school_year
-        description: School year specified by Spring year, e.g. the 2021-2022 year would be 2022. For assessment records, `school_year` is primarily populated based on the year associated with the source ODS, which is assumed to contain data for only that school year. If not available from the ODS, it is inferred from `administration_date` using a school-year cutoff date that can vary by implementation (e.g. defaulting to 8/1, meaning an assessment administered on or after 8/1/2021 and before 8/1/2022 is assigned school year 2022). Some implementations may also configure a school year crosswalk to override the ODS-sourced or inferred year for specific assessments or date ranges.
+        description: "{{ doc('school_year_assessment') }}"
       - name: administration_date
         description: The date and time an assessment was completed by the student.
       - name: administration_end_date

--- a/models/core_warehouse/fct_student_cohort_association.yml
+++ b/models/core_warehouse/fct_student_cohort_association.yml
@@ -42,7 +42,7 @@ models:
       - name: k_school
       - name: tenant_code
       - name: school_year
-        description: School year specified by Spring year, e.g. the 2021-2022 year would be 2022. The school year is populated based on the year associated with the source ODS, which is assumed to contain data for only that school year (with rare exceptions for transcript/academic record data).
+        description: School year specified by Spring year, e.g. the 2021-2022 year would be 2022. The school year is populated based on the year associated with the source ODS, which is assumed to contain data for only that school year.
       - name: cohort_begin_date
       - name: cohort_end_date
       - name: is_active_cohort_association

--- a/models/core_warehouse/fct_student_cohort_association.yml
+++ b/models/core_warehouse/fct_student_cohort_association.yml
@@ -42,7 +42,7 @@ models:
       - name: k_school
       - name: tenant_code
       - name: school_year
-        description: School year specified by Spring year, e.g. the 2021-2022 year would be 2022. The school year is populated based on the year associated with the source ODS, which is assumed to contain data for only that school year.
+        description: "{{ doc('school_year_ods_pull') }}"
       - name: cohort_begin_date
       - name: cohort_end_date
       - name: is_active_cohort_association

--- a/models/core_warehouse/fct_student_cohort_association.yml
+++ b/models/core_warehouse/fct_student_cohort_association.yml
@@ -42,6 +42,7 @@ models:
       - name: k_school
       - name: tenant_code
       - name: school_year
+        description: School year specified by Spring year, e.g. the 2021-2022 year would be 2022. The school year is populated based on the year associated with the source ODS, which is assumed to contain data for only that school year (with rare exceptions for transcript/academic record data).
       - name: cohort_begin_date
       - name: cohort_end_date
       - name: is_active_cohort_association

--- a/models/core_warehouse/fct_student_cte_program_associations.yml
+++ b/models/core_warehouse/fct_student_cte_program_associations.yml
@@ -44,7 +44,7 @@ models:
       - name: k_school
       - name: tenant_code
       - name: school_year
-        description: School year specified by Spring year, e.g. the 2021-2022 year would be 2022. The school year is populated based on the year associated with the source ODS, which is assumed to contain data for only that school year (with rare exceptions for transcript/academic record data).
+        description: School year specified by Spring year, e.g. the 2021-2022 year would be 2022. The school year is populated based on the year associated with the source ODS, which is assumed to contain data for only that school year.
       - name: program_enroll_begin_date
       - name: program_enroll_end_date
       - name: non_traditional_gender_status

--- a/models/core_warehouse/fct_student_cte_program_associations.yml
+++ b/models/core_warehouse/fct_student_cte_program_associations.yml
@@ -44,7 +44,7 @@ models:
       - name: k_school
       - name: tenant_code
       - name: school_year
-        description: School year specified by Spring year, e.g. the 2021-2022 year would be 2022. The school year is populated based on the year associated with the source ODS, which is assumed to contain data for only that school year.
+        description: "{{ doc('school_year_ods_pull') }}"
       - name: program_enroll_begin_date
       - name: program_enroll_end_date
       - name: non_traditional_gender_status

--- a/models/core_warehouse/fct_student_cte_program_associations.yml
+++ b/models/core_warehouse/fct_student_cte_program_associations.yml
@@ -44,6 +44,7 @@ models:
       - name: k_school
       - name: tenant_code
       - name: school_year
+        description: School year specified by Spring year, e.g. the 2021-2022 year would be 2022. The school year is populated based on the year associated with the source ODS, which is assumed to contain data for only that school year (with rare exceptions for transcript/academic record data).
       - name: program_enroll_begin_date
       - name: program_enroll_end_date
       - name: non_traditional_gender_status

--- a/models/core_warehouse/fct_student_daily_attendance.yml
+++ b/models/core_warehouse/fct_student_daily_attendance.yml
@@ -58,7 +58,7 @@ models:
       - name: k_calendar_date
         description: Unique identifier for an individual day in a single calendar at a single school.
       - name: school_year
-        description: School year specified by Spring year, e.g. the 2021-2022 year would be 2022.
+        description: School year specified by Spring year, e.g. the 2021-2022 year would be 2022. The school year is populated based on the year associated with the source ODS, which is assumed to contain data for only that school year (with rare exceptions for transcript/academic record data).
       - name: calendar_date
         description: Date on school calendar.
         config:

--- a/models/core_warehouse/fct_student_daily_attendance.yml
+++ b/models/core_warehouse/fct_student_daily_attendance.yml
@@ -58,7 +58,7 @@ models:
       - name: k_calendar_date
         description: Unique identifier for an individual day in a single calendar at a single school.
       - name: school_year
-        description: School year specified by Spring year, e.g. the 2021-2022 year would be 2022. The school year is populated based on the year associated with the source ODS, which is assumed to contain data for only that school year (with rare exceptions for transcript/academic record data).
+        description: "School year specified by Spring year, e.g. the 2021-2022 year would be 2022. Unlike most other tables, `school_year` here reflects a school year reference embedded directly in the source Ed-Fi record, rather than the year of the source ODS pull — so it can differ from the pull year in edge cases (e.g. calendar or schedule data that spans a year boundary)."
       - name: calendar_date
         description: Date on school calendar.
         config:

--- a/models/core_warehouse/fct_student_daily_attendance.yml
+++ b/models/core_warehouse/fct_student_daily_attendance.yml
@@ -58,7 +58,7 @@ models:
       - name: k_calendar_date
         description: Unique identifier for an individual day in a single calendar at a single school.
       - name: school_year
-        description: "School year specified by Spring year, e.g. the 2021-2022 year would be 2022. Unlike most other tables, `school_year` here reflects a school year reference embedded directly in the source Ed-Fi record, rather than the year of the source ODS pull — so it can differ from the pull year in edge cases (e.g. calendar or schedule data that spans a year boundary)."
+        description: "{{ doc('school_year_source_reference') }}"
       - name: calendar_date
         description: Date on school calendar.
         config:

--- a/models/core_warehouse/fct_student_diploma.yml
+++ b/models/core_warehouse/fct_student_diploma.yml
@@ -36,7 +36,7 @@ models:
       - name: k_lea
       - name: k_school
       - name: school_year
-        description: The school year for which the diploma was awarded to a student.
+        description: School year specified by Spring year, e.g. the 2021-2022 year would be 2022. The school year is populated based on the year associated with the source ODS, which is assumed to contain data for only that school year (with rare exceptions for transcript/academic record data).
       - name: diploma_type
         description: The type of diploma/credential that is awarded to a student in recognition of his/her completion of the curricular requirements.
       - name: diploma_award_date

--- a/models/core_warehouse/fct_student_diploma.yml
+++ b/models/core_warehouse/fct_student_diploma.yml
@@ -36,7 +36,7 @@ models:
       - name: k_lea
       - name: k_school
       - name: school_year
-        description: School year specified by Spring year, e.g. the 2021-2022 year would be 2022. Unlike most other tables, `school_year` here is sourced from the `student_academic_records` Ed-Fi endpoint, where it is a required field provided directly by the source system rather than inferred from a single-year ODS.
+        description: "{{ doc('school_year_academic_record') }}"
       - name: diploma_type
         description: The type of diploma/credential that is awarded to a student in recognition of his/her completion of the curricular requirements.
       - name: diploma_award_date

--- a/models/core_warehouse/fct_student_diploma.yml
+++ b/models/core_warehouse/fct_student_diploma.yml
@@ -36,7 +36,7 @@ models:
       - name: k_lea
       - name: k_school
       - name: school_year
-        description: School year specified by Spring year, e.g. the 2021-2022 year would be 2022. The school year is populated based on the year associated with the source ODS, which is assumed to contain data for only that school year (with rare exceptions for transcript/academic record data).
+        description: School year specified by Spring year, e.g. the 2021-2022 year would be 2022. Unlike most other tables, `school_year` here is sourced from the `student_academic_records` Ed-Fi endpoint, where it is a required field provided directly by the source system rather than inferred from a single-year ODS.
       - name: diploma_type
         description: The type of diploma/credential that is awarded to a student in recognition of his/her completion of the curricular requirements.
       - name: diploma_award_date

--- a/models/core_warehouse/fct_student_discipline_actions.yml
+++ b/models/core_warehouse/fct_student_discipline_actions.yml
@@ -153,6 +153,8 @@ models:
       - name: k_school__responsibility
         description: >
           The school responsible for the student's discipline
+      - name: school_year
+        description: School year specified by Spring year, e.g. the 2021-2022 year would be 2022. The school year is populated based on the year associated with the source ODS, which is assumed to contain data for only that school year.
       - name: k_discipline_actions_event
         description: >
           A key containing discipline_action_id and discipline_date to represent a single discipline event.

--- a/models/core_warehouse/fct_student_discipline_actions.yml
+++ b/models/core_warehouse/fct_student_discipline_actions.yml
@@ -154,7 +154,7 @@ models:
         description: >
           The school responsible for the student's discipline
       - name: school_year
-        description: School year specified by Spring year, e.g. the 2021-2022 year would be 2022. The school year is populated based on the year associated with the source ODS, which is assumed to contain data for only that school year.
+        description: "{{ doc('school_year_ods_pull') }}"
       - name: k_discipline_actions_event
         description: >
           A key containing discipline_action_id and discipline_date to represent a single discipline event.

--- a/models/core_warehouse/fct_student_discipline_actions_summary.yml
+++ b/models/core_warehouse/fct_student_discipline_actions_summary.yml
@@ -36,7 +36,7 @@ models:
           A key containing discipline_action_id and discipline_date to represent a single discipline action event.
       - name: tenant_code
       - name: school_year
-        description: School year specified by Spring year, e.g. the 2021-2022 year would be 2022. The school year is populated based on the year associated with the source ODS, which is assumed to contain data for only that school year.
+        description: "{{ doc('school_year_ods_pull') }}"
       - name: behavior_types_array
         description: >
           An array of behavior types, which are defined as a category of behavior describing the 

--- a/models/core_warehouse/fct_student_discipline_actions_summary.yml
+++ b/models/core_warehouse/fct_student_discipline_actions_summary.yml
@@ -36,6 +36,7 @@ models:
           A key containing discipline_action_id and discipline_date to represent a single discipline action event.
       - name: tenant_code
       - name: school_year
+        description: School year specified by Spring year, e.g. the 2021-2022 year would be 2022. The school year is populated based on the year associated with the source ODS, which is assumed to contain data for only that school year (with rare exceptions for transcript/academic record data).
       - name: behavior_types_array
         description: >
           An array of behavior types, which are defined as a category of behavior describing the 

--- a/models/core_warehouse/fct_student_discipline_actions_summary.yml
+++ b/models/core_warehouse/fct_student_discipline_actions_summary.yml
@@ -36,7 +36,7 @@ models:
           A key containing discipline_action_id and discipline_date to represent a single discipline action event.
       - name: tenant_code
       - name: school_year
-        description: School year specified by Spring year, e.g. the 2021-2022 year would be 2022. The school year is populated based on the year associated with the source ODS, which is assumed to contain data for only that school year (with rare exceptions for transcript/academic record data).
+        description: School year specified by Spring year, e.g. the 2021-2022 year would be 2022. The school year is populated based on the year associated with the source ODS, which is assumed to contain data for only that school year.
       - name: behavior_types_array
         description: >
           An array of behavior types, which are defined as a category of behavior describing the 

--- a/models/core_warehouse/fct_student_discipline_incident_behaviors.yml
+++ b/models/core_warehouse/fct_student_discipline_incident_behaviors.yml
@@ -46,6 +46,7 @@ models:
           A key containing incident_id and school_id to represent a single discipline incident.
       - name: tenant_code
       - name: school_year
+        description: School year specified by Spring year, e.g. the 2021-2022 year would be 2022. The school year is populated based on the year associated with the source ODS, which is assumed to contain data for only that school year (with rare exceptions for transcript/academic record data).
       - name: school_id
       - name: incident_id
         description: > 

--- a/models/core_warehouse/fct_student_discipline_incident_behaviors.yml
+++ b/models/core_warehouse/fct_student_discipline_incident_behaviors.yml
@@ -46,7 +46,7 @@ models:
           A key containing incident_id and school_id to represent a single discipline incident.
       - name: tenant_code
       - name: school_year
-        description: School year specified by Spring year, e.g. the 2021-2022 year would be 2022. The school year is populated based on the year associated with the source ODS, which is assumed to contain data for only that school year.
+        description: "{{ doc('school_year_ods_pull') }}"
       - name: school_id
       - name: incident_id
         description: > 

--- a/models/core_warehouse/fct_student_discipline_incident_behaviors.yml
+++ b/models/core_warehouse/fct_student_discipline_incident_behaviors.yml
@@ -46,7 +46,7 @@ models:
           A key containing incident_id and school_id to represent a single discipline incident.
       - name: tenant_code
       - name: school_year
-        description: School year specified by Spring year, e.g. the 2021-2022 year would be 2022. The school year is populated based on the year associated with the source ODS, which is assumed to contain data for only that school year (with rare exceptions for transcript/academic record data).
+        description: School year specified by Spring year, e.g. the 2021-2022 year would be 2022. The school year is populated based on the year associated with the source ODS, which is assumed to contain data for only that school year.
       - name: school_id
       - name: incident_id
         description: > 

--- a/models/core_warehouse/fct_student_discipline_incident_summary.yml
+++ b/models/core_warehouse/fct_student_discipline_incident_summary.yml
@@ -42,6 +42,7 @@ models:
           A key containing discipline_action_id and discipline_date to represent a single discipline event.
       - name: tenant_code
       - name: school_year
+        description: School year specified by Spring year, e.g. the 2021-2022 year would be 2022. The school year is populated based on the year associated with the source ODS, which is assumed to contain data for only that school year (with rare exceptions for transcript/academic record data).
       - name: behavior_types_array
         description: >
           An array of behavior types, which are defined as a category of behavior describing the 

--- a/models/core_warehouse/fct_student_discipline_incident_summary.yml
+++ b/models/core_warehouse/fct_student_discipline_incident_summary.yml
@@ -42,7 +42,7 @@ models:
           A key containing discipline_action_id and discipline_date to represent a single discipline event.
       - name: tenant_code
       - name: school_year
-        description: School year specified by Spring year, e.g. the 2021-2022 year would be 2022. The school year is populated based on the year associated with the source ODS, which is assumed to contain data for only that school year.
+        description: "{{ doc('school_year_ods_pull') }}"
       - name: behavior_types_array
         description: >
           An array of behavior types, which are defined as a category of behavior describing the 

--- a/models/core_warehouse/fct_student_discipline_incident_summary.yml
+++ b/models/core_warehouse/fct_student_discipline_incident_summary.yml
@@ -42,7 +42,7 @@ models:
           A key containing discipline_action_id and discipline_date to represent a single discipline event.
       - name: tenant_code
       - name: school_year
-        description: School year specified by Spring year, e.g. the 2021-2022 year would be 2022. The school year is populated based on the year associated with the source ODS, which is assumed to contain data for only that school year (with rare exceptions for transcript/academic record data).
+        description: School year specified by Spring year, e.g. the 2021-2022 year would be 2022. The school year is populated based on the year associated with the source ODS, which is assumed to contain data for only that school year.
       - name: behavior_types_array
         description: >
           An array of behavior types, which are defined as a category of behavior describing the 

--- a/models/core_warehouse/fct_student_gpa.yml
+++ b/models/core_warehouse/fct_student_gpa.yml
@@ -56,7 +56,7 @@ models:
       - name: k_school
       - name: tenant_code
       - name: school_year
-        description: School year specified by Spring year, e.g. the 2021-2022 year would be 2022. Unlike most other tables, `school_year` here is sourced from the `student_academic_records` Ed-Fi endpoint, where it is a required field provided directly by the source system rather than inferred from a single-year ODS.
+        description: "{{ doc('school_year_academic_record') }}"
       - name: academic_term
       - name: gpa_type
         description: The system used for calculating the grade point average for an individual.

--- a/models/core_warehouse/fct_student_gpa.yml
+++ b/models/core_warehouse/fct_student_gpa.yml
@@ -56,7 +56,7 @@ models:
       - name: k_school
       - name: tenant_code
       - name: school_year
-        description: School year specified by Spring year, e.g. the 2021-2022 year would be 2022. The school year is populated based on the year associated with the source ODS, which is assumed to contain data for only that school year (with rare exceptions for transcript/academic record data).
+        description: School year specified by Spring year, e.g. the 2021-2022 year would be 2022. Unlike most other tables, `school_year` here is sourced from the `student_academic_records` Ed-Fi endpoint, where it is a required field provided directly by the source system rather than inferred from a single-year ODS.
       - name: academic_term
       - name: gpa_type
         description: The system used for calculating the grade point average for an individual.

--- a/models/core_warehouse/fct_student_gpa.yml
+++ b/models/core_warehouse/fct_student_gpa.yml
@@ -56,6 +56,7 @@ models:
       - name: k_school
       - name: tenant_code
       - name: school_year
+        description: School year specified by Spring year, e.g. the 2021-2022 year would be 2022. The school year is populated based on the year associated with the source ODS, which is assumed to contain data for only that school year (with rare exceptions for transcript/academic record data).
       - name: academic_term
       - name: gpa_type
         description: The system used for calculating the grade point average for an individual.

--- a/models/core_warehouse/fct_student_grades.yml
+++ b/models/core_warehouse/fct_student_grades.yml
@@ -71,7 +71,7 @@ models:
           Exam, Grading Period).
       - name: tenant_code
       - name: school_year
-        description: School year specified by Spring year, e.g. the 2021-2022 year would be 2022. The school year is populated based on the year associated with the source ODS, which is assumed to contain data for only that school year (with rare exceptions for transcript/academic record data).
+        description: "School year specified by Spring year, e.g. the 2021-2022 year would be 2022. Unlike most other tables, `school_year` here reflects a school year reference embedded directly in the source Ed-Fi record, rather than the year of the source ODS pull — so it can differ from the pull year in edge cases (e.g. calendar or schedule data that spans a year boundary)."
       - name: letter_grade_earned
       - name: numeric_grade_earned
       - name: diagnostic_statement

--- a/models/core_warehouse/fct_student_grades.yml
+++ b/models/core_warehouse/fct_student_grades.yml
@@ -71,6 +71,7 @@ models:
           Exam, Grading Period).
       - name: tenant_code
       - name: school_year
+        description: School year specified by Spring year, e.g. the 2021-2022 year would be 2022. The school year is populated based on the year associated with the source ODS, which is assumed to contain data for only that school year (with rare exceptions for transcript/academic record data).
       - name: letter_grade_earned
       - name: numeric_grade_earned
       - name: diagnostic_statement

--- a/models/core_warehouse/fct_student_grades.yml
+++ b/models/core_warehouse/fct_student_grades.yml
@@ -71,7 +71,7 @@ models:
           Exam, Grading Period).
       - name: tenant_code
       - name: school_year
-        description: "School year specified by Spring year, e.g. the 2021-2022 year would be 2022. Unlike most other tables, `school_year` here reflects a school year reference embedded directly in the source Ed-Fi record, rather than the year of the source ODS pull — so it can differ from the pull year in edge cases (e.g. calendar or schedule data that spans a year boundary)."
+        description: "{{ doc('school_year_source_reference') }}"
       - name: letter_grade_earned
       - name: numeric_grade_earned
       - name: diagnostic_statement

--- a/models/core_warehouse/fct_student_homeless_program_association.yml
+++ b/models/core_warehouse/fct_student_homeless_program_association.yml
@@ -44,7 +44,7 @@ models:
       - name: k_school
       - name: tenant_code
       - name: school_year
-        description: School year specified by Spring year, e.g. the 2021-2022 year would be 2022. The school year is populated based on the year associated with the source ODS, which is assumed to contain data for only that school year.
+        description: "{{ doc('school_year_ods_pull') }}"
       - name: program_enroll_begin_date
       - name: program_enroll_end_date
       - name: is_awaiting_foster_care

--- a/models/core_warehouse/fct_student_homeless_program_association.yml
+++ b/models/core_warehouse/fct_student_homeless_program_association.yml
@@ -44,7 +44,7 @@ models:
       - name: k_school
       - name: tenant_code
       - name: school_year
-        description: School year specified by Spring year, e.g. the 2021-2022 year would be 2022. The school year is populated based on the year associated with the source ODS, which is assumed to contain data for only that school year (with rare exceptions for transcript/academic record data).
+        description: School year specified by Spring year, e.g. the 2021-2022 year would be 2022. The school year is populated based on the year associated with the source ODS, which is assumed to contain data for only that school year.
       - name: program_enroll_begin_date
       - name: program_enroll_end_date
       - name: is_awaiting_foster_care

--- a/models/core_warehouse/fct_student_homeless_program_association.yml
+++ b/models/core_warehouse/fct_student_homeless_program_association.yml
@@ -44,6 +44,7 @@ models:
       - name: k_school
       - name: tenant_code
       - name: school_year
+        description: School year specified by Spring year, e.g. the 2021-2022 year would be 2022. The school year is populated based on the year associated with the source ODS, which is assumed to contain data for only that school year (with rare exceptions for transcript/academic record data).
       - name: program_enroll_begin_date
       - name: program_enroll_end_date
       - name: is_awaiting_foster_care

--- a/models/core_warehouse/fct_student_language_instruction_program_association.yml
+++ b/models/core_warehouse/fct_student_language_instruction_program_association.yml
@@ -44,7 +44,7 @@ models:
       - name: k_school
       - name: tenant_code
       - name: school_year
-        description: School year specified by Spring year, e.g. the 2021-2022 year would be 2022. The school year is populated based on the year associated with the source ODS, which is assumed to contain data for only that school year (with rare exceptions for transcript/academic record data).
+        description: School year specified by Spring year, e.g. the 2021-2022 year would be 2022. The school year is populated based on the year associated with the source ODS, which is assumed to contain data for only that school year.
       - name: program_enroll_begin_date
       - name: program_enroll_end_date
       - name: has_english_learner_participation

--- a/models/core_warehouse/fct_student_language_instruction_program_association.yml
+++ b/models/core_warehouse/fct_student_language_instruction_program_association.yml
@@ -44,7 +44,7 @@ models:
       - name: k_school
       - name: tenant_code
       - name: school_year
-        description: School year specified by Spring year, e.g. the 2021-2022 year would be 2022. The school year is populated based on the year associated with the source ODS, which is assumed to contain data for only that school year.
+        description: "{{ doc('school_year_ods_pull') }}"
       - name: program_enroll_begin_date
       - name: program_enroll_end_date
       - name: has_english_learner_participation

--- a/models/core_warehouse/fct_student_language_instruction_program_association.yml
+++ b/models/core_warehouse/fct_student_language_instruction_program_association.yml
@@ -44,6 +44,7 @@ models:
       - name: k_school
       - name: tenant_code
       - name: school_year
+        description: School year specified by Spring year, e.g. the 2021-2022 year would be 2022. The school year is populated based on the year associated with the source ODS, which is assumed to contain data for only that school year (with rare exceptions for transcript/academic record data).
       - name: program_enroll_begin_date
       - name: program_enroll_end_date
       - name: has_english_learner_participation

--- a/models/core_warehouse/fct_student_migrant_education_program_associations.yml
+++ b/models/core_warehouse/fct_student_migrant_education_program_associations.yml
@@ -44,7 +44,7 @@ models:
       - name: k_school
       - name: tenant_code
       - name: school_year
-        description: School year specified by Spring year, e.g. the 2021-2022 year would be 2022. The school year is populated based on the year associated with the source ODS, which is assumed to contain data for only that school year.
+        description: "{{ doc('school_year_ods_pull') }}"
       - name: program_enroll_begin_date
       - name: program_enroll_end_date
       - name: priority_for_service 

--- a/models/core_warehouse/fct_student_migrant_education_program_associations.yml
+++ b/models/core_warehouse/fct_student_migrant_education_program_associations.yml
@@ -44,7 +44,7 @@ models:
       - name: k_school
       - name: tenant_code
       - name: school_year
-        description: School year specified by Spring year, e.g. the 2021-2022 year would be 2022. The school year is populated based on the year associated with the source ODS, which is assumed to contain data for only that school year (with rare exceptions for transcript/academic record data).
+        description: School year specified by Spring year, e.g. the 2021-2022 year would be 2022. The school year is populated based on the year associated with the source ODS, which is assumed to contain data for only that school year.
       - name: program_enroll_begin_date
       - name: program_enroll_end_date
       - name: priority_for_service 

--- a/models/core_warehouse/fct_student_migrant_education_program_associations.yml
+++ b/models/core_warehouse/fct_student_migrant_education_program_associations.yml
@@ -44,6 +44,7 @@ models:
       - name: k_school
       - name: tenant_code
       - name: school_year
+        description: School year specified by Spring year, e.g. the 2021-2022 year would be 2022. The school year is populated based on the year associated with the source ODS, which is assumed to contain data for only that school year (with rare exceptions for transcript/academic record data).
       - name: program_enroll_begin_date
       - name: program_enroll_end_date
       - name: priority_for_service 

--- a/models/core_warehouse/fct_student_objective_assessment.yml
+++ b/models/core_warehouse/fct_student_objective_assessment.yml
@@ -58,6 +58,7 @@ models:
       - name: k_assessment
       - name: k_student
       - name: school_year
+        description: School year specified by Spring year, e.g. the 2021-2022 year would be 2022. The school year is populated based on the year associated with the source ODS, which is assumed to contain data for only that school year (with rare exceptions for transcript/academic record data).
       - name: administration_date
       - name: administration_end_date
       - name: event_description

--- a/models/core_warehouse/fct_student_objective_assessment.yml
+++ b/models/core_warehouse/fct_student_objective_assessment.yml
@@ -58,7 +58,7 @@ models:
       - name: k_assessment
       - name: k_student
       - name: school_year
-        description: School year specified by Spring year, e.g. the 2021-2022 year would be 2022. The school year is populated based on the year associated with the source ODS, which is assumed to contain data for only that school year (with rare exceptions for transcript/academic record data).
+        description: "School year specified by Spring year, e.g. the 2021-2022 year would be 2022. For assessment records, `school_year` is primarily populated based on the year associated with the source ODS, which is assumed to contain data for only that school year. If not available from the ODS, it is inferred from `administration_date` using a school-year cutoff date that can vary by implementation (e.g. defaulting to 8/1, meaning an assessment administered on or after 8/1/2021 and before 8/1/2022 is assigned school year 2022). Some implementations may also configure a school year crosswalk to override the ODS-sourced or inferred year for specific assessments or date ranges."
       - name: administration_date
       - name: administration_end_date
       - name: event_description

--- a/models/core_warehouse/fct_student_objective_assessment.yml
+++ b/models/core_warehouse/fct_student_objective_assessment.yml
@@ -58,7 +58,7 @@ models:
       - name: k_assessment
       - name: k_student
       - name: school_year
-        description: "School year specified by Spring year, e.g. the 2021-2022 year would be 2022. For assessment records, `school_year` is primarily populated based on the year associated with the source ODS, which is assumed to contain data for only that school year. If not available from the ODS, it is inferred from `administration_date` using a school-year cutoff date that can vary by implementation (e.g. defaulting to 8/1, meaning an assessment administered on or after 8/1/2021 and before 8/1/2022 is assigned school year 2022). Some implementations may also configure a school year crosswalk to override the ODS-sourced or inferred year for specific assessments or date ranges."
+        description: "{{ doc('school_year_assessment') }}"
       - name: administration_date
       - name: administration_end_date
       - name: event_description

--- a/models/core_warehouse/fct_student_parent_association.yml
+++ b/models/core_warehouse/fct_student_parent_association.yml
@@ -44,7 +44,7 @@ models:
       - name: k_parent
       - name: tenant_code
       - name: school_year
-        description: School year specified by Spring year, e.g. the 2021-2022 year would be 2022. The school year is populated based on the year associated with the source ODS, which is assumed to contain data for only that school year (with rare exceptions for transcript/academic record data).
+        description: School year specified by Spring year, e.g. the 2021-2022 year would be 2022. The school year is populated based on the year associated with the source ODS, which is assumed to contain data for only that school year.
       - name: contact_priority
       - name: contact_restrictions
       - name: relation_type

--- a/models/core_warehouse/fct_student_parent_association.yml
+++ b/models/core_warehouse/fct_student_parent_association.yml
@@ -44,6 +44,7 @@ models:
       - name: k_parent
       - name: tenant_code
       - name: school_year
+        description: School year specified by Spring year, e.g. the 2021-2022 year would be 2022. The school year is populated based on the year associated with the source ODS, which is assumed to contain data for only that school year (with rare exceptions for transcript/academic record data).
       - name: contact_priority
       - name: contact_restrictions
       - name: relation_type

--- a/models/core_warehouse/fct_student_parent_association.yml
+++ b/models/core_warehouse/fct_student_parent_association.yml
@@ -44,7 +44,7 @@ models:
       - name: k_parent
       - name: tenant_code
       - name: school_year
-        description: School year specified by Spring year, e.g. the 2021-2022 year would be 2022. The school year is populated based on the year associated with the source ODS, which is assumed to contain data for only that school year.
+        description: "{{ doc('school_year_ods_pull') }}"
       - name: contact_priority
       - name: contact_restrictions
       - name: relation_type

--- a/models/core_warehouse/fct_student_program_association.yml
+++ b/models/core_warehouse/fct_student_program_association.yml
@@ -41,7 +41,7 @@ models:
       - name: k_school
       - name: tenant_code
       - name: school_year
-        description: School year specified by Spring year, e.g. the 2021-2022 year would be 2022. The school year is populated based on the year associated with the source ODS, which is assumed to contain data for only that school year (with rare exceptions for transcript/academic record data).
+        description: School year specified by Spring year, e.g. the 2021-2022 year would be 2022. The school year is populated based on the year associated with the source ODS, which is assumed to contain data for only that school year.
       - name: program_enroll_begin_date
       - name: program_enroll_end_date
       - name: is_served_outside_regular_session

--- a/models/core_warehouse/fct_student_program_association.yml
+++ b/models/core_warehouse/fct_student_program_association.yml
@@ -41,6 +41,7 @@ models:
       - name: k_school
       - name: tenant_code
       - name: school_year
+        description: School year specified by Spring year, e.g. the 2021-2022 year would be 2022. The school year is populated based on the year associated with the source ODS, which is assumed to contain data for only that school year (with rare exceptions for transcript/academic record data).
       - name: program_enroll_begin_date
       - name: program_enroll_end_date
       - name: is_served_outside_regular_session

--- a/models/core_warehouse/fct_student_program_association.yml
+++ b/models/core_warehouse/fct_student_program_association.yml
@@ -41,7 +41,7 @@ models:
       - name: k_school
       - name: tenant_code
       - name: school_year
-        description: School year specified by Spring year, e.g. the 2021-2022 year would be 2022. The school year is populated based on the year associated with the source ODS, which is assumed to contain data for only that school year.
+        description: "{{ doc('school_year_ods_pull') }}"
       - name: program_enroll_begin_date
       - name: program_enroll_end_date
       - name: is_served_outside_regular_session

--- a/models/core_warehouse/fct_student_school_association.yml
+++ b/models/core_warehouse/fct_student_school_association.yml
@@ -98,7 +98,7 @@ models:
       - name: tenant_code
         description: The tenant associated with the record.
       - name: school_year
-        description: School year specified by Spring year, e.g. the 2021-2022 year would be 2022.
+        description: School year specified by Spring year, e.g. the 2021-2022 year would be 2022. The school year is populated based on the year associated with the source ODS, which is assumed to contain data for only that school year (with rare exceptions for transcript/academic record data).
       - name: entry_date
         description: > 
           The month, day, and year on which an individual enters and begins to 

--- a/models/core_warehouse/fct_student_school_association.yml
+++ b/models/core_warehouse/fct_student_school_association.yml
@@ -98,7 +98,7 @@ models:
       - name: tenant_code
         description: The tenant associated with the record.
       - name: school_year
-        description: School year specified by Spring year, e.g. the 2021-2022 year would be 2022. The school year is populated based on the year associated with the source ODS, which is assumed to contain data for only that school year (with rare exceptions for transcript/academic record data).
+        description: "School year specified by Spring year, e.g. the 2021-2022 year would be 2022. Unlike most other tables, `school_year` here reflects a school year reference embedded directly in the source Ed-Fi record, rather than the year of the source ODS pull — so it can differ from the pull year in edge cases (e.g. calendar or schedule data that spans a year boundary). If that reference is missing, `school_year` falls back to a value inferred from `entry_date` using a school-year cutoff date that can vary by implementation."
       - name: entry_date
         description: > 
           The month, day, and year on which an individual enters and begins to 

--- a/models/core_warehouse/fct_student_school_association.yml
+++ b/models/core_warehouse/fct_student_school_association.yml
@@ -98,7 +98,7 @@ models:
       - name: tenant_code
         description: The tenant associated with the record.
       - name: school_year
-        description: "School year specified by Spring year, e.g. the 2021-2022 year would be 2022. Unlike most other tables, `school_year` here reflects a school year reference embedded directly in the source Ed-Fi record, rather than the year of the source ODS pull — so it can differ from the pull year in edge cases (e.g. calendar or schedule data that spans a year boundary). If that reference is missing, `school_year` falls back to a value inferred from `entry_date` using a school-year cutoff date that can vary by implementation."
+        description: "{{ doc('school_year_source_reference') }} If that reference is missing, `school_year` falls back to a value inferred from `entry_date` using a school-year cutoff date that can vary by implementation."
       - name: entry_date
         description: > 
           The month, day, and year on which an individual enters and begins to 

--- a/models/core_warehouse/fct_student_school_attendance_event.yml
+++ b/models/core_warehouse/fct_student_school_attendance_event.yml
@@ -49,6 +49,7 @@ models:
       - name: k_session
       - name: tenant_code
       - name: school_year
+        description: School year specified by Spring year, e.g. the 2021-2022 year would be 2022. The school year is populated based on the year associated with the source ODS, which is assumed to contain data for only that school year (with rare exceptions for transcript/academic record data).
       - name: attendance_event_category
       - name: attendance_event_reason
       - name: is_absent

--- a/models/core_warehouse/fct_student_school_attendance_event.yml
+++ b/models/core_warehouse/fct_student_school_attendance_event.yml
@@ -49,7 +49,7 @@ models:
       - name: k_session
       - name: tenant_code
       - name: school_year
-        description: School year specified by Spring year, e.g. the 2021-2022 year would be 2022. The school year is populated based on the year associated with the source ODS, which is assumed to contain data for only that school year (with rare exceptions for transcript/academic record data).
+        description: "School year specified by Spring year, e.g. the 2021-2022 year would be 2022. Unlike most other tables, `school_year` here reflects a school year reference embedded directly in the source Ed-Fi record, rather than the year of the source ODS pull — so it can differ from the pull year in edge cases (e.g. calendar or schedule data that spans a year boundary)."
       - name: attendance_event_category
       - name: attendance_event_reason
       - name: is_absent

--- a/models/core_warehouse/fct_student_school_attendance_event.yml
+++ b/models/core_warehouse/fct_student_school_attendance_event.yml
@@ -49,7 +49,7 @@ models:
       - name: k_session
       - name: tenant_code
       - name: school_year
-        description: "School year specified by Spring year, e.g. the 2021-2022 year would be 2022. Unlike most other tables, `school_year` here reflects a school year reference embedded directly in the source Ed-Fi record, rather than the year of the source ODS pull — so it can differ from the pull year in edge cases (e.g. calendar or schedule data that spans a year boundary)."
+        description: "{{ doc('school_year_source_reference') }}"
       - name: attendance_event_category
       - name: attendance_event_reason
       - name: is_absent

--- a/models/core_warehouse/fct_student_school_food_service_program_associations.yml
+++ b/models/core_warehouse/fct_student_school_food_service_program_associations.yml
@@ -44,7 +44,7 @@ models:
       - name: k_school
       - name: tenant_code
       - name: school_year
-        description: School year specified by Spring year, e.g. the 2021-2022 year would be 2022. The school year is populated based on the year associated with the source ODS, which is assumed to contain data for only that school year (with rare exceptions for transcript/academic record data).
+        description: School year specified by Spring year, e.g. the 2021-2022 year would be 2022. The school year is populated based on the year associated with the source ODS, which is assumed to contain data for only that school year.
       - name: program_enroll_begin_date
       - name: program_enroll_end_date
       - name: direct_certification

--- a/models/core_warehouse/fct_student_school_food_service_program_associations.yml
+++ b/models/core_warehouse/fct_student_school_food_service_program_associations.yml
@@ -44,7 +44,7 @@ models:
       - name: k_school
       - name: tenant_code
       - name: school_year
-        description: School year specified by Spring year, e.g. the 2021-2022 year would be 2022. The school year is populated based on the year associated with the source ODS, which is assumed to contain data for only that school year.
+        description: "{{ doc('school_year_ods_pull') }}"
       - name: program_enroll_begin_date
       - name: program_enroll_end_date
       - name: direct_certification

--- a/models/core_warehouse/fct_student_school_food_service_program_associations.yml
+++ b/models/core_warehouse/fct_student_school_food_service_program_associations.yml
@@ -44,6 +44,7 @@ models:
       - name: k_school
       - name: tenant_code
       - name: school_year
+        description: School year specified by Spring year, e.g. the 2021-2022 year would be 2022. The school year is populated based on the year associated with the source ODS, which is assumed to contain data for only that school year (with rare exceptions for transcript/academic record data).
       - name: program_enroll_begin_date
       - name: program_enroll_end_date
       - name: direct_certification

--- a/models/core_warehouse/fct_student_section_association.yml
+++ b/models/core_warehouse/fct_student_section_association.yml
@@ -47,6 +47,7 @@ models:
         description: "Unique key for course section, foreign key reference to `dim_course_section`"
       - name: tenant_code
       - name: school_year
+        description: School year specified by Spring year, e.g. the 2021-2022 year would be 2022. The school year is populated based on the year associated with the source ODS, which is assumed to contain data for only that school year (with rare exceptions for transcript/academic record data).
       - name: begin_date
         description: "Month, day, and year of the student's entry or assignment to the section."
       - name: end_date

--- a/models/core_warehouse/fct_student_section_association.yml
+++ b/models/core_warehouse/fct_student_section_association.yml
@@ -47,7 +47,7 @@ models:
         description: "Unique key for course section, foreign key reference to `dim_course_section`"
       - name: tenant_code
       - name: school_year
-        description: "School year specified by Spring year, e.g. the 2021-2022 year would be 2022. Unlike most other tables, `school_year` here reflects a school year reference embedded directly in the source Ed-Fi record, rather than the year of the source ODS pull — so it can differ from the pull year in edge cases (e.g. calendar or schedule data that spans a year boundary)."
+        description: "{{ doc('school_year_source_reference') }}"
       - name: begin_date
         description: "Month, day, and year of the student's entry or assignment to the section."
       - name: end_date

--- a/models/core_warehouse/fct_student_section_association.yml
+++ b/models/core_warehouse/fct_student_section_association.yml
@@ -47,7 +47,7 @@ models:
         description: "Unique key for course section, foreign key reference to `dim_course_section`"
       - name: tenant_code
       - name: school_year
-        description: School year specified by Spring year, e.g. the 2021-2022 year would be 2022. The school year is populated based on the year associated with the source ODS, which is assumed to contain data for only that school year (with rare exceptions for transcript/academic record data).
+        description: "School year specified by Spring year, e.g. the 2021-2022 year would be 2022. Unlike most other tables, `school_year` here reflects a school year reference embedded directly in the source Ed-Fi record, rather than the year of the source ODS pull — so it can differ from the pull year in edge cases (e.g. calendar or schedule data that spans a year boundary)."
       - name: begin_date
         description: "Month, day, and year of the student's entry or assignment to the section."
       - name: end_date

--- a/models/core_warehouse/fct_student_section_attendance_event.yml
+++ b/models/core_warehouse/fct_student_section_attendance_event.yml
@@ -49,7 +49,7 @@ models:
         description: Unique identifier for the course section. Foreign key reference to dim_course_section.
       - name: tenant_code
       - name: school_year
-        description: School year specified by Spring year, e.g. the 2021-2022 year would be 2022. The school year is populated based on the year associated with the source ODS, which is assumed to contain data for only that school year (with rare exceptions for transcript/academic record data).
+        description: "School year specified by Spring year, e.g. the 2021-2022 year would be 2022. Unlike most other tables, `school_year` here reflects a school year reference embedded directly in the source Ed-Fi record, rather than the year of the source ODS pull — so it can differ from the pull year in edge cases (e.g. calendar or schedule data that spans a year boundary)."
       - name: attendance_event_date
         description: The date of the attendance event.
       - name: attendance_event_category

--- a/models/core_warehouse/fct_student_section_attendance_event.yml
+++ b/models/core_warehouse/fct_student_section_attendance_event.yml
@@ -49,6 +49,7 @@ models:
         description: Unique identifier for the course section. Foreign key reference to dim_course_section.
       - name: tenant_code
       - name: school_year
+        description: School year specified by Spring year, e.g. the 2021-2022 year would be 2022. The school year is populated based on the year associated with the source ODS, which is assumed to contain data for only that school year (with rare exceptions for transcript/academic record data).
       - name: attendance_event_date
         description: The date of the attendance event.
       - name: attendance_event_category

--- a/models/core_warehouse/fct_student_section_attendance_event.yml
+++ b/models/core_warehouse/fct_student_section_attendance_event.yml
@@ -49,7 +49,7 @@ models:
         description: Unique identifier for the course section. Foreign key reference to dim_course_section.
       - name: tenant_code
       - name: school_year
-        description: "School year specified by Spring year, e.g. the 2021-2022 year would be 2022. Unlike most other tables, `school_year` here reflects a school year reference embedded directly in the source Ed-Fi record, rather than the year of the source ODS pull — so it can differ from the pull year in edge cases (e.g. calendar or schedule data that spans a year boundary)."
+        description: "{{ doc('school_year_source_reference') }}"
       - name: attendance_event_date
         description: The date of the attendance event.
       - name: attendance_event_category

--- a/models/core_warehouse/fct_student_special_education_program_association.yml
+++ b/models/core_warehouse/fct_student_special_education_program_association.yml
@@ -43,7 +43,7 @@ models:
       - name: k_school
       - name: tenant_code
       - name: school_year
-        description: School year specified by Spring year, e.g. the 2021-2022 year would be 2022. The school year is populated based on the year associated with the source ODS, which is assumed to contain data for only that school year.
+        description: "{{ doc('school_year_ods_pull') }}"
       - name: program_enroll_begin_date
       - name: program_enroll_end_date
       - name: is_idea_eligible

--- a/models/core_warehouse/fct_student_special_education_program_association.yml
+++ b/models/core_warehouse/fct_student_special_education_program_association.yml
@@ -43,7 +43,7 @@ models:
       - name: k_school
       - name: tenant_code
       - name: school_year
-        description: School year specified by Spring year, e.g. the 2021-2022 year would be 2022. The school year is populated based on the year associated with the source ODS, which is assumed to contain data for only that school year (with rare exceptions for transcript/academic record data).
+        description: School year specified by Spring year, e.g. the 2021-2022 year would be 2022. The school year is populated based on the year associated with the source ODS, which is assumed to contain data for only that school year.
       - name: program_enroll_begin_date
       - name: program_enroll_end_date
       - name: is_idea_eligible

--- a/models/core_warehouse/fct_student_special_education_program_association.yml
+++ b/models/core_warehouse/fct_student_special_education_program_association.yml
@@ -43,6 +43,7 @@ models:
       - name: k_school
       - name: tenant_code
       - name: school_year
+        description: School year specified by Spring year, e.g. the 2021-2022 year would be 2022. The school year is populated based on the year associated with the source ODS, which is assumed to contain data for only that school year (with rare exceptions for transcript/academic record data).
       - name: program_enroll_begin_date
       - name: program_enroll_end_date
       - name: is_idea_eligible

--- a/models/core_warehouse/fct_student_subgroup.yml
+++ b/models/core_warehouse/fct_student_subgroup.yml
@@ -99,5 +99,5 @@ models:
       - name: k_student_xyear
       - name: tenant_code
       - name: school_year
-        description: School year specified by Spring year, e.g. the 2021-2022 year would be 2022. The school year is populated based on the year associated with the source ODS, which is assumed to contain data for only that school year (with rare exceptions for transcript/academic record data).
+        description: School year specified by Spring year, e.g. the 2021-2022 year would be 2022. The school year is populated based on the year associated with the source ODS, which is assumed to contain data for only that school year.
       - name: k_subgroup

--- a/models/core_warehouse/fct_student_subgroup.yml
+++ b/models/core_warehouse/fct_student_subgroup.yml
@@ -99,5 +99,5 @@ models:
       - name: k_student_xyear
       - name: tenant_code
       - name: school_year
-        description: School year specified by Spring year, e.g. the 2021-2022 year would be 2022. The school year is populated based on the year associated with the source ODS, which is assumed to contain data for only that school year.
+        description: "{{ doc('school_year_ods_pull') }}"
       - name: k_subgroup

--- a/models/core_warehouse/fct_student_subgroup.yml
+++ b/models/core_warehouse/fct_student_subgroup.yml
@@ -99,4 +99,5 @@ models:
       - name: k_student_xyear
       - name: tenant_code
       - name: school_year
+        description: School year specified by Spring year, e.g. the 2021-2022 year would be 2022. The school year is populated based on the year associated with the source ODS, which is assumed to contain data for only that school year (with rare exceptions for transcript/academic record data).
       - name: k_subgroup

--- a/models/core_warehouse/fct_student_title_i_part_a_program_association.yml
+++ b/models/core_warehouse/fct_student_title_i_part_a_program_association.yml
@@ -44,7 +44,7 @@ models:
       - name: k_school
       - name: tenant_code
       - name: school_year
-        description: School year specified by Spring year, e.g. the 2021-2022 year would be 2022. The school year is populated based on the year associated with the source ODS, which is assumed to contain data for only that school year (with rare exceptions for transcript/academic record data).
+        description: School year specified by Spring year, e.g. the 2021-2022 year would be 2022. The school year is populated based on the year associated with the source ODS, which is assumed to contain data for only that school year.
       - name: program_enroll_begin_date
       - name: program_enroll_end_date
       - name: title_i_part_a_participant_status

--- a/models/core_warehouse/fct_student_title_i_part_a_program_association.yml
+++ b/models/core_warehouse/fct_student_title_i_part_a_program_association.yml
@@ -44,6 +44,7 @@ models:
       - name: k_school
       - name: tenant_code
       - name: school_year
+        description: School year specified by Spring year, e.g. the 2021-2022 year would be 2022. The school year is populated based on the year associated with the source ODS, which is assumed to contain data for only that school year (with rare exceptions for transcript/academic record data).
       - name: program_enroll_begin_date
       - name: program_enroll_end_date
       - name: title_i_part_a_participant_status

--- a/models/core_warehouse/fct_student_title_i_part_a_program_association.yml
+++ b/models/core_warehouse/fct_student_title_i_part_a_program_association.yml
@@ -44,7 +44,7 @@ models:
       - name: k_school
       - name: tenant_code
       - name: school_year
-        description: School year specified by Spring year, e.g. the 2021-2022 year would be 2022. The school year is populated based on the year associated with the source ODS, which is assumed to contain data for only that school year.
+        description: "{{ doc('school_year_ods_pull') }}"
       - name: program_enroll_begin_date
       - name: program_enroll_end_date
       - name: title_i_part_a_participant_status

--- a/models/core_warehouse/msr_student_cumulative_attendance.yml
+++ b/models/core_warehouse/msr_student_cumulative_attendance.yml
@@ -27,7 +27,7 @@ models:
       - name: k_school
         description: Unique identifier for a school.
       - name: school_year
-        description: School year specified by Spring year, e.g. the 2021-2022 year would be 2022.
+        description: School year specified by Spring year, e.g. the 2021-2022 year would be 2022. The school year is populated based on the year associated with the source ODS, which is assumed to contain data for only that school year (with rare exceptions for transcript/academic record data).
       - name: tenant_code
         description: The tenant associated with the record.
       - name: days_absent

--- a/models/core_warehouse/msr_student_cumulative_attendance.yml
+++ b/models/core_warehouse/msr_student_cumulative_attendance.yml
@@ -27,7 +27,7 @@ models:
       - name: k_school
         description: Unique identifier for a school.
       - name: school_year
-        description: "School year specified by Spring year, e.g. the 2021-2022 year would be 2022. Unlike most other tables, `school_year` here reflects a school year reference embedded directly in the source Ed-Fi record, rather than the year of the source ODS pull — so it can differ from the pull year in edge cases (e.g. calendar or schedule data that spans a year boundary)."
+        description: "{{ doc('school_year_source_reference') }}"
       - name: tenant_code
         description: The tenant associated with the record.
       - name: days_absent

--- a/models/core_warehouse/msr_student_cumulative_attendance.yml
+++ b/models/core_warehouse/msr_student_cumulative_attendance.yml
@@ -27,7 +27,7 @@ models:
       - name: k_school
         description: Unique identifier for a school.
       - name: school_year
-        description: School year specified by Spring year, e.g. the 2021-2022 year would be 2022. The school year is populated based on the year associated with the source ODS, which is assumed to contain data for only that school year (with rare exceptions for transcript/academic record data).
+        description: "School year specified by Spring year, e.g. the 2021-2022 year would be 2022. Unlike most other tables, `school_year` here reflects a school year reference embedded directly in the source Ed-Fi record, rather than the year of the source ODS pull — so it can differ from the pull year in edge cases (e.g. calendar or schedule data that spans a year boundary)."
       - name: tenant_code
         description: The tenant associated with the record.
       - name: days_absent


### PR DESCRIPTION
<!---
Provide Title above, ensure it summarizes the work in the PR. Example PR titles templates:
* "feature/ (or build/): describe new functionality"
* "hotfix/: describe issue fix for immediate release"
* "bugfix/ (or fix/): describe issue fix, not necessary for immediate release"
* "docs/: adding or updating documentation"
-->

## Description & motivation
<!---
High level description your PR, and why you're making it. Is this linked to slack thread, Monday board, open
issue, a continuation to a previous PR? Link it here if relevant (use the "#" symbol for issues/PRs).
-->

### Motivation

This is a first pass at  SafeInsights work to improve existing DBT docs while writing documentation for the SCDE enclave, as documented in #SI-108 ([here](https://edanalytics.atlassian.net/browse/SI-108)). 

### Description

Fill in a description for every `school_year` column in `prod_wh` schema, so that a range of audiences understand both 
the sourcing mechanism and format of school_year variables within each table. This involved:
* Identifying the sourcing mechanism of the `school_year` variable for each specific `core_wh` table based on model lineage, and categorizing those into four main categories of `school_year` description
* Using docs blocks to store those four standard descriptions 
* Applying those descriptions to every `school_year` reference in the `core_warehouse/` models, which involved the following changes from existing documentation (note - there are 57 .yml files in there, and 11 validly have no `school_year` column):
    -  Filling out a new description when none existed (30 files)
    - Updating a description from an existing value to one of the new descriptions (14 files)
    - Adding a variable when `school_year` was present in the model but not in the docs (2 files)

## Breaking changes introduced by this PR:
<!---
Describe any breaking changes that are introduced. Take a wide approach to what might be 'breaking'. One example of a 'hidden' breaking change could be adding a new column. For most applications, this will not cause error, but if someone has configured a downstream query that references this column name from elsewhere, their query could break.

Make sure to include these breaking changes in the CHANGELOG.md
-->

I reeally doubt these are breaking changes, but will note just in case. I added school_year variable and descriptions to the following yml files:
* dim_class_period.yml
* fct_student_discipline_actions.yml

## PR Merge Priority:
<!---
This checklist helps the reviewers understand the level of priority for merging this PR.
A loose description of merging priority levels is:
Low: A week or more.
Medium: Within 3 days or less.
High: As soon as possible.
-->
- [ x] Low
- [ ] Medium
- [ ] High

<!---
If High Priority, explain why as a comment below.
-->

## Changes to existing files:
<!---
Include this section if you are changing any existing files or creating breaking changes to existing files. Label the model name and describe the logic behind the changes made, try to be very descriptive here. For example:
- `stg_model` : Describe any changes made to `stg_model` and why the changes where made.
- `src_staging` : Describe any changes made to `src_staging` and why the changes where made.
-->

Changes to every yml file in the `models/core_warehouse/` folder. To help organize, there are four broad categories that were used to update or fill in (for the first time) the `school_year` description.

### Category 1 — ODS Pull (24 files)

**Description**:  `school_year_ods_pull`

dim_student.yml, dim_learning_standard.yml, dim_parent.yml, dim_program.yml, fct_student_migrant_education_program_associations.yml, fct_student_program_association.yml, fct_student_special_education_program_association.yml, fct_student_title_i_part_a_program_association.yml, fct_student_homeless_program_association.yml, fct_student_school_food_service_program_associations.yml, fct_student_language_instruction_program_association.yml, fct_student_cte_program_associations.yml, fct_student_subgroup.yml, fct_student_parent_association.yml, dim_course.yml, dim_graduation_plan.yml, dim_cohort.yml, fct_student_cohort_association.yml, dim_discipline_incident.yml, fct_student_discipline_incident_behaviors.yml, fct_student_discipline_incident_summary.yml, fct_student_discipline_actions.yml, fct_student_discipline_actions_summary.yml, dim_class_period.yml

### Category 2

**Version A: School Year Source Reference, no fallback (12 files)**

**Description**: `school_year_source_reference`

fct_student_school_attendance_event.yml, fct_student_section_association.yml, fct_student_section_attendance_event.yml, fct_staff_section_association.yml, dim_school_calendar.yml, dim_calendar_date.yml, dim_course_section.yml, dim_session.yml, dim_grading_period.yml, fct_student_grades.yml, fct_student_daily_attendance.yml, msr_student_cumulative_attendance.yml

**Version B: School Year Source Reference, with fallback (2 files, unique text each)** 

fct_staff_school_association.yml:

**Description**:  `school_year_source_reference` +  "If that reference is missing, school_year falls back to the source ODS pull year."

fct_student_school_association.yml:

**Description**:  `school_year_source_reference` + "If that reference is missing, school_year falls back to a value inferred from entry_date using a school-year cutoff date that can vary by implementation."

### Category 3 — Assessment-derived (4 files, identical text)

**Description**:  `school_year_assessment`

fct_student_assessment.yml, dim_assessment.yml, dim_objective_assessment.yml, fct_student_objective_assessment.yml

### Category 4 — Academic Record, Required source field (4 files)

**Description**: `school_year_academic_record`

fct_student_academic_record.yml, fct_student_diploma.yml, fct_student_gpa.yml, fct_course_transcripts.yml

### Changes of particular note

The following files had prior descriptions that were unusual:
* dim_course: ""The school year passed to the Ed-Fi API when pulling this record from Course". When I traced back, I didn't see anything to distinguish it from the typical api_year based on single-year ODS sourcing.
* **dim_discipline_incident**: "Sourced from the year of the ODS, since Ed-Fi does not include school year in the model for discipline incidents". I'm not sure why this was particularly noted here? Is this an important differentiation from all the edfi models that just infer school_year from the ODS?
* dim_grading_period: "The identifier for the grading period school year." Real vague. I didn't see any differences from just inferred ODS year in the lineage here, so unsure why this had its own anomalous description.
* dim_graduation_plan: "The identifier for the grading period school year.". Yeah, I think this one was just copy-pasted from grading period. I also traced `school_year` back to the `api_year` in raw edfi models (`graduation_school_year` _is_ different, though).
* fct_student_assessment: "The school year for which the assessment was administered to a student.". That got overwritten with the complicated assessment assignment pathway.	
* fct_student_diploma: "The school year for which the diploma was awarded to a student.". I think the general noting that school_year here does not come from API year is well-represented from the updated description.

## New files created:
<!---
Include this section if you are creating any new files. Label the model name and describe the logic behind the changes made, try to be very descriptive here. For example:
- `stg_new_model` : Describe the purpose of `stg_new_model` and the logic behind creating the model.
- `src_new_staging` : Describe the purpose of `src_new_staging`.
-->

Added a new sub-folder in `/models/core_warehouse/` called `docs/`. 

Within that new sub-folder, added a new file `school_year_docs.md` containing the doc blocks definitions for the four categories of school year descriptions.

## Tests and QC done:
<!---
Describe any process that confirms that the files do what is expected, include screenshots if relevant. For example:
- Analyst replication confirmed that updates to `stg_model` new counts were correct.
- Executed a dbt project run and ensured it was successful.
-->

NOTE: I used Claude Code to do the majority of the categorization and lineage mapping, so that likely merits extra review on that alone.

*  I traced the lineage and confirmed the categorization for a small sub-sample of these pathways. 
* I manually verified that the documented categorization in this PR description matched the description implemented for each yml.

## edu_wh PR Review Checklist:
Make sure the following have been completed before approving this PR:
- [x ] Description of changes has been added to Unreleased section of [CHANGELOG.md](/CHANGELOG.md). Add under `## New Features` for features, etc.
- [ x] Code has been tested/checked for Databricks and Snowflake compatibility - EA engineers see Databricks checklist [here](https://edanalytics.slite.com/app/docs/LRjXFxVRAWA5ST) 
- [x ] Reviewer confirms the grain of all tables are unchanged, OR any changes are expected, communicated, and this PR is flagged as a breaking change (not for patch release)
- [ ] If a new configuration xwalk was added:
  - [ ] The code is written such that the xwalk is optional (preferred), and this behavior was tested, OR
  - [ ] The code is written such that the xwalk is required, and the required xwalk is added to edu_project_template, and this PR is flagged as breaking change (not for patch release)
  - [ ] A description for the new xwalk has been added to EDU documentation site [here](https://github.com/edanalytics/edu_docs/blob/main/docs/docs/manage_extend/reference/configure_dbt_xwalks.md) 
- [ ] If a new configuration variable was added:
  - [ ] The code is written such that the variable is optional (preferred), and this behavior was tested, OR
  - [ ] The code is written such that the variable is required, and a default value was added to edu_project_template, and this PR is flagged as breaking change (not for patch release)
  - [ ] A description for the new variable has been added to EDU documentation site [here](https://github.com/edanalytics/edu_docs/blob/main/docs/docs/manage_extend/reference/configure_dbt_vars.md) 

<!---## Future ToDos & Questions:-->
<!---
[Optional] Include any future steps and questions related to this PR.
-->

> [!IMPORTANT]
>  Questions 
> 1. Is the derive_school_year thing that will infer `school_year` from administration date for test-related tables (and entry date in student-school assocation) optional for implementations? If so, I will update language to note optional configuration.
> 2. Any suggested changes to the categories or standard descriptions? 
> 3.  I'm wondering about the "{{ doc('{docblock') }}" format for referencing the doc blocks, specifically - does that exact quotation format work with our DBT system? It does not exactly match the[ DBT docs blocks documentation](https://docs.getdbt.com/docs/build/documentation?version=2.0&name=Fusion#usage), which uses the format '{{ doc("docblock") }}' (single quotes outside, double quotes inside) in their example reference. I do not have DBT access, and this clearly uses some DBT placement, so I would definitely test that the format is working.