### PR TITLE
Feature/Section 504 and Neglected or Delinquent programs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Unreleased
 ## New features
+- Added program models for `student_section_504_program_associations` and `student_neglected_or_delinquent_program_associations`
 ## Under the hood
 ## Fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Unreleased
 ## New features
-- Added program models for `student_section_504_program_associations` and `student_neglected_or_delinquent_program_associations`
+- Added program models for `student_section_504_program_associations` and `student_neglected_or_delinquent_program_associations`. Disable these programs by setting `'src:program:section_504:enabled': False` and `'src:program:neglected_or_delinquent:enabled': False` if necessary
 ## Under the hood
 ## Fixes
 

--- a/dbt_project.yml
+++ b/dbt_project.yml
@@ -93,6 +93,16 @@ vars:
   'edu:migrant_education:exclude_programs': Null
   'edu:migrant_education:agg_types': ['annual', 'active']
 
+  'edu:section_504:start_date_column': program_enroll_begin_date
+  'edu:section_504:exit_date_column': program_enroll_end_date
+  'edu:section_504:exclude_programs': Null
+  'edu:section_504:agg_types': ['annual', 'active']
+
+  'edu:neglected_or_delinquent:start_date_column': program_enroll_begin_date
+  'edu:neglected_or_delinquent:exit_date_column': program_enroll_end_date
+  'edu:neglected_or_delinquent:exclude_programs': Null
+  'edu:neglected_or_delinquent:agg_types': ['annual', 'active']
+
   # label for 'Present' days generated from negative attendance
   'edu:attendance:in_attendance_code': In Attendance
   # threshold and minimum enrolled days for chronic absence definition

--- a/models/build/edfi_3/students/_edfi_3__students.yml
+++ b/models/build/edfi_3/students/_edfi_3__students.yml
@@ -85,6 +85,18 @@ models:
     config:
       tags: ['migrant_education']
       enabled: "{{ var('src:program:migrant_education:enabled', True) }}"
+  - name: bld_ef3__student_program__neglected_or_delinquent
+    config:
+      tags: ['neglected_or_delinquent']
+      enabled: "{{ var('src:program:neglected_or_delinquent:enabled', True) }}"
+  - name: bld_ef3__student_program__neglected_or_delinquent__program_services
+    config:
+      tags: ['neglected_or_delinquent']
+      enabled: "{{ var('src:program:neglected_or_delinquent:enabled', True) }}"
+  - name: bld_ef3__student_program__section_504
+    config:
+      tags: ['section_504']
+      enabled: "{{ var('src:program:section_504:enabled', True) }}"
   - name: bld_ef3__student__disabilities
     config:
       tags: ['special_ed']

