### PR TITLE
Refactor/fct_student_school_association active enrollment flag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,10 @@
 # Unreleased
 ## New features
 ## Under the hood
+- Refactored `fct_student_school_association` to move the enrollment status logic into a new `bld_ef3__stu_sch_assoc__enrollment_flags` build model. The build now calculates the individual flags that make up active enrollment, while the fact model combines those flags into the final `is_active_enrollment` definition, making the logic easier to follow and maintain.
+
 ## Fixes
+- Fixed `is_active_enrollment` in `fct_student_school_association`, which made current enrollments inactive when data for the next school year was loaded before that year had actually started. The active school year is now based on the most recent school year that has begun, using the first school day and falling back to `entry_date` when no calendar match is available, rather than using the most recent school year loaded in general.
 
 # edu_wh v0.7.0
 ## New features

--- a/models/build/edfi_3/_edfi_3.yml
+++ b/models/build/edfi_3/_edfi_3.yml
@@ -10,6 +10,9 @@ models:
   - name: bld_ef3__school_calendar_windows
     config:
       tags: ['core']
+  - name: bld_ef3__stu_sch_assoc__enrollment_flags
+    config:
+      tags: ['core']
   - name: bld_ef3__wide_ids_lea
     config:
       tags: ['core']

--- a/models/build/edfi_3/bld_ef3__stu_sch_assoc__enrollment_flags.sql
+++ b/models/build/edfi_3/bld_ef3__stu_sch_assoc__enrollment_flags.sql
@@ -1,0 +1,163 @@
+with stg_stu_school as (
+    select * from {{ ref('stg_ef3__student_school_associations') }}
+),
+
+dim_student as (
+    select * from {{ ref('dim_student') }}
+),
+
+dim_school as (
+    select * from {{ ref('dim_school') }}
+),
+
+dim_school_calendar as (
+    select * from {{ ref('dim_school_calendar') }}
+),
+
+bld_school_calendar_windows as (
+    select * from {{ ref('bld_ef3__school_calendar_windows') }}
+),
+
+single_calendar_schools as (
+    -- some implementations may not provide a school calendar link because
+    -- their system only allows one calendar per school anyway.
+    -- we will detect these cases and fill in missing school calendars
+    -- only when doing so is unambiguous
+    select * from dim_school_calendar
+    qualify 1 = count(*) over(partition by k_school, school_year)
+),
+
+valid_stu_school_records as (
+
+    select
+        -- exclude the raw calendar reference so the resolved value below
+        -- can take over the k_school_calendar name
+        {{ edu_edfi_source.star('stg_stu_school', except=['k_school_calendar']) }},
+
+        dim_school.k_lea,
+
+        -- the enrollment's raw calendar reference, resolved: the direct match
+        -- against dim_school_calendar when it exists, otherwise the school's
+        -- only calendar when that choice is unambiguous
+        coalesce(
+            dim_school_calendar.k_school_calendar,
+            single_calendar_schools.k_school_calendar
+        ) as k_school_calendar,
+
+        -- first_school_day to decide whether a school year has begun,
+        -- last_school_day for the year-end buffer check
+        bld_school_calendar_windows.first_school_day,
+        bld_school_calendar_windows.last_school_day
+
+    from stg_stu_school
+    -- these joins are filters as much as lookups: an enrollment with no
+    -- matching student or school row is dropped, and must be dropped here so
+    -- it does not vote in the is_active_school_year window below
+    join dim_student
+        on stg_stu_school.k_student = dim_student.k_student
+    join dim_school
+        on stg_stu_school.k_school = dim_school.k_school
+    left join dim_school_calendar
+        on stg_stu_school.k_school_calendar = dim_school_calendar.k_school_calendar
+    left join single_calendar_schools
+        on stg_stu_school.k_school = single_calendar_schools.k_school
+        and stg_stu_school.school_year = single_calendar_schools.school_year
+    -- the windows join keys on the direct calendar match only, never the
+    -- single-calendar fallback
+    left join bld_school_calendar_windows
+        on stg_stu_school.k_school = bld_school_calendar_windows.k_school
+        and stg_stu_school.school_year = bld_school_calendar_windows.school_year
+        and equal_null(
+            dim_school_calendar.k_school_calendar,
+            bld_school_calendar_windows.k_school_calendar
+        )
+
+    where true
+    {%- if var('edu:enroll:exclude_exit_before_first_day', True) %}
+      {#- allow implementations with exclusive exit dates to still keep first-day exits -#}
+      {%- set first_day_inclusive = var('edu:enroll:first_day_exit_date_inclusive', var('edu:enroll:exit_withdraw_date_inclusive', True)) %}
+        -- exclude students who exited before the first school day
+        and (
+            {{ date_within_end_date(
+                'bld_school_calendar_windows.first_school_day',
+                'stg_stu_school.exit_withdraw_date',
+                first_day_inclusive
+            ) }}
+            or bld_school_calendar_windows.first_school_day is null
+        )
+    {%- endif %}
+        -- make sure exit occurred on or after entry
+        and (
+            stg_stu_school.exit_withdraw_date is null
+            or stg_stu_school.exit_withdraw_date >= stg_stu_school.entry_date
+        )
+    {%- set excl_withdraw_codes = var('edu:enroll:exclude_withdraw_codes') %}
+    {%- if excl_withdraw_codes is string %}
+      {%- set excl_withdraw_codes = [excl_withdraw_codes] %}
+    {%- endif %}
+    {%- if excl_withdraw_codes | length %}
+        -- drop invalid enrollments while retaining rows without an exit type
+        and (
+            stg_stu_school.exit_withdraw_type not in (
+                '{{ excl_withdraw_codes | join("', '") }}'
+            )
+            or stg_stu_school.exit_withdraw_type is null
+        )
+    {%- endif %}
+    {%- if var('edu:enroll:exclude_cross_year_enrollments', False) %}
+        -- drop enrollments whose year disagrees with the student record's year
+        and dim_student.school_year = stg_stu_school.school_year
+    {%- endif %}
+
+),
+
+enrollment_status_flags as (
+
+    select
+        *,
+
+        -- is this row's school year the newest one that has actually begun
+        -- for this tenant? falls back to entry_date when the calendar
+        -- didn't match, so tenants with missing calendar data aren't
+        -- stranded. using the newest year *loaded* would strand current
+        -- enrollments whenever next year's data is ingested early.
+        school_year = max(
+            iff(
+                coalesce(first_school_day, entry_date) <= current_date(),
+                school_year,
+                null
+            )
+        ) over (
+            partition by tenant_code
+        ) as is_active_school_year,
+
+        entry_date <= current_date() as has_enrollment_started,
+
+        -- is today still within this enrollment's end boundary? normally that
+        -- boundary is exit_withdraw_date, but when the year-end buffer is
+        -- configured a student who exited within buffer_days of
+        -- last_school_day also counts, until the calendar year rolls over.
+        (
+            {{ date_within_end_date(
+                'current_date()',
+                'exit_withdraw_date',
+                var('edu:enroll:exit_withdraw_date_inclusive', True)
+            ) }}
+            {%- set buffer_days = var('edu:enroll:year_end_active_buffer_days', none) %}
+            {%- if buffer_days is not none %}
+            or (
+                -- jinja negates, rather than emitting a literal "-" prefix:
+                -- a negative buffer_days would otherwise render as "--5",
+                -- which SQL reads as the start of a line comment
+                exit_withdraw_date
+                    >= dateadd(day, {{ -buffer_days }}, last_school_day)
+                and year(last_school_day) = year(current_date())
+            )
+            {%- endif %}
+        ) as is_within_effective_end_date
+
+    from valid_stu_school_records
+
+)
+
+select * from enrollment_status_flags

--- a/models/build/edfi_3/bld_ef3__stu_sch_assoc__enrollment_flags.sql
+++ b/models/build/edfi_3/bld_ef3__stu_sch_assoc__enrollment_flags.sql
@@ -1,3 +1,53 @@
+{#-
+    enrollment behavior is configurable because source systems do not all
+    represent enrollment dates and withdrawal records the same way.
+
+    these values control which enrollment records survive validation and how
+    active enrollment status is calculated later in the model. they are resolved
+    once here to keep the ctes below easier to read and understand.
+-#}
+
+    {#- controls whether the model removes exits before the first day of school. -#}
+    {%- set exclude_exit_before_first_day = var('edu:enroll:exclude_exit_before_first_day', true) -%}
+
+    {#- controls whether a student is still considered enrolled on exit_withdraw_date. -#}
+    {%- set exit_date_inclusive = var('edu:enroll:exit_withdraw_date_inclusive', true) -%}
+
+    {#-
+        controls whether a student who exits on the first school day is treated
+        as having enrolled that year or as exiting before enrollment began.
+        defaults to the exit-date behavior above.
+    -#}
+    {%- set first_day_inclusive = var('edu:enroll:first_day_exit_date_inclusive', exit_date_inclusive) -%}
+
+    {#-
+        withdrawal codes that indicate the student was recorded as enrolled but never actually attended. 
+        records with these codes are removed later.
+    -#}
+    {%- set excl_withdraw_codes = var('edu:enroll:exclude_withdraw_codes') -%}
+    {%- if excl_withdraw_codes is string -%}
+        {%- set excl_withdraw_codes = [excl_withdraw_codes] -%}
+    {%- endif -%}
+
+    {#-
+        controls whether an enrollment is removed when the enrollment school year does not
+        match the school year on the corresponding dim_student record.
+    -#}
+    {%- set exclude_cross_year = var('edu:enroll:exclude_cross_year_enrollments', false) -%}
+
+    {#-
+        when configured, students who exit within this many days of last_school_day
+        can remain active through the end of that calendar year.
+
+        example:
+        - buffer_days = 5
+        - last_school_day = 2026-06-15
+        - exit_withdraw_date = 2026-06-12
+        - result: the student qualifies for the year-end extension
+    -#}
+    {%- set buffer_days = var('edu:enroll:year_end_active_buffer_days', none) -%}
+
+
 with stg_stu_school as (
     select * from {{ ref('stg_ef3__student_school_associations') }}
 ),
@@ -19,51 +69,90 @@ bld_school_calendar_windows as (
 ),
 
 single_calendar_schools as (
-    -- some implementations may not provide a school calendar link because
-    -- their system only allows one calendar per school anyway.
-    -- we will detect these cases and fill in missing school calendars
-    -- only when doing so is unambiguous
+
+    -- some implementations do not link enrollments to a specific calendar because each school only has one. 
+    -- when there is exactly one option, we can safely use it as a fallback.
     select * from dim_school_calendar
     qualify 1 = count(*) over(partition by k_school, school_year)
+
 ),
 
-valid_stu_school_records as (
+stu_school_records as (
 
     select
-        -- exclude the raw calendar reference so the resolved value below
-        -- can take over the k_school_calendar name
+        -- select all enrollment columns except k_school_calendar because the calendar
+        -- key is replaced below with the direct match or single-calendar fallback.
         {{ edu_edfi_source.star('stg_stu_school', except=['k_school_calendar']) }},
 
         dim_school.k_lea,
 
-        -- the enrollment's raw calendar reference, resolved: the direct match
-        -- against dim_school_calendar when it exists, otherwise the school's
-        -- only calendar when that choice is unambiguous
+        -- prefer the calendar attached to the enrollment.
+        -- if it is missing, use the school calendar only when there is one unambiguous option.
         coalesce(
             dim_school_calendar.k_school_calendar,
             single_calendar_schools.k_school_calendar
         ) as k_school_calendar,
 
-        -- first_school_day to decide whether a school year has begun,
-        -- last_school_day for the year-end buffer check
         bld_school_calendar_windows.first_school_day,
-        bld_school_calendar_windows.last_school_day
+        bld_school_calendar_windows.last_school_day,
+
+        -- these flags will help us identify which enrollment records to keep
+        -- when calculating active enrollments.
+
+        -- flag 1: 
+            -- keep the enrollment only if the exit date is on or after the first school day.
+            -- if no calendar is available, keep the record because there is no
+            -- reliable first school day to compare against.
+        (
+            {{ date_within_end_date(
+                'bld_school_calendar_windows.first_school_day',
+                'stg_stu_school.exit_withdraw_date',
+                first_day_inclusive
+            ) }}
+            or bld_school_calendar_windows.first_school_day is null
+        ) as is_exit_on_or_after_first_day,
+
+        -- flag 2:
+            -- keep the enrollment only if it does not end before its entry date.
+            -- example:
+                -- valid:   entry_date = 08/20/2026 and exit_withdraw_date = 08/20/2026.
+                -- invalid: entry_date = 08/20/2026 and exit_withdraw_date = 08/10/2026.
+        (
+            stg_stu_school.exit_withdraw_date is null
+            or stg_stu_school.exit_withdraw_date >= stg_stu_school.entry_date
+        ) as is_exit_on_or_after_entry,
+
+        -- flag 3:
+            -- keep the enrollment only if its withdrawal code does not indicate that the student never actually enrolled.
+        {%- if excl_withdraw_codes | length %}
+        (
+            stg_stu_school.exit_withdraw_type not in (
+                '{{ excl_withdraw_codes | join("', '") }}'
+            )
+            or stg_stu_school.exit_withdraw_type is null
+        ) as has_retained_withdraw_type
+        {%- else %}
+        true as has_retained_withdraw_type
+        {%- endif %},
+
+        -- flag 4:
+            -- keep the enrollment only if its school_year matches the school_year on
+            -- the student record joined by k_student.
+        dim_student.school_year = stg_stu_school.school_year as is_same_year_as_student_record
 
     from stg_stu_school
-    -- these joins are filters as much as lookups: an enrollment with no
-    -- matching student or school row is dropped, and must be dropped here so
-    -- it does not vote in the is_active_school_year window below
+    -- student and school records are required, so these joins also filter.
     join dim_student
         on stg_stu_school.k_student = dim_student.k_student
     join dim_school
         on stg_stu_school.k_school = dim_school.k_school
+    -- these are left joins because the calendar may not be available for every enrollment record.
     left join dim_school_calendar
         on stg_stu_school.k_school_calendar = dim_school_calendar.k_school_calendar
     left join single_calendar_schools
         on stg_stu_school.k_school = single_calendar_schools.k_school
         and stg_stu_school.school_year = single_calendar_schools.school_year
-    -- the windows join keys on the direct calendar match only, never the
-    -- single-calendar fallback
+    -- calendar windows only use the direct calendar match, not the fallback.
     left join bld_school_calendar_windows
         on stg_stu_school.k_school = bld_school_calendar_windows.k_school
         and stg_stu_school.school_year = bld_school_calendar_windows.school_year
@@ -72,41 +161,33 @@ valid_stu_school_records as (
             bld_school_calendar_windows.k_school_calendar
         )
 
-    where true
-    {%- if var('edu:enroll:exclude_exit_before_first_day', True) %}
-      {#- allow implementations with exclusive exit dates to still keep first-day exits -#}
-      {%- set first_day_inclusive = var('edu:enroll:first_day_exit_date_inclusive', var('edu:enroll:exit_withdraw_date_inclusive', True)) %}
-        -- exclude students who exited before the first school day
-        and (
-            {{ date_within_end_date(
-                'bld_school_calendar_windows.first_school_day',
-                'stg_stu_school.exit_withdraw_date',
-                first_day_inclusive
-            ) }}
-            or bld_school_calendar_windows.first_school_day is null
-        )
+),
+
+valid_stu_school_records as (
+
+    -- apply the validation flags created above to decide which enrollment records continue through the model. 
+    -- the entry/exit check is always required, while the other checks only apply when enabled by configuration.
+    -- once the filtering is done, remove the helper flags because they are no longer needed downstream.
+    select
+        {{ edu_edfi_source.star('stu_school_records', except=[
+            'is_exit_on_or_after_first_day',
+            'is_exit_on_or_after_entry',
+            'has_retained_withdraw_type',
+            'is_same_year_as_student_record'
+        ]) }}
+    from stu_school_records
+    where is_exit_on_or_after_entry
+
+    {%- if exclude_exit_before_first_day %}
+        and is_exit_on_or_after_first_day
     {%- endif %}
-        -- make sure exit occurred on or after entry
-        and (
-            stg_stu_school.exit_withdraw_date is null
-            or stg_stu_school.exit_withdraw_date >= stg_stu_school.entry_date
-        )
-    {%- set excl_withdraw_codes = var('edu:enroll:exclude_withdraw_codes') %}
-    {%- if excl_withdraw_codes is string %}
-      {%- set excl_withdraw_codes = [excl_withdraw_codes] %}
-    {%- endif %}
+
     {%- if excl_withdraw_codes | length %}
-        -- drop invalid enrollments while retaining rows without an exit type
-        and (
-            stg_stu_school.exit_withdraw_type not in (
-                '{{ excl_withdraw_codes | join("', '") }}'
-            )
-            or stg_stu_school.exit_withdraw_type is null
-        )
+        and has_retained_withdraw_type
     {%- endif %}
-    {%- if var('edu:enroll:exclude_cross_year_enrollments', False) %}
-        -- drop enrollments whose year disagrees with the student record's year
-        and dim_student.school_year = stg_stu_school.school_year
+
+    {%- if exclude_cross_year %}
+        and is_same_year_as_student_record
     {%- endif %}
 
 ),
@@ -116,39 +197,38 @@ enrollment_status_flags as (
     select
         *,
 
-        -- is this row's school year the newest one that has actually begun
-        -- for this tenant? falls back to entry_date when the calendar
-        -- didn't match, so tenants with missing calendar data aren't
-        -- stranded. using the newest year *loaded* would strand current
-        -- enrollments whenever next year's data is ingested early.
+        -- identify the school year that should currently count as active for each tenant.
+        -- only consider school years whose first school day has already passed.
+        -- example: 
+            -- if 2027 enrollment records are loaded in july 2026,
+            -- but the 2027 school year starts in august, 2026 remains the active school year until then.
         school_year = max(
             iff(
                 coalesce(first_school_day, entry_date) <= current_date(),
                 school_year,
                 null
             )
-        ) over (
-            partition by tenant_code
-        ) as is_active_school_year,
+        ) over(partition by tenant_code) as is_active_school_year,
 
+        -- identify whether the enrollment has started as of today.
+        -- future enrollment records remain false until entry_date is reached.
         entry_date <= current_date() as has_enrollment_started,
 
-        -- is today still within this enrollment's end boundary? normally that
-        -- boundary is exit_withdraw_date, but when the year-end buffer is
-        -- configured a student who exited within buffer_days of
-        -- last_school_day also counts, until the calendar year rolls over.
+        -- identify whether the enrollment should still count as active based on its exit date.
+        -- normally, the student stops counting as active once exit_withdraw_date is reached,
+        -- depending on the configured exit-date inclusivity.
+        -- when a year-end buffer is configured, students who exit near last_school_day
+        -- can remain active through the end of that calendar year.
         (
             {{ date_within_end_date(
                 'current_date()',
                 'exit_withdraw_date',
-                var('edu:enroll:exit_withdraw_date_inclusive', True)
+                exit_date_inclusive
             ) }}
-            {%- set buffer_days = var('edu:enroll:year_end_active_buffer_days', none) %}
             {%- if buffer_days is not none %}
             or (
-                -- jinja negates, rather than emitting a literal "-" prefix:
-                -- a negative buffer_days would otherwise render as "--5",
-                -- which SQL reads as the start of a line comment
+                -- negate in jinja so a negative value cannot render as "--5",
+                -- which sql would interpret as the start of a comment.
                 exit_withdraw_date
                     >= dateadd(day, {{ -buffer_days }}, last_school_day)
                 and year(last_school_day) = year(current_date())

--- a/models/core_warehouse/fct_student_school_association.sql
+++ b/models/core_warehouse/fct_student_school_association.sql
@@ -11,157 +11,68 @@
   )
 }}
 
-with stg_stu_school as (
-    select * from {{ ref('stg_ef3__student_school_associations') }}
-),
-dim_student as (
-    select * from {{ ref('dim_student') }}
-),
-dim_school as (
-    select * from {{ ref('dim_school') }}
-),
-dim_school_calendar as (
-    select * from {{ ref('dim_school_calendar') }}
-),
-dim_calendar_date as (
-    select * from {{ ref('dim_calendar_date') }}
-),
-bld_school_calendar_windows as (
-    select * from {{ ref('bld_ef3__school_calendar_windows') }}
+with bld_enrollment_flags as (
+    -- valid enrollment records only: the build model applies the
+    -- enrollment-validity filters, resolves k_school_calendar, and computes
+    -- the component status flags
+    select * from {{ ref('bld_ef3__stu_sch_assoc__enrollment_flags') }}
 ),
 xwalk_grade_levels as (
-    select * from {{ ref('xwalk_grade_levels')}}
-),
-single_calendar_schools as (
-    -- some implementations may not provide a school calendar link because
-    -- their system only allows one calendar per school anyway.
-    -- we will detect these cases and fill in missing school calendars
-    -- only when doing so is unambiguous
-    select * from dim_school_calendar
-    qualify 1 = count(*) over(partition by k_school, school_year)
+    select * from {{ ref('xwalk_grade_levels') }}
 ),
 formatted as (
-    select 
-        dim_student.k_student,
-        dim_student.k_student_xyear,
-        dim_school.k_lea,
-        dim_school.k_school,
+    select
+        bld_enrollment_flags.k_student,
+        bld_enrollment_flags.k_student_xyear,
+        bld_enrollment_flags.k_lea,
+        bld_enrollment_flags.k_school,
+        bld_enrollment_flags.k_school_calendar,
+        bld_enrollment_flags.tenant_code,
+        bld_enrollment_flags.school_year,
+        bld_enrollment_flags.entry_date,
+        bld_enrollment_flags.exit_withdraw_date,
+        bld_enrollment_flags.is_primary_school,
+        bld_enrollment_flags.is_repeat_grade,
+        bld_enrollment_flags.is_school_choice_transfer,
+        bld_enrollment_flags.is_school_choice,
+        bld_enrollment_flags.school_choice_basis,
+        bld_enrollment_flags.enrollment_type,
+        -- create indicator for active enrollment. coalesce so that a null
+        -- component reads as inactive rather than null, matching the
+        -- behavior of the iff() this replaced.
         coalesce(
-            dim_school_calendar.k_school_calendar,
-            single_calendar_schools.k_school_calendar
-        ) as k_school_calendar,
-        stg_stu_school.tenant_code,
-        stg_stu_school.school_year,
-        stg_stu_school.entry_date,
-        stg_stu_school.exit_withdraw_date,
-        stg_stu_school.is_primary_school,
-        stg_stu_school.is_repeat_grade,
-        stg_stu_school.is_school_choice_transfer,
-        stg_stu_school.is_school_choice,
-        stg_stu_school.school_choice_basis,
-        stg_stu_school.enrollment_type,
-        -- create indicator for active enrollment
-        iff(
-            -- is highest school year observed by tenant. 
-            stg_stu_school.school_year = max(stg_stu_school.school_year)
-                over(partition by stg_stu_school.tenant_code)
+            -- is the newest school year that has actually begun for this tenant
+            bld_enrollment_flags.is_active_school_year
             -- enrollment has begun
-            and entry_date <= current_date()
+            and bld_enrollment_flags.has_enrollment_started
             -- not yet exited, or 'year-end extension' if configured
-            and (
-                -- standard: not yet exited as of today
-                {{ date_within_end_date('current_date()', 'exit_withdraw_date', var('edu:enroll:exit_withdraw_date_inclusive', True)) }}
-                
-                -- extended: if configured, students who exit at the end of the school year are still active until the next year's data loads
-                {%- set buffer_days = var('edu:enroll:year_end_active_buffer_days', none) -%}
-                {%- if buffer_days is not none %}
-                    or (exit_withdraw_date >= dateadd(
-                        day,
-                        -- Adjust last_school_day by buffer_days to determine the cutoff date for "active enrollment":
-                        -- If buffer_days > 0: Move cutoff date earlier (prior to last_school_day) (use to keep students active who exit during the last buffer_days days of the school year)
-                        -- If buffer_days < 0: Move cutoff date later (after last_school_day) (use to keep students active who exit after the last school day)
-                        -- If buffer_days == 0: Use last_school_day as-is (use to keep students active who exit on or after the last school day)
-                        {% if buffer_days > 0 %}
-                            -{{ buffer_days }}
-                        {% elif buffer_days < 0 %}
-                            {{ -buffer_days }}
-                        {% else %}
-                            0
-                        {% endif %},
-
-                        bld_school_calendar_windows.last_school_day
-                        )
-                        -- only apply to cases where calendar end is in the current year (exclude from active if calendar ended in Fall or previous year, or tenant only has data from last year)
-                        AND year(bld_school_calendar_windows.last_school_day) = year(current_date())
-                    )
-                {% endif %}
-            ),
-            true, false
+            and bld_enrollment_flags.is_within_effective_end_date,
+            false
         ) as is_active_enrollment,
-        stg_stu_school.entry_grade_level,
+        bld_enrollment_flags.entry_grade_level,
         xwalk_grade_levels.grade_level_integer,
-        stg_stu_school.entry_grade_level_reason,
-        stg_stu_school.entry_type,
-        stg_stu_school.exit_withdraw_type,
-        stg_stu_school.class_of_school_year,
-        stg_stu_school.next_year_school_id,
-        stg_stu_school.next_year_grade_level,
-        stg_stu_school.k_graduation_plan,
-        stg_stu_school.graduation_plan_type,
-        stg_stu_school.v_alternative_graduation_plans,
-        stg_stu_school.v_education_plans,
-        stg_stu_school.residency_status,
-        -- column to choose the latest record for multiple enrollments 
+        bld_enrollment_flags.entry_grade_level_reason,
+        bld_enrollment_flags.entry_type,
+        bld_enrollment_flags.exit_withdraw_type,
+        bld_enrollment_flags.class_of_school_year,
+        bld_enrollment_flags.next_year_school_id,
+        bld_enrollment_flags.next_year_grade_level,
+        bld_enrollment_flags.k_graduation_plan,
+        bld_enrollment_flags.graduation_plan_type,
+        bld_enrollment_flags.v_alternative_graduation_plans,
+        bld_enrollment_flags.v_education_plans,
+        bld_enrollment_flags.residency_status,
+        -- column to choose the latest record for multiple enrollments
         -- at the same school in the same year
         -- note: difficult column to name without implying it has cross-year
         -- or cross-school meaning
-        stg_stu_school.entry_date = max(stg_stu_school.entry_date) over(
-            partition by stg_stu_school.k_student, stg_stu_school.k_school
+        bld_enrollment_flags.entry_date = max(bld_enrollment_flags.entry_date) over(
+            partition by bld_enrollment_flags.k_student, bld_enrollment_flags.k_school
         ) as is_latest_annual_entry
         {# add any extension columns configured from stg_ef3__student_school_associations #}
         {{ edu_edfi_source.extract_extension(model_name='stg_ef3__student_school_associations', flatten=False) }}
-    from stg_stu_school
-    join dim_student
-        on stg_stu_school.k_student = dim_student.k_student
-    join dim_school
-        on stg_stu_school.k_school = dim_school.k_school
-    left join dim_school_calendar
-        on stg_stu_school.k_school_calendar = dim_school_calendar.k_school_calendar
-    left join single_calendar_schools
-        on stg_stu_school.k_school = single_calendar_schools.k_school
-        and stg_stu_school.school_year = single_calendar_schools.school_year
-    left join bld_school_calendar_windows
-        on stg_stu_school.k_school = bld_school_calendar_windows.k_school
-        and stg_stu_school.school_year = bld_school_calendar_windows.school_year
-        and equal_null(dim_school_calendar.k_school_calendar, bld_school_calendar_windows.k_school_calendar)
+    from bld_enrollment_flags
     left join xwalk_grade_levels
-        on stg_stu_school.entry_grade_level = xwalk_grade_levels.grade_level
-    where true
-   {% if var('edu:enroll:exclude_exit_before_first_day', True) -%}
-      {#- allow implementations with exclusive exit dates to still keep first-day exits -#}
-      {%- set first_day_inclusive = var('edu:enroll:first_day_exit_date_inclusive', var('edu:enroll:exit_withdraw_date_inclusive', True)) -%}
-      -- exclude students who exited before the first school day
-      and ({{ date_within_end_date('bld_school_calendar_windows.first_school_day', 'exit_withdraw_date', first_day_inclusive) }}
-          or bld_school_calendar_windows.first_school_day is null
-          )
-    {% endif %}
-    -- make sure exit is after entry
-    and (exit_withdraw_date is null or exit_withdraw_date >= entry_date)
-    -- exclude students who never actually enrolled
-    {% set excl_withdraw_codes =  var('edu:enroll:exclude_withdraw_codes')  %}
-    {% if excl_withdraw_codes | length -%}
-      {% if excl_withdraw_codes is string -%}
-        {% set excl_withdraw_codes = [excl_withdraw_codes] %}
-      {%- endif -%}
-      -- drop invalid enrollments
-      and (stg_stu_school.exit_withdraw_type not in (
-      '{{ excl_withdraw_codes | join("', '") }}'
-      )
-      -- keep rows with no exit_withdraw
-      or stg_stu_school.exit_withdraw_type is null) 
-    {% endif %}
-    {% if var('edu:enroll:exclude_cross_year_enrollments', False)%}
-    and dim_student.school_year = stg_stu_school.school_year
-    {% endif %}
+        on bld_enrollment_flags.entry_grade_level = xwalk_grade_levels.grade_level
 )
 select * from formatted

--- a/models/core_warehouse/fct_student_school_association.sql
+++ b/models/core_warehouse/fct_student_school_association.sql
@@ -11,68 +11,72 @@
   )
 }}
 
-with bld_enrollment_flags as (
-    -- valid enrollment records only: the build model applies the
-    -- enrollment-validity filters, resolves k_school_calendar, and computes
-    -- the component status flags
+with bld_stu_sch_assoc_flags as (
     select * from {{ ref('bld_ef3__stu_sch_assoc__enrollment_flags') }}
 ),
+
 xwalk_grade_levels as (
     select * from {{ ref('xwalk_grade_levels') }}
 ),
+
 formatted as (
     select
-        bld_enrollment_flags.k_student,
-        bld_enrollment_flags.k_student_xyear,
-        bld_enrollment_flags.k_lea,
-        bld_enrollment_flags.k_school,
-        bld_enrollment_flags.k_school_calendar,
-        bld_enrollment_flags.tenant_code,
-        bld_enrollment_flags.school_year,
-        bld_enrollment_flags.entry_date,
-        bld_enrollment_flags.exit_withdraw_date,
-        bld_enrollment_flags.is_primary_school,
-        bld_enrollment_flags.is_repeat_grade,
-        bld_enrollment_flags.is_school_choice_transfer,
-        bld_enrollment_flags.is_school_choice,
-        bld_enrollment_flags.school_choice_basis,
-        bld_enrollment_flags.enrollment_type,
-        -- create indicator for active enrollment. coalesce so that a null
-        -- component reads as inactive rather than null, matching the
-        -- behavior of the iff() this replaced.
+        bld_stu_sch_assoc_flags.k_student,
+        bld_stu_sch_assoc_flags.k_student_xyear,
+        bld_stu_sch_assoc_flags.k_lea,
+        bld_stu_sch_assoc_flags.k_school,
+        bld_stu_sch_assoc_flags.k_school_calendar,
+        bld_stu_sch_assoc_flags.tenant_code,
+        bld_stu_sch_assoc_flags.school_year,
+        bld_stu_sch_assoc_flags.entry_date,
+        bld_stu_sch_assoc_flags.exit_withdraw_date,
+        bld_stu_sch_assoc_flags.is_primary_school,
+        bld_stu_sch_assoc_flags.is_repeat_grade,
+        bld_stu_sch_assoc_flags.is_school_choice_transfer,
+        bld_stu_sch_assoc_flags.is_school_choice,
+        bld_stu_sch_assoc_flags.school_choice_basis,
+        bld_stu_sch_assoc_flags.enrollment_type,
+
+        -- an enrollment is active only when all three conditions are true:
+            -- the enrollment's school_year is the most recent school year that is actively in session for that tenant,
+            -- the enrollment entry date has been reached as of today,
+            -- the enrollment has not reached its effective end date.
+        -- coalesce null to false so an unknown component does not result in
+        -- a null active-enrollment flag.
         coalesce(
-            -- is the newest school year that has actually begun for this tenant
-            bld_enrollment_flags.is_active_school_year
-            -- enrollment has begun
-            and bld_enrollment_flags.has_enrollment_started
-            -- not yet exited, or 'year-end extension' if configured
-            and bld_enrollment_flags.is_within_effective_end_date,
+            bld_stu_sch_assoc_flags.is_active_school_year
+            and bld_stu_sch_assoc_flags.has_enrollment_started
+            and bld_stu_sch_assoc_flags.is_within_effective_end_date,
             false
         ) as is_active_enrollment,
-        bld_enrollment_flags.entry_grade_level,
+
+        bld_stu_sch_assoc_flags.entry_grade_level,
         xwalk_grade_levels.grade_level_integer,
-        bld_enrollment_flags.entry_grade_level_reason,
-        bld_enrollment_flags.entry_type,
-        bld_enrollment_flags.exit_withdraw_type,
-        bld_enrollment_flags.class_of_school_year,
-        bld_enrollment_flags.next_year_school_id,
-        bld_enrollment_flags.next_year_grade_level,
-        bld_enrollment_flags.k_graduation_plan,
-        bld_enrollment_flags.graduation_plan_type,
-        bld_enrollment_flags.v_alternative_graduation_plans,
-        bld_enrollment_flags.v_education_plans,
-        bld_enrollment_flags.residency_status,
+        bld_stu_sch_assoc_flags.entry_grade_level_reason,
+        bld_stu_sch_assoc_flags.entry_type,
+        bld_stu_sch_assoc_flags.exit_withdraw_type,
+        bld_stu_sch_assoc_flags.class_of_school_year,
+        bld_stu_sch_assoc_flags.next_year_school_id,
+        bld_stu_sch_assoc_flags.next_year_grade_level,
+        bld_stu_sch_assoc_flags.k_graduation_plan,
+        bld_stu_sch_assoc_flags.graduation_plan_type,
+        bld_stu_sch_assoc_flags.v_alternative_graduation_plans,
+        bld_stu_sch_assoc_flags.v_education_plans,
+        bld_stu_sch_assoc_flags.residency_status,
+
         -- column to choose the latest record for multiple enrollments
         -- at the same school in the same year
         -- note: difficult column to name without implying it has cross-year
         -- or cross-school meaning
-        bld_enrollment_flags.entry_date = max(bld_enrollment_flags.entry_date) over(
-            partition by bld_enrollment_flags.k_student, bld_enrollment_flags.k_school
+        bld_stu_sch_assoc_flags.entry_date = max(bld_stu_sch_assoc_flags.entry_date) over(
+            partition by bld_stu_sch_assoc_flags.k_student, bld_stu_sch_assoc_flags.k_school
         ) as is_latest_annual_entry
-        {# add any extension columns configured from stg_ef3__student_school_associations #}
+
+        {#- add any extension columns configured from stg_ef3__student_school_associations #}
         {{ edu_edfi_source.extract_extension(model_name='stg_ef3__student_school_associations', flatten=False) }}
-    from bld_enrollment_flags
+
+    from bld_stu_sch_assoc_flags
     left join xwalk_grade_levels
-        on bld_enrollment_flags.entry_grade_level = xwalk_grade_levels.grade_level
+        on bld_stu_sch_assoc_flags.entry_grade_level = xwalk_grade_levels.grade_level
 )
 select * from formatted


### PR DESCRIPTION
Related to TN PR #248 

# Description & motivation

This PR moves enrollment validation and active-enrollment logic out of `fct_student_school_association` and into a new build model, `bld_ef3__stu_sch_assoc__enrollment_flags`.

Before:
<img width="5700" height="1511" alt="enrollment__before" src="https://github.com/user-attachments/assets/ef8c8d40-58cc-409e-9c9d-f754988e3d29" />


After:
<img width="5700" height="1511" alt="enrollment__after" src="https://github.com/user-attachments/assets/8b7c8ecb-1285-4e96-9a27-7f848f305ccf" />



## Main Problem Tackled
The main behavior change is a fix for tenants that load next year's enrollment data early. Before, as soon as a future school year appeared in the data, that year became the "active" school year. Current-year enrollments would immediately flip to inactive, even though the future school year had not started yet.

<img width="2498" height="1811" alt="active_enrollment_errors" src="https://github.com/user-attachments/assets/cdb614fd-42f2-4b7a-ae89-f7e0540820f4" />


## Refactoring Goals
The fact table keeps the same output columns as before, so downstream models do not need to change.

The refactor also untangles a lot of logic that had all been living in `fct_student_school_association`. Before this change, that one fact model was responsible for all of the following:

- validating enrollment records.
- resolving school calendars.
- calculating `is_active_enrollment` inside one dense `iff()`.
- outputting the final fact-table columns.

This meant you had to read through a lot of different concerns at once just to understand how active enrollment was being decided. It also made the logic harder to reuse elsewhere and made bugs like the active-school-year issue harder to debug externally.

With this PR, those responsibilities are divided into two models:

- `bld_ef3__stu_sch_assoc__enrollment_flags` owns enrollment validation, calendar resolution, and the component flags that describe enrollment status.
- `fct_student_school_association` combines those flags into `is_active_enrollment` and outputs the final schema/fields.


## Optional Walkthrough of new logic with Examples

<details>
  <summary> Click to expand </summary>

---
Let's say we have a district, District A, and it is currently mid-July 2026. 
The district decides to load records for the upcoming 2027 school year early in order to prep for that year, which begins August 25, 2026.

`stg_ef3__student_school_associations` contains these four records:

| row | school_year | entry_date | exit_withdraw_date | exit_withdraw_type |
| --- | --- | --- | --- | --- |
| Bob | 2026 | 2025-08-20 | null | null |
| Sandy | 2026 | 2025-08-20 | 2025-08-10 | Withdrawn |
| Pearl | 2026 | 2025-09-01 | 2025-09-01 | No show |
| Patrick | 2027 | 2026-08-25 | null | null |

These represent four different situations:

- **Bob** is a student who enrolled last August and is still enrolled.
- **Sandy** is invalid because the exit date is before the entry date.
- **Pearl** is a no-show who was recorded but never actually attended.
- **Patrick** is a valid pre-registration for the next school year.

### Step 1: resolve enrollment configuration once

The build model starts by resolving every `edu:enroll:*` var it uses.

This includes configuration such as:

- which withdrawal codes should remove an enrollment.
- whether exit dates are inclusive.
- whether enrollment-date filters are enabled.
- how the year-end active-enrollment buffer behaves.

Implementations can still override these values in their own `dbt_project.yml`.

The goal is to have these configurations be more readable, so instead of finding `var()` calls and `{% set %}` statements scattered throughout the SQL, you can see all of the enrollment configuration in one place before getting into the actual logic.

### Step 2: join the related dimensions and name each validity check


The `stu_school_records` CTE joins staging to `dim_student` and `dim_school`.

These are inner joins, so records that cannot be tied to a valid student or school drop here.

The CTE also resolves `k_school_calendar`:

- use the directly matched calendar when one exists.
- otherwise use the school's only calendar when there is exactly one clear option.

It then calculates four enrollment validity flags, each are phrased positively so `true` means the enrollment should survive that rule.

For the example records, some of those checks look like this:

| row | school_year | entry_date | exit_withdraw_date | exit_withdraw_type |is_exit_on_or_after_entry | has_retained_withdraw_type | is_exit_on_or_after_first_day |
| --- | --- | --- | --- | --- |--- | --- | --- |
| Bob | 2026 | 2025-08-20 | null | null |true | true | true |
| Sandy | 2026 | 2025-08-20 | 2025-08-10 | Withdrawn |**false** | true | true |
| Pearl | 2026 | 2025-09-01 | 2025-09-01 | No show |true | **false** | true |
| Patrick | 2027 | 2026-08-25 | null | null |true | true | true |

Before, these same checks were all folded into one larger `where` clause. Now each one is separated into its own field so it is much easier to see what is being checked and why a record would be kept or removed.

### Step 3: filter invalid records before calculating enrollment status

`valid_stu_school_records` applies the filters based on validity flags set above.

In the example:

- Sandy is removed because its exit date is before its entry date.
- Pearl is removed because its withdrawal type is configured to exclude the record.
- Bob and Patrick remain.

After filtering, the helper validity flags are dropped with `star(except=...)` because they won't need to be used downstream, so avoiding the noise is valuable.

The next step decides which school year is active using a `max()` window.

### Step 4: calculate the component enrollment-status flags

`enrollment_status_flags` adds the three pieces that eventually make up `is_active_enrollment`:

- `is_active_school_year`.
- `has_enrollment_started`.
- `is_within_effective_end_date`.

Breaking these into separate flags makes the final `is_active_enrollment` definition much easier to read, and it also means another model can reuse one of those pieces without having to recreate the full active-enrollment calculation.

#### `is_active_school_year`

This flag answers:

> Is this enrollment part of the most recent school year that has actually started for this tenant?

This is also where the bug with future school-year data is fixed. 

Before, the logic effectively chose the newest school year present in the data, which meant that in our example, loading Patrick in July caused 2027 to become the active year immediately, even though the 2027 school year does not begin until August 25.

That produced this situation:

| row | school_year | entry_date | exit_withdraw_date | max(school_year) | notes |
| --- | --- | --- | --- | --- |--- |
| Bob | 2026 | 2025-08-20 | null | **false** | this means we are setting this record as inactive even though we are in this active school year
| Patrick | 2027 | 2026-08-25 | null | true |

The problem gets worse because Patrick also has a future `entry_date`.

So during the summer:

- 2026 was no longer considered the effective school year.
- 2027 students had not started yet.
- the tenant ends up showing zero active enrollments until 2027 starts.

The new logic only allows a school year to become active once its first school day has passed.

| row | school_year | entry_date | exit_withdraw_date | max(school_year if the enrollment window has started) | notes |
| --- | --- | --- | --- | --- |--- |
| Bob | 2026 | 2025-08-20 | null | true | now this row remains active.
| Patrick | 2027 | 2026-08-25 | null | **false** |

#### `has_enrollment_started`

This flag answers:

> Has the student's `entry_date` arrived yet?

For the example:

| row | school_year | entry_date | exit_withdraw_date | is_active_school_year | has_enrollment_started | notes |
| --- | --- | --- | --- | --- |--- |--- |
| Bob | 2026 | 2025-08-20 | null | true | true |
| Patrick | 2027 | 2026-08-25 | null | **false** |  **false** | this remains false until 2026-08-25


#### `is_within_effective_end_date`

This flag answers:

> Has the enrollment reached the date when it should stop being considered active?

Normally, this is based on the enrollment's exit date, using the configured inclusive or exclusive behavior.

When the year-end buffer is configured, there is one additional case.

Students who exit within the configured number of days around the final school day can remain active through the end of that calendar year. This prevents summer reporting from immediately losing students the day after the school year ends.

### Step 5: compose the flags in the fact model

After this refactor, `fct_student_school_association` mostly handles presentation/final definition through an `iff()` statement.

It selects from the new build model and calculates:

`is_active_enrollment = is_active_school_year and has_enrollment_started and is_within_effective_end_date`

The result is coalesced to `false` so a null value does not produce a null active-enrollment flag.

The fact still handles the pieces that belong specifically to the final output table:

- joins `xwalk_grade_levels` to calculate the grade integer.
- calculates `is_latest_annual_entry`.
- includes configured extension columns.
- applies the existing post-hook constraints.
- outputs the same explicit column list as before.

For the walkthrough:

- Bob is outputted with `is_active_enrollment = true`.
- Patrick is outputted with `is_active_enrollment = false` until the new school year begins.
- Sandy and Pearl are filtered out.

That is the same expected record behavior as before the refactor, except the summer active-school-year bug is removed.

</details>

## Why split the models this way?

The main point of separating the logic is to make it clearer, more accessible, and easier to maintain/extend. 

In this PR, the build model owns the creation of the flags:

- record validation.
- calendar resolution.
- active-school-year selection.
- enrollment-start status.
- effective-end-date status.

The fact owns the final definition that downstream apps/tables can use:

- what combination of those flags means `is_active_enrollment`.
- what columns are outputted in the final version.

It also gives us a chance to extend what flags we include as active enrollment in the future, and make this configurable if the need arises.

# PR Merge Priority

- [x] Low
- [ ] Medium
- [ ] High

# Changes to existing files

## `fct_student_school_association`

Now selects from `bld_ef3__stu_sch_assoc__enrollment_flags` instead of staging.

Changes include:

- Removed the enrollment-validity `where` logic.
- Removed the school-calendar resolution joins.
- Removed the active-school-year window logic.
- Moved those responsibilities into the new build model.
- Changed `is_active_enrollment` to combine the build model's three status flags and coalesce the result to `false`.
- Removed an unused `dim_calendar_date` CTE that was declared but never joined or selected.

The following behavior remains in the fact:

- `xwalk_grade_levels` join.
- `is_latest_annual_entry`.
- extension column roll call through `extract_extension` with `flatten=False`.
- existing post-hook constraints.
- the same final output column set.


## `CHANGELOG.md`

Added two Unreleased entries:

- an "Under the hood" entry for the model refactor.
- a "Fixes" entry for the active-school-year behavior change.

## `models/build/edfi_3/_edfi_3.yml`

Registered the new build model with the `core` tag and kept the model list alphabetical.

# New files created

## `bld_ef3__stu_sch_assoc__enrollment_flags`

New build model at the same grain as the staged enrollment record after deduplication:

`k_student, k_school, entry_date`

The model produces validated enrollment records with a resolved `k_school_calendar` and three enrollment-status flags:

- `is_active_school_year`.
- `has_enrollment_started`.
- `is_within_effective_end_date`.

The model is broken into four main pieces:

1. A configuration block that resolves all `edu:enroll:*` vars used by the model.
2. A join CTE that resolves related dimensions and calculates the named validity flags.
3. A filter CTE that applies the validity rules and removes the helper flags.
4. A final CTE that calculates the three enrollment-status flags.

# Behavior change to be aware of

No new vars are introduced, and the meanings of the existing `edu:enroll:*` vars do not change.

However, `is_active_enrollment` can change for tenants that load next year's enrollment data before that school year begins.

Before, loading the future year caused the current year to stop being considered active immediately. Because the future enrollments had not reached their entry dates yet, this could leave the tenant with zero active enrollments until the new school year started.

Now, the current school year remains active until the future school year's first school day has actually passed.

# Tests and QC done

- [x] Compared the build model's filtering, calendar resolution, and status logic clause by clause against the original fact logic, including year-end buffer sign handling and exit-date inclusivity fallbacks.
- [x] Run `dbt build -s +fct_student_school_association`
- [x] Compared outputs and `is_active_enrollment` values against the pre-refactor table to confirm the refactor is functioning properly and outputting the same rows as before
