### PR TITLE
Feature/tenant official email domains

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Unreleased
 ## New features
+- Adds optional filtering of `bld_ef3__staff_official_emails` to only official email domains. Set `edu:staff:email_domains_xwalk_enabled` to true and add `xwalk_tenant_email_domains` with columns `tenant_code`, `email_domain` to use this feature.
 ## Under the hood
 ## Fixes
 

--- a/models/build/edfi_3/staffs/bld_ef3__staff_official_emails.sql
+++ b/models/build/edfi_3/staffs/bld_ef3__staff_official_emails.sql
@@ -10,7 +10,7 @@ with emails as (
 
 -- if using a tenant to email domain xwalk, keep only valid emails that match the official domain(s) for the tenant
 -- otherwise keep only emails that are valid, coded as a 'work'-type email, and don't appear to be personal domains
-{% if var('edu:staff:use_official_email_domains_xwalk', False) %}
+{% if var('edu:staff:email_domains_xwalk_enabled', False) %}
     official_email_domains as (
         select * from {{ ref('xwalk_tenant_email_domains') }}
     ),

--- a/models/build/edfi_3/staffs/bld_ef3__staff_official_emails.sql
+++ b/models/build/edfi_3/staffs/bld_ef3__staff_official_emails.sql
@@ -4,23 +4,42 @@
     )
 }}
 
-{% set work_email_codes = var('edu:staff:official_email_codes', ['Work']) %}
-{% if work_email_codes is string %} {% set work_email_codes = [work_email_codes] %} {% endif %}
-
-{% set banned_personal_domains = var('edu:staff:banned_personal_domains', 
-    ['aim.com', 'aol.com', 'att.net', 'gmail.com', 'yahoo.com', 
-    'hotmail.com', 'msn.com', 'live.com', 'charter.net', 
-    'earthlink.net', 'verizon.net', 'comcast.net', 'outlook.com']) %}
-{% if banned_personal_domains is string %} {% set banned_personal_domains = [banned_personal_domains] %}{% endif %}
-
--- keep only emails that are valid, coded as a 'work'-type email, and don't appear to be personal domains
-with official_emails as (
-    select *
-    from {{ ref('bld_ef3__staff_emails') }}
-    where is_valid_email
-        and email_type in ('{{ work_email_codes | join("', '") }}')
-        and split_part(email_address, '@', 2) not in ('{{ banned_personal_domains | join("', '") }}')
+with emails as (
+    select * from {{ ref('bld_ef3__staff_emails') }}
 ),
+
+-- if using a tenant to email domain xwalk, keep only valid emails that match the official domain(s) for the tenant
+-- otherwise keep only emails that are valid, coded as a 'work'-type email, and don't appear to be personal domains
+{% if var('edu:staff:use_official_email_domains_xwalk', False) %}
+    official_email_domains as (
+        select * from {{ ref('xwalk_tenant_email_domains') }}
+    ),
+    official_emails as (
+        select emails.*
+        from emails
+        join official_email_domains
+            on emails.tenant_code = official_email_domains.tenant_code
+            and lower(split_part(emails.email_address, '@', 2)) = lower(official_email_domains.email_domain)
+        where is_valid_email
+    ),
+{% else %}
+    {% set work_email_codes = var('edu:staff:official_email_codes', ['Work']) %}
+    {% if work_email_codes is string %} {% set work_email_codes = [work_email_codes] %} {% endif %}
+
+    {% set banned_personal_domains = var('edu:staff:banned_personal_domains', 
+        ['aim.com', 'aol.com', 'att.net', 'gmail.com', 'yahoo.com', 
+        'hotmail.com', 'msn.com', 'live.com', 'charter.net', 
+        'earthlink.net', 'verizon.net', 'comcast.net', 'outlook.com']) %}
+    {% if banned_personal_domains is string %} {% set banned_personal_domains = [banned_personal_domains] %}{% endif %}
+
+    official_emails as (
+        select *
+        from emails
+        where is_valid_email
+            and email_type in ('{{ work_email_codes | join("', '") }}')
+            and lower(split_part(email_address, '@', 2)) not in ('{{ banned_personal_domains | join("', '") }}')
+    ),
+{% endif %}
 -- keep only one row per k_staff and unique email address, regardless of where it came from
 -- sort is arbitrary, since source doesn't really matter here
 deduped as (


### PR DESCRIPTION
## Description & motivation
Adds optional logic to use an email domain xwalk to filter staff emails in `bld_ef3__staff_official_emails` as an alternative to the current logic that uses email type and a list of banned personal email domains. This is used in WDL currently because of unusually messy staff data, with unreliable email types and old emails from prior district employment. 
Related to https://github.com/edanalytics/edu_docs/pull/67

## Breaking changes introduced by this PR:
None

## PR Merge Priority:
- [ ] Low
- [ ] Medium
- [ ] High

## Changes to existing files:
`bld_ef3__staff_official_emails`: When `edu:staff:email_domains_xwalk_enabled` is true, join to `xwalk_tenant_email_domains` to filter to official emails

## New files created:
None

## Tests and QC done:
Confirmed that behavior was unchanged in CA with no additional variables or xwalks.
Confirmed that only official domains were present in `bld_ef3__staff_official_emails` in WDL when the variable was enabled and xwalk populated.

## edu_wh PR Review Checklist:
Make sure the following have been completed before approving this PR:
- [x] Description of changes has been added to Unreleased section of [CHANGELOG.md](/CHANGELOG.md). Add under `## New Features` for features, etc.
- [x] Code has been tested/checked for Databricks and Snowflake compatibility - EA engineers see Databricks checklist [here](https://edanalytics.slite.com/app/docs/LRjXFxVRAWA5ST) 
- [x] Reviewer confirms the grain of all tables are unchanged, OR any changes are expected, communicated, and this PR is flagged as a breaking change (not for patch release)
- [x] If a new configuration xwalk was added:
  - [x] The code is written such that the xwalk is optional (preferred), and this behavior was tested, OR
  - [ ] The code is written such that the xwalk is required, and the required xwalk is added to edu_project_template, and this PR is flagged as breaking change (not for patch release)
  - [x] A description for the new xwalk has been added to EDU documentation site [here](https://github.com/edanalytics/edu_docs/blob/main/docs/docs/manage_extend/reference/configure_dbt_xwalks.md) 
- [x] If a new configuration variable was added:
  - [x] The code is written such that the variable is optional (preferred), and this behavior was tested, OR
  - [ ] The code is written such that the variable is required, and a default value was added to edu_project_template, and this PR is flagged as breaking change (not for patch release)
  - [x] A description for the new variable has been added to EDU documentation site [here](https://github.com/edanalytics/edu_docs/blob/main/docs/docs/manage_extend/reference/configure_dbt_vars.md) 
