### PR TITLE
Add core warehouse models for Ed-Fi Survey Domain

### DIFF
--- a/models/core_warehouse/dim_survey.sql
+++ b/models/core_warehouse/dim_survey.sql
@@ -1,0 +1,29 @@
+{{
+    config(
+        post_hook=[
+            "alter table {{ this }} alter column k_survey set not null",
+            "alter table {{ this }} add primary key (k_survey)",
+        ]
+    )
+}}
+
+with stg_surveys as (
+    select * from {{ ref('stg_ef3__surveys') }}
+),
+-- Intermediate CTE w/ prefixed field references to make adding complexity later easier
+formatted as (
+    select
+        stg_surveys.k_survey,
+        stg_surveys.tenant_code,
+        stg_surveys.survey_id,
+        stg_surveys.survey_title,
+        stg_surveys.survey_category,
+        stg_surveys.school_year,
+        stg_surveys.ed_org_id,
+        stg_surveys.ed_org_type,
+        stg_surveys.school_id,
+        stg_surveys.session_name,
+        stg_surveys.number_administered
+    from stg_surveys
+)
+select * from formatted

--- a/models/core_warehouse/dim_survey.yml
+++ b/models/core_warehouse/dim_survey.yml
@@ -1,0 +1,41 @@
+version: 2
+
+models:
+  - name: dim_survey
+    description: "Survey definitions and metadata"
+    config:
+      tags: ['survey', 'core']
+      enabled: "{{ var('src:domain:survey:enabled', True) }}"
+    columns:
+      - name: k_survey
+        description: "Surrogate key for survey"
+        tests:
+          - unique
+          - not_null
+
+      - name: survey_id
+        description: "Natural key identifier for the survey"
+
+      - name: survey_title
+        description: "Title of the survey"
+
+      - name: survey_category
+        description: "Category or type of survey"
+
+      - name: school_year
+        description: "School year when the survey was administered"
+
+      - name: ed_org_id
+        description: "Education organization identifier"
+
+      - name: ed_org_type
+        description: "Type of education organization (e.g., SEA, LEA, School)"
+
+      - name: school_id
+        description: "School identifier if survey is school-specific"
+
+      - name: session_name
+        description: "Session name when survey was administered"
+
+      - name: number_administered
+        description: "Number of times the survey was administered"

--- a/models/core_warehouse/dim_survey_question.sql
+++ b/models/core_warehouse/dim_survey_question.sql
@@ -1,0 +1,25 @@
+-- TODO: make indentation more consistent
+{{
+  config(
+    post_hook=[
+        "alter table {{ this }} alter column k_survey_question set not null",
+        "alter table {{ this }} add primary key (k_survey_question)",
+        "alter table {{ this }} add constraint fk_{{ this.name }}_survey foreign key (k_survey) references {{ ref('dim_survey') }}",
+    ]
+  )
+}}
+
+with stg_survey_questions as (
+    select * from {{ ref('stg_ef3__survey_questions') }}
+),
+formatted as (
+    select
+        stg_survey_questions.k_survey_question,
+        stg_survey_questions.k_survey,
+        stg_survey_questions.tenant_code,
+        stg_survey_questions.question_code,
+        stg_survey_questions.question_text,
+        stg_survey_questions.question_form
+    from stg_survey_questions
+)
+select * from formatted

--- a/models/core_warehouse/dim_survey_question.yml
+++ b/models/core_warehouse/dim_survey_question.yml
@@ -1,0 +1,31 @@
+version: 2
+
+models:
+  - name: dim_survey_question
+    description: "Survey question definitions"
+    config:
+      tags: ['survey', 'core']
+      enabled: "{{ var('src:domain:survey:enabled', True) }}"
+    columns:
+      - name: k_survey_question
+        description: "Surrogate key for survey question"
+        tests:
+          - unique
+          - not_null
+
+      - name: k_survey
+        description: "Foreign key to dim_survey"
+        tests:
+          - not_null
+          - relationships:
+              to: ref('dim_survey')
+              field: k_survey
+
+      - name: question_code
+        description: "Code or identifier for the question"
+
+      - name: question_text
+        description: "Full text of the survey question"
+
+      - name: question_form
+        description: "Form or type of question (e.g., multiple choice, free text)"