--- a/models/build/edfi_3/students/bld_ef3__student_program__neglected_or_delinquent.sql
+++ b/models/build/edfi_3/students/bld_ef3__student_program__neglected_or_delinquent.sql
@@ -1,0 +1,69 @@
+{# customizable: certain program names may be excluded and not counted as neglected or delinquent #}
+{% set exclude_programs = var('edu:neglected_or_delinquent:exclude_programs') %}
+
+{# customizable: the column that defines the start date for the neglected or delinquent programs #}
+{% set start_date_column = var('edu:neglected_or_delinquent:start_date_column') %}
+
+{# customizable: the column that defines the end date for the neglected or delinquent programs #}
+{% set exit_date_column = var('edu:neglected_or_delinquent:exit_date_column') %}
+
+{# customizable: extra indicators to create in the aggregate query #}
+{% set custom_program_agg_indicators = var('edu:neglected_or_delinquent:custom_program_agg_indicators', None) %}
+
+with stage as (
+    select * from {{ ref('stg_ef3__student_neglected_or_delinquent_program_associations') }}
+),
+
+maxed as (
+    -- take one row per student, maxing across kept rows
+    select
+        k_student,
+        k_student_xyear,
+        any_value(tenant_code) as tenant_code,
+
+        max(
+          {{ value_not_in_list(field='program_name', excluded_items=exclude_programs) }}
+          and {{ start_date_column }} <= current_date()
+          and ({{ exit_date_column }} is null or {{ exit_date_column }} > current_date())
+        ) as is_neglected_or_delinquent_active,
+
+        max(
+          {{ value_not_in_list(field='program_name', excluded_items=exclude_programs) }}
+        ) as is_neglected_or_delinquent_annual,
+
+        -- custom neglected/delinquent program agg indicators
+        {% if custom_program_agg_indicators -%}
+          {%- for indicator in custom_program_agg_indicators -%}
+            {{ custom_program_agg_indicators[indicator]['agg_sql'] }} as {{ indicator }},
+          {%- endfor -%}
+        {%- endif %}
+
+        max(served_outside_of_regular_session) as served_outside_of_regular_session,
+        max(ela_progress_level) as ela_progress_level,
+        max(mathematics_progress_level) as mathematics_progress_level,
+        max(neglected_or_delinquent_program) as neglected_or_delinquent_program
+
+    from stage
+    group by 1, 2
+),
+
+xyear_agged as (
+    select
+        k_student_xyear,
+        max(is_neglected_or_delinquent_annual) as is_neglected_or_delinquent_ever
+
+    from maxed
+    group by 1
+),
+
+joined as (
+    select
+        maxed.*,
+        xyear_agged.is_neglected_or_delinquent_ever
+
+    from maxed
+        left join xyear_agged
+        on maxed.k_student_xyear = xyear_agged.k_student_xyear
+)
+
+select * from joined

--- a/models/build/edfi_3/students/bld_ef3__student_program__neglected_or_delinquent__program_services.sql
+++ b/models/build/edfi_3/students/bld_ef3__student_program__neglected_or_delinquent__program_services.sql
@@ -1,0 +1,23 @@
+with stage_program_services as (
+    select * from {{ ref('stg_ef3__stu_neglected_delinquent__program_services') }}
+),
+
+wide as (
+    select
+        tenant_code,
+        api_year,
+        k_student_program,
+        k_student,
+        k_student_xyear,
+        k_program,
+        k_lea,
+        k_school,
+        program_enroll_begin_date,
+        {{ edu_edfi_source.json_array_agg('program_service', order_by='program_service', is_terminal=True) }} as program_services
+
+    from stage_program_services
+
+    {{ dbt_utils.group_by(n=9) }}
+)
+
+select * from wide

--- a/models/build/edfi_3/students/bld_ef3__student_program__section_504.sql
+++ b/models/build/edfi_3/students/bld_ef3__student_program__section_504.sql
@@ -1,0 +1,70 @@
+{# customizable: certain program names may be excluded and not counted as section 504 #}
+{% set exclude_programs = var('edu:section_504:exclude_programs') %}
+
+{# customizable: the column that defines the start date for the section 504 programs #}
+{% set start_date_column = var('edu:section_504:start_date_column') %}
+
+{# customizable: the column that defines the end date for the section 504 programs #}
+{% set exit_date_column = var('edu:section_504:exit_date_column') %}
+
+{# customizable: extra indicators to create in the aggregate query #}
+{% set custom_program_agg_indicators = var('edu:section_504:custom_program_agg_indicators', None) %}
+
+with stage as (
+    select * from {{ ref('stg_ef3__student_section_504_program_associations') }}
+),
+
+maxed as (
+    -- take one row per student, maxing across kept rows
+    select
+        k_student,
+        k_student_xyear,
+        any_value(tenant_code) as tenant_code,
+
+        max(
+          {{ value_not_in_list(field='program_name', excluded_items=exclude_programs) }}
+          and {{ start_date_column }} <= current_date()
+          and ({{ exit_date_column }} is null or {{ exit_date_column }} > current_date())
+        ) as is_section_504_active,
+
+        max(
+          {{ value_not_in_list(field='program_name', excluded_items=exclude_programs) }}
+        ) as is_section_504_annual,
+
+        -- custom section 504 program agg indicators
+        {% if custom_program_agg_indicators -%}
+          {%- for indicator in custom_program_agg_indicators -%}
+            {{ custom_program_agg_indicators[indicator]['agg_sql'] }} as {{ indicator }},
+          {%- endfor -%}
+        {%- endif %}
+
+        max(accommodation_plan) as accommodation_plan,
+        max(section_504_eligibility) as section_504_eligibility,
+        max(section_504_eligibility_decision_date) as section_504_eligibility_decision_date,
+        max(section_504_meeting_date) as section_504_meeting_date,
+        max(section_504_disability) as section_504_disability
+
+    from stage
+    group by 1, 2
+),
+
+xyear_agged as (
+    select
+        k_student_xyear,
+        max(is_section_504_annual) as is_section_504_ever
+
+    from maxed
+    group by 1
+),
+
+joined as (
+    select
+        maxed.*,
+        xyear_agged.is_section_504_ever
+
+    from maxed
+        left join xyear_agged
+        on maxed.k_student_xyear = xyear_agged.k_student_xyear
+)
+
+select * from joined

--- a/models/core_warehouse/dim_student.sql
+++ b/models/core_warehouse/dim_student.sql
@@ -27,6 +27,8 @@
 {% set custom_cte_program_agg_indicators = var('edu:cte:custom_program_agg_indicators', None) %}
 {% set custom_food_service_program_agg_indicators = var('edu:food_service:custom_program_agg_indicators', None) %}
 {% set custom_migrant_education_program_agg_indicators = var('edu:migrant_education:custom_program_agg_indicators', None) %}
+{% set custom_section_504_program_agg_indicators = var('edu:section_504:custom_program_agg_indicators', None) %}
+{% set custom_neglected_or_delinquent_program_agg_indicators = var('edu:neglected_or_delinquent:custom_program_agg_indicators', None) %}
 
 {% set other_name_types = var('edu:stu_demos:other_names', None) %}
 {%- set name_type_list = ['personal_title_prefix', 'first_name', 'middle_name', 'last_surname', 'generation_code_suffix']-%}
@@ -102,6 +104,18 @@ stu_other_names as (
 {% if var('src:program:migrant_education:enabled', True) %}
     stu_migrant_education as (
         select * from {{ ref('bld_ef3__student_program__migrant_education') }}
+    ),
+{% endif %}
+
+{% if var('src:program:section_504:enabled', True) %}
+    stu_section_504 as (
+        select * from {{ ref('bld_ef3__student_program__section_504') }}
+    ),
+{% endif %}
+
+{% if var('src:program:neglected_or_delinquent:enabled', True) %}
+    stu_neglected_or_delinquent as (
+        select * from {{ ref('bld_ef3__student_program__neglected_or_delinquent') }}
     ),
 {% endif %}
 
@@ -206,6 +220,28 @@ formatted as (
             {% if custom_migrant_education_program_agg_indicators -%}
                 {% for custom_indicator in custom_migrant_education_program_agg_indicators %}
                 coalesce(stu_migrant_education.{{custom_indicator}}, false) as {{custom_indicator}},
+                {% endfor %}
+            {% endif %}
+        {% endif %}
+
+        {% if var('src:program:section_504:enabled', True) %}
+            {% for agg_type in var('edu:section_504:agg_types') %}
+                coalesce(stu_section_504.is_section_504_{{agg_type}}, false) as is_section_504_{{agg_type}},
+            {% endfor %}
+            {% if custom_section_504_program_agg_indicators -%}
+                {% for custom_indicator in custom_section_504_program_agg_indicators %}
+                coalesce(stu_section_504.{{custom_indicator}}, false) as {{custom_indicator}},
+                {% endfor %}
+            {% endif %}
+        {% endif %}
+
+        {% if var('src:program:neglected_or_delinquent:enabled', True) %}
+            {% for agg_type in var('edu:neglected_or_delinquent:agg_types') %}
+                coalesce(stu_neglected_or_delinquent.is_neglected_or_delinquent_{{agg_type}}, false) as is_neglected_or_delinquent_{{agg_type}},
+            {% endfor %}
+            {% if custom_neglected_or_delinquent_program_agg_indicators -%}
+                {% for custom_indicator in custom_neglected_or_delinquent_program_agg_indicators %}
+                coalesce(stu_neglected_or_delinquent.{{custom_indicator}}, false) as {{custom_indicator}},
                 {% endfor %}
             {% endif %}
         {% endif %}
@@ -326,6 +362,16 @@ formatted as (
     {% if var('src:program:migrant_education:enabled', True) %}
         left join stu_migrant_education
             on stu_demos.k_student = stu_migrant_education.k_student
+    {% endif %}
+
+    {% if var('src:program:section_504:enabled', True) %}
+        left join stu_section_504
+            on stu_demos.k_student = stu_section_504.k_student
+    {% endif %}
+
+    {% if var('src:program:neglected_or_delinquent:enabled', True) %}
+        left join stu_neglected_or_delinquent
+            on stu_demos.k_student = stu_neglected_or_delinquent.k_student
     {% endif %}
 
     -- custom data sources

--- a/models/core_warehouse/fct_student_neglected_or_delinquent_program_associations.sql
+++ b/models/core_warehouse/fct_student_neglected_or_delinquent_program_associations.sql
@@ -1,0 +1,57 @@
+{{
+  config(
+    post_hook=[
+        "alter table {{ this }} alter column k_student_program set not null",
+        "alter table {{ this }} alter column k_student set not null",
+        "alter table {{ this }} alter column k_program set not null",
+        "alter table {{ this }} alter column program_enroll_begin_date set not null",
+        "alter table {{ this }} add primary key (k_student_program)",
+        "alter table {{ this }} add constraint fk_{{ this.name }}_student foreign key (k_student) references {{ ref('dim_student') }}",
+        "alter table {{ this }} add constraint fk_{{ this.name }}_program foreign key (k_program) references {{ ref('dim_program') }}",
+    ]
+  )
+}}
+
+with stage as (
+    select * from {{ ref('stg_ef3__student_neglected_or_delinquent_program_associations') }}
+),
+
+dim_student as (
+    select * from {{ ref('dim_student') }}
+),
+
+dim_program as (
+    select * from {{ ref('dim_program') }}
+),
+
+formatted as (
+    select
+        stage.k_student_program,
+        dim_student.k_student,
+        dim_student.k_student_xyear,
+        stage.k_program,
+        stage.k_lea,
+        stage.k_school,
+        stage.tenant_code,
+        stage.school_year,
+        stage.program_enroll_begin_date,
+        stage.program_enroll_end_date,
+
+        stage.served_outside_of_regular_session,
+        stage.ela_progress_level,
+        stage.mathematics_progress_level,
+        stage.neglected_or_delinquent_program,
+        stage.reason_exited
+        {# add any extension columns configured from stg_ef3__student_neglected_or_delinquent_program_associations #}
+        {{ edu_edfi_source.extract_extension(model_name='stg_ef3__student_neglected_or_delinquent_program_associations', flatten=False) }}
+
+    from stage
+
+    inner join dim_student
+        on stage.k_student = dim_student.k_student
+
+    inner join dim_program
+        on stage.k_program = dim_program.k_program
+)
+
+select * from formatted

--- a/models/core_warehouse/fct_student_neglected_or_delinquent_program_associations.yml
+++ b/models/core_warehouse/fct_student_neglected_or_delinquent_program_associations.yml
@@ -1,0 +1,51 @@
+version: 2
+
+models:
+  - name: fct_student_neglected_or_delinquent_program_associations
+    description: >
+      ##### Overview:
+        This fact table contains student neglected or delinquent program enrollment information.
+
+      ##### Primary Key:
+        `k_student_program` -- There is one record per student, year, program, ed org, and program enrollment begin date.
+
+    config:
+      tags: ['neglected_or_delinquent']
+      enabled: "{{ var('src:program:neglected_or_delinquent:enabled', True) }}"
+
+    constraints:
+      - type: primary_key
+        columns: [k_student_program]
+      - type: foreign_key
+        name: fk__fct_student_neglected_or_delinquent_program_associations__k_student
+        columns: [k_student]
+        to: ref('dim_student')
+        to_columns: [k_student]
+      - type: foreign_key
+        name: fk__fct_student_neglected_or_delinquent_program_associations__k_program
+        columns: [k_program]
+        to: ref('dim_program')
+        to_columns: [k_program]
+
+    tests:
+      - dbt_utils.unique_combination_of_columns:
+          arguments:
+            combination_of_columns:
+              - k_student_program
+
+    columns:
+      - name: k_student_program
+      - name: k_student
+      - name: k_student_xyear
+      - name: k_program
+      - name: k_lea
+      - name: k_school
+      - name: tenant_code
+      - name: school_year
+      - name: program_enroll_begin_date
+      - name: program_enroll_end_date
+      - name: served_outside_of_regular_session
+      - name: ela_progress_level
+      - name: mathematics_progress_level
+      - name: neglected_or_delinquent_program
+      - name: reason_exited

--- a/models/core_warehouse/fct_student_program_participation_status.sql
+++ b/models/core_warehouse/fct_student_program_participation_status.sql
@@ -50,6 +50,16 @@
     {% do stage_program_relations.append(ref('stg_ef3__stu_migrant_edu__program_participation_statuses')) %}
 {% endif %}
 
+-- Section 504
+{% if var('src:program:section_504:enabled', True) %}
+    {% do stage_program_relations.append(ref('stg_ef3__stu_section_504__program_participation_statuses')) %}
+{% endif %}
+
+-- Neglected or Delinquent
+{% if var('src:program:neglected_or_delinquent:enabled', True) %}
+    {% do stage_program_relations.append(ref('stg_ef3__stu_neglected_delinquent__program_participation_statuses')) %}
+{% endif %}
+
 -- Food Service
 {% if var('src:program:food_service:enabled', True) %}
     {% do stage_program_relations.append(ref('stg_ef3__stu_school_food_service__program_participation_statuses')) %}

--- a/models/core_warehouse/fct_student_program_service.sql
+++ b/models/core_warehouse/fct_student_program_service.sql
@@ -50,6 +50,11 @@
     {% do stage_program_relations.append(ref('stg_ef3__stu_migrant_edu__program_services')) %}
 {% endif %}
 
+-- Neglected or Delinquent
+{% if var('src:program:neglected_or_delinquent:enabled', True) %}
+    {% do stage_program_relations.append(ref('stg_ef3__stu_neglected_delinquent__program_services')) %}
+{% endif %}
+
 -- Food Service
 {% if var('src:program:food_service:enabled', True) %}
     {% do stage_program_relations.append(ref('stg_ef3__stu_school_food_service__program_services')) %}

--- a/models/core_warehouse/fct_student_section_504_program_associations.sql
+++ b/models/core_warehouse/fct_student_section_504_program_associations.sql
@@ -1,0 +1,59 @@
+{{
+  config(
+    post_hook=[
+        "alter table {{ this }} alter column k_student_program set not null",
+        "alter table {{ this }} alter column k_student set not null",
+        "alter table {{ this }} alter column k_program set not null",
+        "alter table {{ this }} alter column program_enroll_begin_date set not null",
+        "alter table {{ this }} add primary key (k_student_program)",
+        "alter table {{ this }} add constraint fk_{{ this.name }}_student foreign key (k_student) references {{ ref('dim_student') }}",
+        "alter table {{ this }} add constraint fk_{{ this.name }}_program foreign key (k_program) references {{ ref('dim_program') }}",
+    ]
+  )
+}}
+
+with stage as (
+    select * from {{ ref('stg_ef3__student_section_504_program_associations') }}
+),
+
+dim_student as (
+    select * from {{ ref('dim_student') }}
+),
+
+dim_program as (
+    select * from {{ ref('dim_program') }}
+),
+
+formatted as (
+    select
+        stage.k_student_program,
+        dim_student.k_student,
+        dim_student.k_student_xyear,
+        stage.k_program,
+        stage.k_lea,
+        stage.k_school,
+        stage.tenant_code,
+        stage.school_year,
+        stage.program_enroll_begin_date,
+        stage.program_enroll_end_date,
+
+        stage.accommodation_plan,
+        stage.section_504_eligibility,
+        stage.served_outside_of_regular_session,
+        stage.section_504_eligibility_decision_date,
+        stage.section_504_meeting_date,
+        stage.section_504_disability,
+        stage.reason_exited
+        {# add any extension columns configured from stg_ef3__student_section_504_program_associations #}
+        {{ edu_edfi_source.extract_extension(model_name='stg_ef3__student_section_504_program_associations', flatten=False) }}
+
+    from stage
+
+    inner join dim_student
+        on stage.k_student = dim_student.k_student
+
+    inner join dim_program
+        on stage.k_program = dim_program.k_program
+)
+
+select * from formatted

--- a/models/core_warehouse/fct_student_section_504_program_associations.yml
+++ b/models/core_warehouse/fct_student_section_504_program_associations.yml
@@ -1,0 +1,53 @@
+version: 2
+
+models:
+  - name: fct_student_section_504_program_associations
+    description: >
+      ##### Overview:
+        This fact table contains student section 504 program enrollment information.
+
+      ##### Primary Key:
+        `k_student_program` -- There is one record per student, year, program, ed org, and program enrollment begin date.
+
+    config:
+      tags: ['section_504']
+      enabled: "{{ var('src:program:section_504:enabled', True) }}"
+
+    constraints:
+      - type: primary_key
+        columns: [k_student_program]
+      - type: foreign_key
+        name: fk__fct_student_section_504_program_associations__k_student
+        columns: [k_student]
+        to: ref('dim_student')
+        to_columns: [k_student]
+      - type: foreign_key
+        name: fk__fct_student_section_504_program_associations__k_program
+        columns: [k_program]
+        to: ref('dim_program')
+        to_columns: [k_program]
+
+    tests:
+      - dbt_utils.unique_combination_of_columns:
+          arguments:
+            combination_of_columns:
+              - k_student_program
+
+    columns:
+      - name: k_student_program
+      - name: k_student
+      - name: k_student_xyear
+      - name: k_program
+      - name: k_lea
+      - name: k_school
+      - name: tenant_code
+      - name: school_year
+      - name: program_enroll_begin_date
+      - name: program_enroll_end_date
+      - name: accommodation_plan
+      - name: section_504_eligibility
+      - name: served_outside_of_regular_session
+      - name: section_504_eligibility_decision_date
+      - name: section_504_meeting_date
+      - name: section_504_disability
+      - name: reason_exited


### PR DESCRIPTION
## Description & motivation
Adds warehouse models and `dim_student` logic for new types of programs. Section 504 is used in WI and Neglected or Delinquent is the only other Ed-Fi program type we haven't yet added to EDU.
Depends on https://github.com/edanalytics/edu_edfi_source/pull/211
Related to https://github.com/edanalytics/edu_docs/pull/66

## Breaking changes introduced by this PR:
If a project does not have these resources in their src_edfi3.yml file, they will have to disable the programs in order for dbt to compile:
'src:program:section_504:enabled': False
'src:program:neglected_or_delinquent:enabled': False

## PR Merge Priority:
- [x] Low
- [ ] Medium
- [ ] High

## Changes to existing files:
`dim_student`: added custom indicator logic for both program types
`fct_student_program_participation_statuses`: appended both new program types when enabled
`fct_student program_service`: appended neglected or delinquent when enabled; section 504 does not have program services

## New files created:
Added standard bld and fct models for both new program types

## Tests and QC done:
Ran successfully in WDL and checked that new columns appear in `dim_student` as expected. I also removed the resources from my src_edfi3.yml and confirmed that dbt ran successfully if I disabled both programs.

## edu_wh PR Review Checklist:
Make sure the following have been completed before approving this PR:
- [x] Description of changes has been added to Unreleased section of [CHANGELOG.md](/CHANGELOG.md). Add under `## New Features` for features, etc.
- [x] Code has been tested/checked for Databricks and Snowflake compatibility - EA engineers see Databricks checklist [here](https://edanalytics.slite.com/app/docs/LRjXFxVRAWA5ST) 
- [x] Reviewer confirms the grain of all tables are unchanged, OR any changes are expected, communicated, and this PR is flagged as a breaking change (not for patch release)
- [ ] If a new configuration xwalk was added:
  - [ ] The code is written such that the xwalk is optional (preferred), and this behavior was tested, OR
  - [ ] The code is written such that the xwalk is required, and the required xwalk is added to edu_project_template, and this PR is flagged as breaking change (not for patch release)
  - [ ] A description for the new xwalk has been added to EDU documentation site [here](https://github.com/edanalytics/edu_docs/blob/main/docs/docs/manage_extend/reference/configure_dbt_xwalks.md) 
- [x] If a new configuration variable was added:
  - [x] The code is written such that the variable is optional (preferred), and this behavior was tested, OR
  - [ ] The code is written such that the variable is required, and a default value was added to edu_project_template, and this PR is flagged as breaking change (not for patch release)
  - [x] A description for the new variable has been added to EDU documentation site [here](https://github.com/edanalytics/edu_docs/blob/main/docs/docs/manage_extend/reference/configure_dbt_vars.md) 
