### PR TITLE
Bugfix/dim assessment year

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,14 +5,14 @@
 
 # edu_wh v0.7.1
 ## New features
-- Add 'bld_ef3__stu_sch_assoc__enrollment_flags` as a clear home for enrollment business rule flags
-- Add `fct_staff_ed_org_assignment`, to surface staff who have edOrg but no school association
-- Update docs for better `school_year` column description everywhere and pull into 'docs block' for DRYer configuration
+- Add `bld_ef3__stu_sch_assoc__enrollment_flags` as a dedicated home for enrollment business rule flags
+- Add `fct_staff_ed_org_assignment` to surface staff who have an ed-org assignment but no school association
+- Improve the school_year column description in the docs and consolidate it into a shared docs block, so the definition is maintained in one place instead of repeated across models
 ## Under the hood
-- Move enrollment flags out of `fct_student_school_association` and make logic modular on series of boolean flags, for better logical flow and readability
+- Move enrollment flags out of `fct_student_school_association` and refactor the logic into a series of modular boolean flags, improving logical flow and readability
 ## Fixes 
-- Change behavior of `fct_student_school_association.is_active_enrollment` to avoid marking current records inactive when the next school year is loaded early.
-- For x-tenant assessments, fix `school_year` attribution in `dim_assessment`. Applies to edge cases where student assess was uploaded to the wrong year ODS
+- Fix `ct_student_school_association.is_active_enrollment` so current records are no longer incorrectly marked inactive when next year's data loads early
+- Fix `school_year` attribution in `dim_assessment` for cross-tenant assessments (applies only when an upstream student assess school year != api_year)
 
 # edu_wh v0.7.0
 ## New features

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,17 @@
 ## Under the hood
 ## Fixes
 
+# edu_wh v0.7.1
+## New features
+- Add 'bld_ef3__stu_sch_assoc__enrollment_flags` as a clear home for enrollment business rule flags
+- Add `fct_staff_ed_org_assignment`, to surface staff who have edOrg but no school association
+- Update docs for better `school_year` column description everywhere and pull into 'docs block' for DRYer configuration
+## Under the hood
+- Move enrollment flags out of `fct_student_school_association` and make logic modular on series of boolean flags, for better logical flow and readability
+## Fixes 
+- Change behavior of `fct_student_school_association.is_active_enrollment` to avoid marking current records inactive when the next school year is loaded early.
+- For x-tenant assessments, fix `school_year` attribution in `dim_assessment`. Applies to edge cases where student assess was uploaded to the wrong year ODS
+
 # edu_wh v0.7.0
 ## New features
 - Add `course_level_characteristics_array` column to `dim_course`. This column was previously added to `dim_course_section`.

--- a/dbt_project.yml
+++ b/dbt_project.yml
@@ -1,7 +1,7 @@
 config-version: 2
 
 name: 'edu_wh'
-version: '0.7.0'
+version: '0.7.1'
 require-dbt-version: [">=1.10.5", "<2.0.0"]
 
 # This setting configures which "profile" dbt uses for this project.

--- a/models/core_warehouse/dim_assessment.sql
+++ b/models/core_warehouse/dim_assessment.sql
@@ -74,7 +74,7 @@ dedupe_assessments as (
         dbt_utils.deduplicate(
             relation='formatted',
             partition_by='k_assessment',
-            order_by='tenant_code,api_year'
+            order_by='tenant_code,school_year'
         )
     }}
 )

--- a/models/core_warehouse/dim_assessment.sql
+++ b/models/core_warehouse/dim_assessment.sql
@@ -38,7 +38,7 @@ formatted as (
     select
         coalesce(dedupe_cross_tenant_assessments.k_assessment, stg_assessments.k_assessment) as k_assessment,
         coalesce(dedupe_cross_tenant_assessments.tenant_code, stg_assessments.tenant_code) as tenant_code,
-        coalesce(dedupe_cross_tenant_assessments.school_year, stg_assessments.api_year) as school_year,
+        coalesce(dedupe_cross_tenant_assessments.api_year, stg_assessments.api_year) as school_year,
         stg_assessments.assessment_identifier,
         stg_assessments.namespace,
         stg_assessments.assessment_title,

--- a/models/core_warehouse/dim_assessment.sql
+++ b/models/core_warehouse/dim_assessment.sql
@@ -30,7 +30,7 @@ dedupe_cross_tenant_assessments as (
         dbt_utils.deduplicate(
             relation='student_assessment_cross_tenant',
             partition_by='k_assessment',
-            order_by='tenant_code,school_year'
+            order_by='tenant_code,api_year'
         )
     }}
 ),
@@ -74,7 +74,7 @@ dedupe_assessments as (
         dbt_utils.deduplicate(
             relation='formatted',
             partition_by='k_assessment',
-            order_by='tenant_code,school_year'
+            order_by='tenant_code,api_year'
         )
     }}
 )