--- a/models/core_warehouse/dim_survey_question_response_choice.sql
+++ b/models/core_warehouse/dim_survey_question_response_choice.sql
@@ -1,0 +1,24 @@
+{{
+  config(
+    post_hook=[
+        "alter table {{ this }} alter column k_survey_question set not null",
+        "alter table {{ this }} alter column sort_order set not null",
+        "alter table {{ this }} add primary key (k_survey_question, sort_order)",
+        "alter table {{ this }} add constraint fk_{{ this.name }}_survey_question foreign key (k_survey_question) references {{ ref('dim_survey_question') }}",
+    ]
+  )
+}}
+
+with stg_survey_question_response_choices as (
+    select * from {{ ref('stg_ef3__survey_questions__response_choices') }}
+),
+formatted as (
+    select
+        stg_survey_question_response_choices.k_survey_question,
+        stg_survey_question_response_choices.tenant_code,
+        stg_survey_question_response_choices.sort_order,
+        stg_survey_question_response_choices.numeric_value,
+        stg_survey_question_response_choices.text_value
+    from stg_survey_question_response_choices
+)
+select * from formatted

--- a/models/core_warehouse/dim_survey_question_response_choice.yml
+++ b/models/core_warehouse/dim_survey_question_response_choice.yml
@@ -1,0 +1,32 @@
+version: 2
+
+models:
+  - name: dim_survey_question_response_choice
+    description: "Available response choices for survey questions"
+    config:
+      tags: ['survey', 'core']
+      enabled: "{{ var('src:domain:survey:enabled', True) }}"
+    tests:
+      - dbt_utils.unique_combination_of_columns:
+          combination_of_columns:
+            - k_survey_question
+            - sort_order
+    columns:
+      - name: k_survey_question
+        description: "Foreign key to dim_survey_question"
+        tests:
+          - not_null
+          - relationships:
+              to: ref('dim_survey_question')
+              field: k_survey_question
+
+      - name: sort_order
+        description: "Sort order for the response choice"
+        tests:
+          - not_null
+
+      - name: numeric_value
+        description: "Numeric value associated with this choice (e.g., 4 for 'Strongly Agree')"
+
+      - name: text_value
+        description: "Text label for this choice (e.g., 'Strongly Agree')"

--- a/models/core_warehouse/fct_survey_question_response.sql
+++ b/models/core_warehouse/fct_survey_question_response.sql
@@ -1,0 +1,39 @@
+{{
+  config(
+    post_hook=[
+        "alter table {{ this }} alter column k_survey_response set not null",
+        "alter table {{ this }} alter column k_survey_question set not null",
+        "alter table {{ this }} add primary key (k_survey_response, k_survey_question)",
+        "alter table {{ this }} add constraint fk_{{ this.name }}_survey_response foreign key (k_survey_response) references {{ ref('fct_survey_response') }}",
+        "alter table {{ this }} add constraint fk_{{ this.name }}_survey_question foreign key (k_survey_question) references {{ ref('dim_survey_question') }}",
+        "alter table {{ this }} add constraint fk_{{ this.name }}_survey foreign key (k_survey) references {{ ref('dim_survey') }}",
+    ]
+  )
+}}
+
+with stg_survey_question_responses as (
+    select * from {{ ref('stg_ef3__survey_question_responses') }}
+),
+fct_survey_response as (
+    select * from {{ ref('fct_survey_response') }}
+),
+formatted as (
+    select
+        stg_survey_question_responses.k_survey_response,
+        stg_survey_question_responses.k_survey_question,
+        fct_survey_response.k_survey,
+        fct_survey_response.k_student,
+        fct_survey_response.k_staff,
+        fct_survey_response.k_parent,
+        stg_survey_question_responses.tenant_code,
+        fct_survey_response.respondent_type,
+        fct_survey_response.location,
+        stg_survey_question_responses.comment,
+        stg_survey_question_responses.no_response,
+        fct_survey_response.response_date,
+        1 as question_response_count
+    from stg_survey_question_responses
+    left join fct_survey_response
+        on stg_survey_question_responses.k_survey_response = fct_survey_response.k_survey_response
+)
+select * from formatted

--- a/models/core_warehouse/fct_survey_question_response.yml
+++ b/models/core_warehouse/fct_survey_question_response.yml
@@ -1,0 +1,70 @@
+version: 2
+
+models:
+  - name: fct_survey_question_response
+    description: "Fact table for survey question responses. Grain: 1 submitted response to 1 survey question"
+    config:
+      tags: ['survey', 'core']
+      enabled: "{{ var('src:domain:survey:enabled', True) }}"
+    tests:
+      - dbt_utils.unique_combination_of_columns:
+          combination_of_columns:
+            - k_survey_response
+            - k_survey_question
+    columns:
+      - name: k_survey_response
+        description: "Foreign key to fct_survey_response"
+        tests:
+          - not_null
+          - relationships:
+              to: ref('fct_survey_response')
+              field: k_survey_response
+
+      - name: k_survey_question
+        description: "Foreign key to dim_survey_question"
+        tests:
+          - not_null
+          - relationships:
+              to: ref('dim_survey_question')
+              field: k_survey_question
+
+      - name: k_survey
+        description: "Foreign key to dim_survey (for filtering/aggregation)"
+        tests:
+          - not_null
+          - relationships:
+              to: ref('dim_survey')
+              field: k_survey
+
+      - name: k_student
+        description: "Foreign key to dim_student (nullable, from parent fct_survey_response)"
+
+      - name: k_staff
+        description: "Foreign key to dim_staff (nullable, from parent fct_survey_response)"
+
+      - name: k_parent
+        description: "Foreign key to dim_parent (nullable, from parent fct_survey_response)"
+
+      - name: respondent_type
+        description: "Type of respondent (from parent fct_survey_response)"
+        tests:
+          - not_null
+          - accepted_values:
+              values: ['student', 'staff', 'contact', 'anonymous']
+
+      - name: location
+        description: "Location where question was answered"
+
+      - name: comment
+        description: "Optional comment or explanation for the response"
+
+      - name: no_response
+        description: "Indicator if respondent did not answer this question"
+
+      - name: response_date
+        description: "Date question was answered"
+
+      - name: question_response_count
+        description: "Measure field, always 1 for counting question responses"
+        tests:
+          - not_null

--- a/models/core_warehouse/fct_survey_question_response_value.sql
+++ b/models/core_warehouse/fct_survey_question_response_value.sql
@@ -1,0 +1,43 @@
+{{
+  config(
+    post_hook=[
+        "alter table {{ this }} alter column k_survey_response set not null",
+        "alter table {{ this }} alter column k_survey_question set not null",
+        "alter table {{ this }} alter column question_response_value_id set not null",
+        "alter table {{ this }} add primary key (k_survey_response, k_survey_question, question_response_value_id)",
+        "alter table {{ this }} add constraint fk_{{ this.name }}_survey_question_response foreign key (k_survey_response, k_survey_question) references {{ ref('fct_survey_question_response') }}",
+        "alter table {{ this }} add constraint fk_{{ this.name }}_survey foreign key (k_survey) references {{ ref('dim_survey') }}",
+    ]
+  )
+}}
+
+with stg_survey_question_response_values as (
+    select * from {{ ref('stg_ef3__survey_question_responses__values') }}
+),
+fct_survey_question_response as (
+    select * from {{ ref('fct_survey_question_response') }}
+),
+formatted as (
+    select
+        stg_survey_question_response_values.k_survey_response,
+        stg_survey_question_response_values.k_survey_question,
+        stg_survey_question_response_values.tenant_code,
+        stg_survey_question_response_values.question_response_value_id,
+        fct_survey_question_response.k_survey,
+        fct_survey_question_response.k_student,
+        fct_survey_question_response.k_staff,
+        fct_survey_question_response.k_parent,
+        fct_survey_question_response.respondent_type,
+        stg_survey_question_response_values.numeric_response,
+        stg_survey_question_response_values.text_response,
+        fct_survey_question_response.location,
+        fct_survey_question_response.comment,
+        fct_survey_question_response.no_response,
+        fct_survey_question_response.response_date,
+        1 as question_response_value_count
+    from stg_survey_question_response_values
+    left join fct_survey_question_response
+        on stg_survey_question_response_values.k_survey_response = fct_survey_question_response.k_survey_response
+        and stg_survey_question_response_values.k_survey_question = fct_survey_question_response.k_survey_question
+)
+select * from formatted