--- a/packages.yml
+++ b/packages.yml
@@ -1,3 +1,3 @@
 packages:
   - package: edanalytics/edu_edfi_source
-    version: [">=0.7.0", "<0.8.0"]
+    version: [">=0.7.1", "<0.8.0"]


### PR DESCRIPTION
<!---
Provide Title above, ensure it summarizes the work in the PR. Example PR titles templates:
* "feature/ (or build/): describe new functionality"
* "hotfix/: describe issue fix for immediate release"
* "bugfix/ (or fix/): describe issue fix, not necessary for immediate release"
* "docs/: adding or updating documentation"
-->

## Description & motivation
<!---
High level description your PR, and why you're making it. Is this linked to slack thread, Monday board, open
issue, a continuation to a previous PR? Link it here if relevant (use the "#" symbol for issues/PRs).
-->
[JIRA ticket](https://edanalytics.atlassian.net/browse/STADIUM-443?atlOrigin=eyJpIjoiMGRkYzY5MmE5N2U0NGIwZWJiNDE5YzU3YmNjYjcyNjkiLCJwIjoiamlyYS1zbGFjay1pbnQifQ)

The current `dim_assessment` deduplication is ordered by tenant code and school year. However, that order is silently assigning the wrong school year to a handful of transferred assessment records. 

Using `k_assessment = '18629cfccbaeea3b90625908bf87b89b'` as an example. This is a `k_assessment` value of a transferred assessment metada record in `tenant_code = 'lexington5'`. It is an KRA assessment for `api_year` 2026.

```
  select *
  from prod_stage.stg_ef3__assessments
    where  k_assessment = '18629cfccbaeea3b90625908bf87b89b'
```

For this case, in `bld_ef3__student_assessment_cross_tenant`, the `k_assessment` ( key of transferred records in the new tenant) can be associated with multiple `school_year`'s values  (when the student took the assessment) within 1 `api_year` (year of ODS this record was sent to). Example:

```
  select distinct k_assessment, tenant_code, k_assessment__original, original_tenant_code, school_year, api_year 
  from prod_build.bld_ef3__student_assessment_cross_tenant
    where  k_assessment = '18629cfccbaeea3b90625908bf87b89b'
```

So the ideal outcome is to match on `api_year` in `bld_ef3__student_assessment_cross_tenant` with `api_year` in `stg_ef3__assessments`.

However, [this ](https://github.com/edanalytics/edu_wh/blob/5a7cf82e646d24c96e8e2a3c7fd2b88150fc97b3/models/core_warehouse/dim_assessment.sql#L41)`coalesce()` is picking up `school_year` in `bld_ef3__student_assessment_cross_tenant` to match with the same k_assessment in `stg_ef3__assessments` + [this ](https://github.com/edanalytics/edu_wh/blob/5a7cf82e646d24c96e8e2a3c7fd2b88150fc97b3/models/core_warehouse/dim_assessment.sql#L77)dedupe = assigning the wrong year (2024 instead of 2026)

```
  select *
  from prod_wh.dim_assessment
    where  k_assessment = '18629cfccbaeea3b90625908bf87b89b'
```


## PR Merge Priority:
<!---
This checklist helps the reviewers understand the level of priority for merging this PR.
A loose description of merging priority levels is:
Low: A week or more.
Medium: Within 3 days or less.
High: As soon as possible.
-->
- [x] Low
- [ ] Medium
- [ ] High

<!---
If High Priority, explain why as a comment below.
-->

## Changes to existing files:
<!---
Include this section if you are changing any existing files or creating breaking changes to existing files. Label the model name and describe the logic behind the changes made, try to be very descriptive here. For example:
- `stg_model` : Describe any changes made to `stg_model` and why the changes where made.
- `src_staging` : Describe any changes made to `src_staging` and why the changes where made.
-->
- `dim_assessment`: change `school_year` to `api_year` in coalesce and dedupe so we are using `api_year` to attach to any `k_assessment`.

## New files created:
<!---
Include this section if you are creating any new files. Label the model name and describe the logic behind the changes made, try to be very descriptive here. For example:
- `stg_new_model` : Describe the purpose of `stg_new_model` and the logic behind creating the model.
- `src_new_staging` : Describe the purpose of `src_new_staging`.
-->

## Tests and QC done:
<!---
Describe any process that confirms that the files do what is expected, include screenshots if relevant. For example:
- Analyst replication confirmed that updates to `stg_model` new counts were correct.
- Executed a dbt project run and ensured it was successful.
-->
I ran `dbt run -s +dim_assessment` in my schema with `dbt defer`.  It is also important to note that my `bld_ef3__student_assessment_cross_tenant` model is ahead of prod during time of QC. Below are the QC queries I ran to test this out:

```
select count(*) from  dev_analytics.dev_nn_wh.dim_assessment; --136997
select count(*) from prod_wh.dim_assessment; --136968

-- There is a 29 row difference between prod and dev

select * from dev_analytics.dev_nn_wh.dim_assessment dev where not exists 
    (
        select * from prod_wh.dim_assessment prod
        where dev.k_assessment = prod.k_assessment
    );


select * from prod_wh.dim_assessment prod where not exists 
    (
        select * from dev_analytics.dev_nn_wh.dim_assessment dev
        where dev.k_assessment = prod.k_assessment
    );

-- No `k_assessment`s records were dropped. 
-- Data difference between dev and prod is due to either differing build times + fake tenant data


select * from prod_wh.dim_assessment prod where not exists 
    (
        select * from dev_analytics.dev_nn_wh.dim_assessment dev
        where dev.k_assessment = prod.k_assessment 
                and dev.school_year = prod.school_year

    );

-- This new change effectively affects the `school_year` field of 529 rows

select * from prod_wh.dim_assessment prod where not exists 
    (
        select * from dev_analytics.dev_nn_wh.dim_assessment dev
        where dev.k_assessment = prod.k_assessment 
                and dev.school_year = prod.school_year

    );

-- With this query, it shows that with this change, `dim_assessment` actually is picking up the correct years for each `k_assessment`

select * from dev_analytics.dev_nn_wh.dim_assessment dev where not exists 
    (
        select * from prod_stage.stg_ef3__assessments prod
        where dev.k_assessment = prod.k_assessment
        and dev.school_year = prod.api_year
    ) and not exists (

    select * from DEV_ANALYTICS.dev_nn_build.bld_ef3__student_assessment_cross_tenant prod_1
        where dev.k_assessment = prod_1.k_assessment
        and dev.school_year = prod_1.api_year
    );

select * from prod_wh.dim_assessment dev where not exists 
    (
        select * from prod_stage.stg_ef3__assessments prod
        where dev.k_assessment = prod.k_assessment
        and dev.school_year = prod.api_year
    ) and not exists (

    select * from DEV_ANALYTICS.dev_nn_build.bld_ef3__student_assessment_cross_tenant prod_1
        where dev.k_assessment = prod_1.k_assessment
        and dev.school_year = prod_1.api_year
    );


-- Double checking `fct_student_assessment` to investigate any unwanted drops/fan-outs introduced by this change, the table looks overall healthy, with the only data difference between dev and prod coming from the `cougar_scdemulti` fake tenant

select
  prod.k_student_assessment is not null as in_prod,
  dev.k_student_assessment is not null as in_dev,
  count(*)
from analytics.prod_wh.fct_student_assessment prod
full outer join dev_analytics.dev_nn_wh.fct_student_assessment dev
 on prod.k_student_assessment = dev.k_student_assessment
group by all
; 

select * from prod_wh.fct_student_assessment prod
where not exists (
    select 1 from dev_analytics.dev_nn_wh.fct_student_assessment dev
    where prod.k_student_assessment = dev.k_student_assessment
) ;

```

## edu_wh PR Review Checklist:
Make sure the following have been completed before approving this PR:
- [ ] Description of changes has been added to Unreleased section of [CHANGELOG.md](/CHANGELOG.md). Add under `## New Features` for features, etc.
- [ ] Code has been tested/checked for Databricks and Snowflake compatibility - EA engineers see Databricks checklist [here](https://edanalytics.slite.com/app/docs/LRjXFxVRAWA5ST) 
- [ ] Reviewer confirms the grain of all tables are unchanged, OR any changes are expected, communicated, and this PR is flagged as a breaking change (not for patch release)
- [ ] If a new configuration xwalk was added:
  - [ ] The code is written such that the xwalk is optional (preferred), and this behavior was tested, OR
  - [ ] The code is written such that the xwalk is required, and the required xwalk is added to edu_project_template, and this PR is flagged as breaking change (not for patch release)
  - [ ] A description for the new xwalk has been added to EDU documentation site [here](https://github.com/edanalytics/edu_docs/blob/main/docs/docs/manage_extend/reference/configure_dbt_xwalks.md) 
- [ ] If a new configuration variable was added:
  - [ ] The code is written such that the variable is optional (preferred), and this behavior was tested, OR
  - [ ] The code is written such that the variable is required, and a default value was added to edu_project_template, and this PR is flagged as breaking change (not for patch release)
  - [ ] A description for the new variable has been added to EDU documentation site [here](https://github.com/edanalytics/edu_docs/blob/main/docs/docs/manage_extend/reference/configure_dbt_vars.md) 

<!---## Future ToDos & Questions:-->
<!---
[Optional] Include any future steps and questions related to this PR.
-->