--- a/models/core_warehouse/fct_survey_question_response_value.yml
+++ b/models/core_warehouse/fct_survey_question_response_value.yml
@@ -1,0 +1,76 @@
+version: 2
+
+models:
+  - name: fct_survey_question_response_value
+    description: "Fact table for individual response values. Grain: 1 selected/entered value for 1 survey question response"
+    config:
+      tags: ['survey', 'core']
+      enabled: "{{ var('src:domain:survey:enabled', True) }}"
+    tests:
+      - dbt_utils.unique_combination_of_columns:
+          combination_of_columns:
+            - k_survey_response
+            - k_survey_question
+            - question_response_value_id
+    columns:
+      - name: k_survey_response
+        description: "Foreign key to fct_survey_response"
+        tests:
+          - not_null
+
+      - name: k_survey_question
+        description: "Foreign key to dim_survey_question"
+        tests:
+          - not_null
+
+      - name: question_response_value_id
+        description: "Identifier for this specific response value"
+        tests:
+          - not_null
+
+      - name: k_survey
+        description: "Foreign key to dim_survey (for filtering/aggregation)"
+        tests:
+          - not_null
+          - relationships:
+              to: ref('dim_survey')
+              field: k_survey
+
+      - name: k_student
+        description: "Foreign key to dim_student (nullable, from parent)"
+
+      - name: k_staff
+        description: "Foreign key to dim_staff (nullable, from parent)"
+
+      - name: k_parent
+        description: "Foreign key to dim_parent (nullable, from parent)"
+
+      - name: respondent_type
+        description: "Type of respondent (from parent)"
+        tests:
+          - not_null
+          - accepted_values:
+              values: ['student', 'staff', 'contact', 'anonymous']
+
+      - name: numeric_response
+        description: "Numeric value of the response"
+
+      - name: text_response
+        description: "Text value of the response. May contain delimited multi-select values."
+
+      - name: location
+        description: "Location where response value was provided"
+
+      - name: comment
+        description: "Optional comment or explanation"
+
+      - name: no_response
+        description: "Indicator if respondent did not provide this value"
+
+      - name: response_date
+        description: "Date response value was provided"
+
+      - name: question_response_value_count
+        description: "Measure field, always 1 for counting response values"
+        tests:
+          - not_null

--- a/models/core_warehouse/fct_survey_response.sql
+++ b/models/core_warehouse/fct_survey_response.sql
@@ -1,0 +1,37 @@
+{{
+  config(
+    post_hook=[
+        "alter table {{ this }} alter column k_survey_response set not null",
+        "alter table {{ this }} add primary key (k_survey_response)",
+        "alter table {{ this }} add constraint fk_{{ this.name }}_survey foreign key (k_survey) references {{ ref('dim_survey') }}",
+    ]
+  )
+}}
+
+with stg_survey_responses as (
+    select * from {{ ref('stg_ef3__survey_responses') }}
+),
+formatted as (
+    select
+        stg_survey_responses.k_survey_response,
+        stg_survey_responses.k_survey,
+        stg_survey_responses.k_student,
+        stg_survey_responses.k_staff,
+        stg_survey_responses.k_contact as k_parent,
+        stg_survey_responses.tenant_code,
+        stg_survey_responses.survey_response_id,
+        case
+            when stg_survey_responses.k_student is not null then 'student'
+            when stg_survey_responses.k_staff is not null then 'staff'
+            when stg_survey_responses.k_contact is not null then 'contact'
+            else 'anonymous'
+        end as respondent_type,
+        stg_survey_responses.electronic_mail_address,
+        stg_survey_responses.full_name,
+        stg_survey_responses.location,
+        stg_survey_responses.response_date,
+        stg_survey_responses.completion_time_seconds,
+        1 as response_count
+    from stg_survey_responses
+)
+select * from formatted

--- a/models/core_warehouse/fct_survey_response.yml
+++ b/models/core_warehouse/fct_survey_response.yml
@@ -1,0 +1,61 @@
+version: 2
+
+models:
+  - name: fct_survey_response
+    description: "Fact table for survey responses. Grain: 1 submitted survey response"
+    config:
+      tags: ['survey', 'core']
+      enabled: "{{ var('src:domain:survey:enabled', True) }}"
+    columns:
+      - name: k_survey_response
+        description: "Surrogate key for survey response"
+        tests:
+          - unique
+          - not_null
+
+      - name: k_survey
+        description: "Foreign key to dim_survey"
+        tests:
+          - not_null
+          - relationships:
+              to: ref('dim_survey')
+              field: k_survey
+
+      - name: k_student
+        description: "Foreign key to dim_student (nullable)"
+
+      - name: k_staff
+        description: "Foreign key to dim_staff (nullable)"
+
+      - name: k_parent
+        description: "Foreign key to dim_parent (nullable)"
+
+      - name: survey_response_id
+        description: "Natural key identifier for the survey response"
+
+      - name: respondent_type
+        description: "Type of respondent"
+        tests:
+          - not_null
+          - accepted_values:
+              values: ['student', 'staff', 'contact', 'anonymous']
+
+      - name: electronic_mail_address
+        description: "Email address of respondent"
+
+      - name: full_name
+        description: "Full name of respondent"
+
+      - name: location
+        description: "Location where survey was taken"
+
+      - name: response_date
+        description: "Date survey was submitted"
+
+      - name: completion_time_seconds
+        description: "Time in seconds to complete the survey"
+
+      - name: response_count
+        description: "Measure field, always 1 for counting responses"
+        tests:
+          - not_null


### PR DESCRIPTION
## Summary

Initial core warehouse star schema for the Ed-Fi Survey Domain, per the [Q2.26 Survey Domain Models](https://edanalytics.slite.com/app/docs/-uBvjCAmjCIS8N) tech spec. Supports the SC School Climate Survey (Resonant) work.

**Dimensions**
- `dim_survey` — survey definitions and metadata
- `dim_survey_question` — question definitions
- `dim_survey_question_response_choice` — available response choices (kept as a separate entity; joins to response values only under specific circumstances, per the spec's "variable join key" note)

**Facts** (three grains, coarsest → finest)
- `fct_survey_response` — 1 submitted survey response
- `fct_survey_question_response` — 1 response to 1 question
- `fct_survey_question_response_value` — 1 selected/entered value per question response

## Design notes
- Respondent identity uses direct respondent keys on the facts (`k_student`, `k_staff`, `k_parent`) with a derived `respondent_type`, rather than a separate respondent dimension — matches the spec and avoids snowflaking. `respondent_type` is derived from the staging keys, not from join success.
- The spec references `dim_contact`; this package uses the existing `dim_parent` (`k_parent`) instead, for consistency with the rest of `edu_wh`. The staging `k_contact` column is aliased to `k_parent` in `fct_survey_response`.
- Multi-select delimited-text parsing (e.g. `Tutoring;Counseling;Mentoring` → one row per value) is **not** implemented in this initial version — flagged as an open decision in the spec.
- Respondent-key joins are explicit `left join`s so orphaned rows surface via `not_null`/PK constraints instead of being silently dropped.

## Open questions / follow-ups
- Whether to build delimited multi-select parsing (and how to configure delimiters per integration).
- Participation-rate denominators (survey eligibility) are out of scope until source data is available.

🤖 Generated with [Claude Code](https://claude.com/claude-code)